### PR TITLE
Fix default privacy consent toggles

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/ui/UsageAndDiagnosticsList.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/ui/UsageAndDiagnosticsList.kt
@@ -52,14 +52,14 @@ fun UsageAndDiagnosticsList(paddingValues: PaddingValues, configProvider: BuildI
         dataStore.usageAndDiagnostics(default = !configProvider.isDebugBuild)
             .collectAsState(initial = !configProvider.isDebugBuild)
 
-    val analyticsState: State<Boolean> = dataStore.analyticsConsent(default = false)
-        .collectAsState(initial = configProvider.isDebugBuild)
-    val adStorageState: State<Boolean> = dataStore.adStorageConsent(default = false)
-        .collectAsState(initial = configProvider.isDebugBuild)
-    val adUserDataState: State<Boolean> = dataStore.adUserDataConsent(default = false)
-        .collectAsState(initial = configProvider.isDebugBuild)
-    val adPersonalizationState: State<Boolean> = dataStore.adPersonalizationConsent(default = false)
-        .collectAsState(initial = configProvider.isDebugBuild)
+    val analyticsState: State<Boolean> = dataStore.analyticsConsent(default = !configProvider.isDebugBuild)
+        .collectAsState(initial = !configProvider.isDebugBuild)
+    val adStorageState: State<Boolean> = dataStore.adStorageConsent(default = !configProvider.isDebugBuild)
+        .collectAsState(initial = !configProvider.isDebugBuild)
+    val adUserDataState: State<Boolean> = dataStore.adUserDataConsent(default = !configProvider.isDebugBuild)
+        .collectAsState(initial = !configProvider.isDebugBuild)
+    val adPersonalizationState: State<Boolean> = dataStore.adPersonalizationConsent(default = !configProvider.isDebugBuild)
+        .collectAsState(initial = !configProvider.isDebugBuild)
 
 
     var advancedSettingsExpanded: Boolean by remember { mutableStateOf<Boolean>(value = false) }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/components/pages/CrashlyticsOnboardingPageTab.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/components/pages/CrashlyticsOnboardingPageTab.kt
@@ -275,13 +275,16 @@ fun CrashlyticsConsentDialog(
     val initialConsentValue: Boolean = !configProvider.isDebugBuild
 
     val analyticsState: State<Boolean> =
-        dataStore.analyticsConsent(default = false).collectAsState(initial = initialConsentValue)
+        dataStore.analyticsConsent(default = initialConsentValue)
+            .collectAsState(initial = initialConsentValue)
     val adStorageState: State<Boolean> =
-        dataStore.adStorageConsent(default = false).collectAsState(initial = initialConsentValue)
+        dataStore.adStorageConsent(default = initialConsentValue)
+            .collectAsState(initial = initialConsentValue)
     val adUserDataState: State<Boolean> =
-        dataStore.adUserDataConsent(default = false).collectAsState(initial = initialConsentValue)
+        dataStore.adUserDataConsent(default = initialConsentValue)
+            .collectAsState(initial = initialConsentValue)
     val adPersonalizationState: State<Boolean> =
-        dataStore.adPersonalizationConsent(default = false)
+        dataStore.adPersonalizationConsent(default = initialConsentValue)
             .collectAsState(initial = initialConsentValue)
 
     fun updateConsentState(type: String, value: Boolean) {


### PR DESCRIPTION
## Summary
- default to enabled consents on release builds
- wire privacy consent defaults through build type checks

## Testing
- `./gradlew test --no-daemon --stacktrace | tail -n 20` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fdf812278832da346346cc71c021f