### PR TITLE
Refactor consent form usage

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/ui/AdsSettingsViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/ui/AdsSettingsViewModel.kt
@@ -1,6 +1,7 @@
 package com.d4rk.android.libs.apptoolkit.app.ads.ui
 
 import com.d4rk.android.libs.apptoolkit.R
+import androidx.lifecycle.viewModelScope
 import com.d4rk.android.libs.apptoolkit.app.ads.domain.actions.AdsSettingsActions
 import com.d4rk.android.libs.apptoolkit.app.ads.domain.events.AdsSettingsEvents
 import com.d4rk.android.libs.apptoolkit.app.ads.domain.model.AdsSettingsData
@@ -11,7 +12,7 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Errors
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.applyResult
 import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
-import com.d4rk.android.libs.apptoolkit.core.utils.helpers.ConsentFormHelper
+import com.d4rk.android.libs.apptoolkit.core.utils.extensions.loadAndShowIfNeeded
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
 import com.google.android.ump.ConsentInformation
 import kotlinx.coroutines.flow.flowOn
@@ -39,13 +40,12 @@ class AdsSettingsViewModel(private val loadConsentInfoUseCase : LoadConsentInfoU
         }
     }
 
-    private fun openConsentForm(activity : AdsSettingsActivity) {
-        screenData?.consentInformation?.let { consentInfo : ConsentInformation ->
-            launch(context = dispatcherProvider.io) {
-                ConsentFormHelper.loadAndShow(activity = activity , consentInfo = consentInfo) {
-                    onEvent(event = AdsSettingsEvents.LoadAdsSettings)
-                }
-            }
-        } ?: return onEvent(event = AdsSettingsEvents.LoadAdsSettings)
+    private fun openConsentForm(activity: AdsSettingsActivity) {
+        screenData?.consentInformation.loadAndShowIfNeeded(
+            scope = viewModelScope,
+            dispatcherProvider = dispatcherProvider,
+            activity = activity,
+            onFormShown = { onEvent(event = AdsSettingsEvents.LoadAdsSettings) },
+        )
     }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/OnboardingViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/OnboardingViewModel.kt
@@ -14,7 +14,7 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.applyResult
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.successData
 import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
-import com.d4rk.android.libs.apptoolkit.core.utils.helpers.ConsentFormHelper
+import com.d4rk.android.libs.apptoolkit.core.utils.extensions.loadAndShowIfNeeded
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
 import com.google.android.ump.ConsentInformation
 import kotlinx.coroutines.flow.SharingStarted
@@ -63,13 +63,12 @@ class OnboardingViewModel(
     }
 
     private fun openConsentForm(activity: Activity) {
-        screenData?.consentInformation?.let { consentInfo: ConsentInformation ->
-            launch(context = dispatcherProvider.io) {
-                ConsentFormHelper.loadAndShow(activity = activity , consentInfo = consentInfo) {
-                    onConsentFormLoaded()
-                }
-            }
-        } ?: onConsentFormLoaded()
+        screenData?.consentInformation.loadAndShowIfNeeded(
+            scope = viewModelScope,
+            dispatcherProvider = dispatcherProvider,
+            activity = activity,
+            onFormShown = { onConsentFormLoaded() },
+        )
     }
 
     private fun onConsentFormLoaded() {

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupViewModel.kt
@@ -14,7 +14,7 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.applyResult
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.successData
 import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
-import com.d4rk.android.libs.apptoolkit.core.utils.helpers.ConsentFormHelper
+import com.d4rk.android.libs.apptoolkit.core.utils.extensions.loadAndShowIfNeeded
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
 import com.google.android.ump.ConsentInformation
 import kotlinx.coroutines.flow.SharingStarted
@@ -48,14 +48,13 @@ class StartupViewModel(private val loadConsentInfoUseCase : LoadConsentInfoUseCa
         }
     }
 
-    private fun openConsentForm(activity : Activity) {
-        screenData?.consentInformation?.let { consentInfo : ConsentInformation ->
-            launch(context = dispatcherProvider.io) {
-                ConsentFormHelper.loadAndShow(activity = activity , consentInfo = consentInfo) {
-                    onConsentFormLoaded()
-                }
-            }
-        } ?: return onConsentFormLoaded()
+    private fun openConsentForm(activity: Activity) {
+        screenData?.consentInformation.loadAndShowIfNeeded(
+            scope = viewModelScope,
+            dispatcherProvider = dispatcherProvider,
+            activity = activity,
+            onFormShown = { onConsentFormLoaded() },
+        )
     }
 
     private fun onConsentFormLoaded() {

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/extensions/ConsentInformationExtensions.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/extensions/ConsentInformationExtensions.kt
@@ -1,0 +1,33 @@
+package com.d4rk.android.libs.apptoolkit.core.utils.extensions
+
+import android.app.Activity
+import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
+import com.d4rk.android.libs.apptoolkit.core.utils.helpers.ConsentFormHelper
+import com.google.android.ump.ConsentInformation
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+/**
+ * Launches the consent form if [ConsentInformation] is available.
+ *
+ * @param scope [CoroutineScope] used to launch the form loading on the provided dispatcher.
+ * @param dispatcherProvider Provides the [kotlin.coroutines.CoroutineDispatcher] on which the form
+ * will be loaded.
+ * @param activity The activity used to show the consent form.
+ * @param onFormShown Callback invoked after the form is shown or immediately if no form is
+ * available.
+ */
+fun ConsentInformation?.loadAndShowIfNeeded(
+    scope: CoroutineScope,
+    dispatcherProvider: DispatcherProvider,
+    activity: Activity,
+    onFormShown: () -> Unit = {},
+) {
+    this?.let { info ->
+        scope.launch(context = dispatcherProvider.io) {
+            ConsentFormHelper.loadAndShow(activity = activity, consentInfo = info) {
+                onFormShown()
+            }
+        }
+    } ?: onFormShown()
+}


### PR DESCRIPTION
## Summary
- add `loadAndShowIfNeeded` extension for `ConsentInformation`
- refactor view models to use new helper

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844138ae404832d84cad8258ef2edcb