### PR TITLE
Fix onboarding redirect loop

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainActivity.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainActivity.kt
@@ -33,10 +33,12 @@ class MainActivity : AppCompatActivity() {
     private val dataStore : DataStore by inject()
     private lateinit var updateResultLauncher : ActivityResultLauncher<IntentSenderRequest>
     private lateinit var viewModel : MainViewModel
+    private var keepSplashVisible : Boolean = true
 
     override fun onCreate(savedInstanceState : Bundle?) {
         super.onCreate(savedInstanceState)
-        installSplashScreen()
+        val splashScreen = installSplashScreen()
+        splashScreen.setKeepOnScreenCondition { keepSplashVisible }
         enableEdgeToEdge()
         initializeDependencies()
         handleStartup()
@@ -61,6 +63,7 @@ class MainActivity : AppCompatActivity() {
     private fun handleStartup() {
         lifecycleScope.launch {
             val isFirstLaunch : Boolean = dataStore.startup.first()
+            keepSplashVisible = false
             if (isFirstLaunch) {
                 startStartupActivity()
             }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/OnboardingScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/OnboardingScreen.kt
@@ -53,8 +53,8 @@ fun OnboardingScreen() {
     val onSkipRequested = {
         coroutineScope.launch {
             dataStore.saveStartup(isFirstTime = false)
+            onboardingProvider.onOnboardingFinished(context = context)
         }
-        onboardingProvider.onOnboardingFinished(context = context)
     }
 
     Scaffold(topBar = {
@@ -86,8 +86,8 @@ fun OnboardingScreen() {
                 else {
                     coroutineScope.launch {
                         dataStore.saveStartup(isFirstTime = false)
+                        onboardingProvider.onOnboardingFinished(context)
                     }
-                    onboardingProvider.onOnboardingFinished(context)
                 }
             } , onBackClicked = {
                 if (pagerState.currentPage > 0) {


### PR DESCRIPTION
## Summary
- keep the splash screen visible until DataStore has been read
- wait for saveStartup to finish before navigating away from onboarding

## Testing
- `./gradlew help`

------
https://chatgpt.com/codex/tasks/task_e_683fe1e3562c832d8fb0dab116536db9