### PR TITLE
Handle missing Play Store gracefully

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/ui/components/AppCard.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/ui/components/AppCard.kt
@@ -1,8 +1,6 @@
 package com.d4rk.android.apps.apptoolkit.app.apps.ui.components
 
 import android.content.Context
-import android.content.Intent
-import android.net.Uri
 import android.view.SoundEffectConstants
 import android.view.View
 import androidx.compose.foundation.clickable
@@ -24,12 +22,11 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.core.net.toUri
 import coil3.compose.AsyncImage
 import com.d4rk.android.apps.apptoolkit.app.apps.domain.model.AppInfo
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeVerticalSpacer
-import com.d4rk.android.libs.apptoolkit.core.utils.constants.links.AppLinks
+import com.d4rk.android.libs.apptoolkit.core.utils.helpers.IntentsHelper
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.AppInfoHelper
 
@@ -47,15 +44,17 @@ fun AppCard(appInfo : AppInfo , modifier : Modifier) {
                 if (appInfo.packageName.isNotEmpty()) {
                     if (AppInfoHelper().isAppInstalled(context = context , packageName = appInfo.packageName)) {
                         if (! AppInfoHelper().openApp(context = context , packageName = appInfo.packageName)) {
-                            "${AppLinks.MARKET_APP_PAGE}${appInfo.packageName}".toUri().let { marketUri : Uri ->
-                                context.startActivity(Intent(Intent.ACTION_VIEW , marketUri))
-                            }
+                            IntentsHelper.openPlayStoreForApp(
+                                context = context ,
+                                packageName = appInfo.packageName
+                            )
                         }
                     }
                     else {
-                        "${AppLinks.MARKET_APP_PAGE}${appInfo.packageName}".toUri().let { marketUri : Uri ->
-                            context.startActivity(Intent(Intent.ACTION_VIEW , marketUri))
-                        }
+                        IntentsHelper.openPlayStoreForApp(
+                            context = context ,
+                            packageName = appInfo.packageName
+                        )
                     }
                 }
             }) {

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/IntentsHelper.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/IntentsHelper.kt
@@ -76,6 +76,28 @@ object IntentsHelper {
     }
 
     /**
+     * Opens the specified application's Play Store page. If the Play Store
+     * application is not available, it falls back to opening the web version
+     * of the Play Store.
+     *
+     * @param context The context used to start the intent.
+     * @param packageName The package name of the application to display.
+     */
+    fun openPlayStoreForApp(context : Context , packageName : String) {
+        val marketIntent = Intent(
+            Intent.ACTION_VIEW , "${AppLinks.MARKET_APP_PAGE}$packageName".toUri()
+        ).apply {
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        if (marketIntent.resolveActivity(context.packageManager) != null) {
+            context.startActivity(marketIntent)
+        }
+        else {
+            openUrl(context , "${AppLinks.PLAY_STORE_APP}$packageName")
+        }
+    }
+
+    /**
      * Opens the app's share sheet, allowing users to share a message about the app.
      *
      * This function constructs a share message using a provided string resource and the app's Play Store link.

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/notifications/managers/AppUpdateNotificationsManager.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/notifications/managers/AppUpdateNotificationsManager.kt
@@ -33,12 +33,20 @@ class AppUpdateNotificationsManager(private val context : Context , private val 
                     channelId , context.getString(R.string.update_notifications) , NotificationManager.IMPORTANCE_HIGH
                 )
                 notificationManager.createNotificationChannel(updateChannel)
+                val marketIntent = Intent(
+                    Intent.ACTION_VIEW , "${AppLinks.MARKET_APP_PAGE}${context.packageName}".toUri()
+                )
+                val finalIntent = if (marketIntent.resolveActivity(context.packageManager) != null) {
+                    marketIntent
+                } else {
+                    Intent(
+                        Intent.ACTION_VIEW , "${AppLinks.PLAY_STORE_APP}${context.packageName}".toUri()
+                    )
+                }
                 val updateBuilder : NotificationCompat.Builder =
                         NotificationCompat.Builder(context , channelId).setSmallIcon(R.drawable.ic_notification_update).setContentTitle(context.getString(R.string.notification_update_title)).setContentText(context.getString(R.string.summary_notification_update)).setAutoCancel(true).setContentIntent(
                             PendingIntent.getActivity(
-                                context , 0 , Intent(
-                                    Intent.ACTION_VIEW , "${AppLinks.MARKET_APP_PAGE}${context.packageName}".toUri()
-                                ) , PendingIntent.FLAG_IMMUTABLE
+                                context , 0 , finalIntent , PendingIntent.FLAG_IMMUTABLE
                             )
                         )
                 notificationManager.notify(updateNotificationId , updateBuilder.build())


### PR DESCRIPTION
## Summary
- avoid `ActivityNotFoundException` when opening Play Store links
- add `IntentsHelper.openPlayStoreForApp` to provide web fallback
- use new helper in `AppCard`
- create safe PendingIntent in `AppUpdateNotificationsManager`

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684537a46184832dbcc768eebb7c2191