### PR TITLE
Fix consent flow conditions

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainActivity.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainActivity.kt
@@ -100,7 +100,8 @@ class MainActivity : AppCompatActivity() {
             .build()
         consentInfo.requestConsentInfoUpdate(this, params, {
             if (consentInfo.isConsentFormAvailable &&
-                consentInfo.consentStatus == ConsentInformation.ConsentStatus.REQUIRED
+                (consentInfo.consentStatus == ConsentInformation.ConsentStatus.REQUIRED ||
+                    consentInfo.consentStatus == ConsentInformation.ConsentStatus.UNKNOWN)
             ) {
                 UserMessagingPlatform.loadConsentForm(this, { form: ConsentForm ->
                     form.show(this) {}

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/ui/AdsSettingsViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/ui/AdsSettingsViewModel.kt
@@ -48,7 +48,8 @@ class AdsSettingsViewModel(private val loadConsentInfoUseCase : LoadConsentInfoU
 
                 consentInfo.requestConsentInfoUpdate(activity , params , {
                     UserMessagingPlatform.loadConsentForm(activity , { consentForm : ConsentForm ->
-                        if (consentInfo.consentStatus == ConsentInformation.ConsentStatus.REQUIRED || consentInfo.consentStatus == ConsentInformation.ConsentStatus.OBTAINED) {
+                        if (consentInfo.consentStatus == ConsentInformation.ConsentStatus.REQUIRED ||
+                            consentInfo.consentStatus == ConsentInformation.ConsentStatus.UNKNOWN) {
                             consentForm.show(activity) {
                                 onEvent(event = AdsSettingsEvents.LoadAdsSettings)
                             }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/OnboardingViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/OnboardingViewModel.kt
@@ -53,7 +53,10 @@ class OnboardingViewModel(
                 ) { consentInfo: ConsentInformation, current: OnboardingUiData ->
                     current.copy(
                         consentRequired = consentInfo.isConsentFormAvailable &&
-                            consentInfo.consentStatus == ConsentInformation.ConsentStatus.REQUIRED,
+                            (
+                                consentInfo.consentStatus == ConsentInformation.ConsentStatus.REQUIRED ||
+                                    consentInfo.consentStatus == ConsentInformation.ConsentStatus.UNKNOWN
+                                ),
                         consentInformation = consentInfo
                     )
                 }
@@ -71,7 +74,7 @@ class OnboardingViewModel(
                 consentInfo.requestConsentInfoUpdate(activity, params, {
                     UserMessagingPlatform.loadConsentForm(activity, { consentForm: ConsentForm ->
                         if (consentInfo.consentStatus == ConsentInformation.ConsentStatus.REQUIRED ||
-                            consentInfo.consentStatus == ConsentInformation.ConsentStatus.OBTAINED
+                            consentInfo.consentStatus == ConsentInformation.ConsentStatus.UNKNOWN
                         ) {
                             consentForm.show(activity) {
                                 onConsentFormLoaded()


### PR DESCRIPTION
## Summary
- show consent when status is UNKNOWN or REQUIRED
- apply new check logic for startup, onboarding, ads settings, and main activity

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68401147d4c4832db1552541ac7f8aa8