### PR TITLE
Simplify suspend billing query

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/domain/usecases/QuerySkuDetailsUseCase.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/domain/usecases/QuerySkuDetailsUseCase.kt
@@ -6,41 +6,29 @@ import com.android.billingclient.api.QueryProductDetailsParams
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Errors
 import com.d4rk.android.libs.apptoolkit.core.domain.usecases.Repository
+import com.d4rk.android.libs.apptoolkit.core.utils.extensions.queryProductDetails
 import com.d4rk.android.libs.apptoolkit.core.utils.extensions.toError
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.suspendCancellableCoroutine
-import kotlin.coroutines.resume
-import kotlin.coroutines.resumeWithException
 
 class QueryProductDetailsUseCase : Repository<BillingClient , Flow<DataState<Map<String , ProductDetails> , Errors>>> {
     override suspend fun invoke(param : BillingClient) : Flow<DataState<Map<String , ProductDetails> , Errors>> = flow {
-        runCatching {
-            suspendCancellableCoroutine { continuation ->
-                val productList = listOf(
-                    "low_donation" , "normal_donation" , "high_donation" , "extreme_donation"
-                ).map {
-                    QueryProductDetailsParams.Product.newBuilder().setProductId(it).setProductType(BillingClient.ProductType.INAPP).build()
-                }
-
-                val params = QueryProductDetailsParams.newBuilder().setProductList(productList).build()
-
-                param.queryProductDetailsAsync(params) { billingResult , productDetailsList ->
-                    if (billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
-                        productDetailsList.let {
-                            val resultMap = it.associateBy { pd -> pd.productId }
-                            continuation.resume(resultMap)
-                        }
-                    }
-                    else {
-                        continuation.resumeWithException(Exception("Failed to query: ${billingResult.debugMessage}"))
-                    }
-                }
-            }
-        }.onSuccess { result ->
-            emit(value = DataState.Success(data = result))
-        }.onFailure { error ->
-            emit(value = DataState.Error(error = error.toError(default = Errors.UseCase.FAILED_TO_LOAD_SKU_DETAILS)))
+        val productList = listOf(
+            "low_donation" , "normal_donation" , "high_donation" , "extreme_donation"
+        ).map {
+            QueryProductDetailsParams.Product.newBuilder().setProductId(it).setProductType(BillingClient.ProductType.INAPP).build()
         }
+
+        val params = QueryProductDetailsParams.newBuilder().setProductList(productList).build()
+
+        param.queryProductDetails(params).fold(
+            onSuccess = { details ->
+                val resultMap = details.associateBy { pd -> pd.productId }
+                emit(DataState.Success(data = resultMap))
+            },
+            onFailure = { error ->
+                emit(DataState.Error(error = error.toError(default = Errors.UseCase.FAILED_TO_LOAD_SKU_DETAILS)))
+            }
+        )
     }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/extensions/BillingClient.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/extensions/BillingClient.kt
@@ -1,0 +1,21 @@
+package com.d4rk.android.libs.apptoolkit.core.utils.extensions
+
+import com.android.billingclient.api.BillingClient
+import com.android.billingclient.api.ProductDetails
+import com.android.billingclient.api.QueryProductDetailsParams
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+
+suspend fun BillingClient.queryProductDetails(params: QueryProductDetailsParams): Result<List<ProductDetails>> =
+    suspendCancellableCoroutine { continuation ->
+        queryProductDetailsAsync(params) { billingResult, productDetailsList ->
+            val result = runCatching {
+                if (billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
+                    productDetailsList
+                } else {
+                    throw Exception("Failed to query: ${billingResult.debugMessage}")
+                }
+            }
+            continuation.resume(result)
+        }
+    }


### PR DESCRIPTION
## Summary
- add BillingClient.queryProductDetails extension using `suspendCancellableCoroutine`
- refactor QueryProductDetailsUseCase to use new extension and remove nested callbacks

## Testing
- `sh ./gradlew tasks --all`
- `sh ./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fdb289710832d9182821dc1b8352d