### PR TITLE
Fix click sound and update privacy link

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
-# Version 1.0.0:
+# Version 1.0.1 (code 26)
+- Added Play Store fallback intent handling.
+- Improved manifest meta-data ordering and added per-app language service.
+- Enabled Firebase Performance Logcat and updated dependencies.
+- Added helper for consent form display.
+- Updated privacy policy link on the startup screen.
+- Ensured click sound feedback across onboarding and privacy settings.
 
+# Version 1.0.0
 - Initial stable version.

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/ui/components/ConsentToggleCard.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/ui/components/ConsentToggleCard.kt
@@ -10,15 +10,11 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.icons.Icons
-import androidx.compose.material.icons.filled.Check
-import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Switch
-import androidx.compose.material3.SwitchDefaults
+import com.d4rk.android.libs.apptoolkit.core.ui.components.switches.CustomSwitch
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -85,20 +81,10 @@ fun ConsentToggleCard(
                     )
                 }
                 LargeHorizontalSpacer()
-                Switch(
-                    checked = switchState, onCheckedChange = onCheckedChange, thumbContent = {
-                        Icon(
-                            imageVector = if (switchState) Icons.Filled.Check else Icons.Filled.Close,
-                            contentDescription = stringResource(R.string.icon_desc_switch_status),
-                            modifier = Modifier.size(SizeConstants.SwitchIconSize),
-                            tint = if (switchState) MaterialTheme.colorScheme.onPrimary else MaterialTheme.colorScheme.onSurfaceVariant
-                        )
-                    }, colors = SwitchDefaults.colors(
-                        checkedThumbColor = MaterialTheme.colorScheme.primary,
-                        checkedTrackColor = MaterialTheme.colorScheme.primaryContainer,
-                        uncheckedThumbColor = MaterialTheme.colorScheme.outline,
-                        uncheckedTrackColor = MaterialTheme.colorScheme.surfaceContainerHighest
-                    )
+                CustomSwitch(
+                    checked = switchState,
+                    onCheckedChange = onCheckedChange,
+                    modifier = Modifier,
                 )
             }
         }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/OnboardingScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/OnboardingScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.oboarding.domain.data.model.ui.OnboardingPage
@@ -41,6 +42,7 @@ import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
+import android.view.SoundEffectConstants
 
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
@@ -52,6 +54,7 @@ fun OnboardingScreen() {
     val coroutineScope: CoroutineScope = rememberCoroutineScope()
     val pagerState: PagerState = rememberPagerState { pages.size }
     val dataStore: CommonDataStore = CommonDataStore.getInstance(context = context)
+    val view = LocalView.current
     val onSkipRequested = {
         coroutineScope.launch {
             dataStore.saveStartup(isFirstTime = false)
@@ -68,7 +71,11 @@ fun OnboardingScreen() {
                     exit = slideOutHorizontally(targetOffsetX = { fullWidth -> fullWidth }) + fadeOut()
                 ) {
                     TextButton(
-                        onClick = onSkipRequested, modifier = Modifier.bounceClick()
+                        onClick = {
+                            view.playSoundEffect(SoundEffectConstants.CLICK)
+                            onSkipRequested()
+                        },
+                        modifier = Modifier.bounceClick()
                     ) {
                         Icon(
                             imageVector = Icons.Filled.SkipNext,

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/components/AmoledModeToggle.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/components/AmoledModeToggle.kt
@@ -75,7 +75,13 @@ fun AmoledModeToggle(
                 )
             }
             LargeHorizontalSpacer()
-            Switch(checked = isAmoledMode, onCheckedChange = onCheckedChange, thumbContent = {
+            Switch(
+                checked = isAmoledMode,
+                onCheckedChange = {
+                    view.playSoundEffect(SoundEffectConstants.CLICK)
+                    onCheckedChange(it)
+                },
+                thumbContent = {
                 Icon(
                     imageVector = Icons.Filled.Tonality,
                     contentDescription = null,

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/components/pages/CrashlyticsOnboardingPageTab.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/components/pages/CrashlyticsOnboardingPageTab.kt
@@ -218,7 +218,13 @@ fun UsageAndDiagnosticsToggleCard(
                 )
             }
             LargeHorizontalSpacer()
-            Switch(checked = switchState, onCheckedChange = onCheckedChange, thumbContent = {
+            Switch(
+                checked = switchState,
+                onCheckedChange = {
+                    view.playSoundEffect(SoundEffectConstants.CLICK)
+                    onCheckedChange(it)
+                },
+                thumbContent = {
                 AnimatedContent(targetState = switchState, transitionSpec = {
                     if (targetState) {
                         slideInVertically { height: Int -> height } + fadeIn() togetherWith slideOutVertically { height: Int -> -height } + fadeOut()
@@ -259,12 +265,15 @@ fun LearnMoreSection(context: Context) {
         )
 
         MediumVerticalSpacer()
-        TextButton(onClick = {
-            val intent = Intent(Intent.ACTION_VIEW, AppLinks.PRIVACY_POLICY.toUri())
-            context.startActivity(intent)
-        },
+        TextButton(
+            onClick = {
+                view.playSoundEffect(SoundEffectConstants.CLICK)
+                val intent = Intent(Intent.ACTION_VIEW, AppLinks.PRIVACY_POLICY.toUri())
+                context.startActivity(intent)
+            },
             modifier = Modifier.bounceClick(),
-            colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.primary)) {
+            colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.primary)
+        ) {
             Icon(
                 imageVector = Icons.AutoMirrored.Filled.Launch,
                 contentDescription = null,
@@ -495,7 +504,10 @@ fun ConsentToggleItem(
             MediumHorizontalSpacer()
             Switch(
                 checked = switchState,
-                onCheckedChange = onCheckedChange,
+                onCheckedChange = {
+                    view.playSoundEffect(SoundEffectConstants.CLICK)
+                    onCheckedChange(it)
+                },
                 colors = SwitchDefaults.colors(
                     checkedThumbColor = MaterialTheme.colorScheme.primary,
                     checkedTrackColor = MaterialTheme.colorScheme.primaryContainer,

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupScreen.kt
@@ -29,6 +29,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.sections.Info
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
 import com.d4rk.android.libs.apptoolkit.core.ui.components.navigation.TopAppBarScaffold
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.links.AppLinks
 
 @Composable
 fun StartupScreen(activity : StartupActivity , viewModel : StartupViewModel) {
@@ -72,7 +73,11 @@ fun StartupScreenContent(paddingValues : PaddingValues) {
         LazyColumn(modifier = Modifier.fillMaxSize()) {
             item {
                 AsyncImage(model = R.drawable.il_startup , contentDescription = null)
-                InfoMessageSection(message = stringResource(R.string.summary_browse_terms_of_service_and_privacy_policy) , learnMoreText = stringResource(R.string.learn_more) , learnMoreUrl = "https://sites.google.com/view/d4rk7355608/more/apps/privacy-policy")
+                InfoMessageSection(
+                    message = stringResource(R.string.summary_browse_terms_of_service_and_privacy_policy),
+                    learnMoreText = stringResource(R.string.learn_more),
+                    learnMoreUrl = AppLinks.PRIVACY_POLICY
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary
- ensure StartupScreen uses AppLinks for privacy policy link
- play click sound on Onboarding skip button
- play click sound on privacy policy button
- play click sound when toggling switches
- document recent changes

## Testing
- `./gradlew tasks --no-daemon`
- `./gradlew testDebugUnitTest --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68454786a78c832daf90a1b17ee8a13c