### PR TITLE
Fix language dialog dismissal

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/display/DisplaySettingsList.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/display/DisplaySettingsList.kt
@@ -209,7 +209,7 @@ fun DisplaySettingsList(paddingValues : PaddingValues = PaddingValues() , provid
             }
 
             if (showLanguageDialog) {
-                SelectLanguageAlertDialog(onDismiss = { showLanguageDialog = true } , onLanguageSelected = { newLanguageCode : String ->
+                SelectLanguageAlertDialog(onDismiss = { showLanguageDialog = false } , onLanguageSelected = { newLanguageCode : String ->
                     AppCompatDelegate.setApplicationLocales(LocaleListCompat.forLanguageTags(newLanguageCode))
                 })
             }


### PR DESCRIPTION
## Summary
- fix `onDismiss` lambda for language dialog to close correctly

## Testing
- `./gradlew assemble` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f3b582ee0832dbed6e10449d773ce