### PR TITLE
Fix consent form timing

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/domain/actions/OnboardingEvent.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/domain/actions/OnboardingEvent.kt
@@ -5,5 +5,5 @@ import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.UiEvent
 
 sealed class OnboardingEvent : UiEvent {
     data class OpenConsentForm(val activity: Activity) : OnboardingEvent()
-    data object LoadConsentInfo : OnboardingEvent()
+    data class LoadConsentInfo(val activity: Activity? = null) : OnboardingEvent()
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/OnboardingActivity.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/OnboardingActivity.kt
@@ -33,6 +33,6 @@ class OnboardingActivity : ComponentActivity() {
 
     override fun onResume() {
         super.onResume()
-        viewModel.onEvent(event = OnboardingEvent.OpenConsentForm(activity = this@OnboardingActivity))
+        viewModel.onEvent(event = OnboardingEvent.LoadConsentInfo(activity = this@OnboardingActivity))
     }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/OnboardingViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/OnboardingViewModel.kt
@@ -28,17 +28,17 @@ class OnboardingViewModel(
 ) {
 
     init {
-        onEvent(event = OnboardingEvent.LoadConsentInfo)
+        onEvent(event = OnboardingEvent.LoadConsentInfo())
     }
 
     override fun onEvent(event: OnboardingEvent) {
         when (event) {
             is OnboardingEvent.OpenConsentForm -> openConsentForm(activity = event.activity)
-            is OnboardingEvent.LoadConsentInfo -> loadConsentInfo()
+            is OnboardingEvent.LoadConsentInfo -> loadConsentInfo(activity = event.activity)
         }
     }
 
-    private fun loadConsentInfo() {
+    private fun loadConsentInfo(activity: Activity? = null) {
         launch(context = dispatcherProvider.io) {
             loadConsentInfoUseCase().stateIn(
                 scope = viewModelScope,
@@ -57,6 +57,9 @@ class OnboardingViewModel(
                                 ),
                         consentInformation = consentInfo
                     )
+                }
+                if (result is DataState.Success && activity != null) {
+                    openConsentForm(activity = activity)
                 }
             }
         }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/startup/domain/actions/StartupEvent.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/startup/domain/actions/StartupEvent.kt
@@ -5,5 +5,5 @@ import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.UiEvent
 
 sealed class StartupEvent : UiEvent {
     data class OpenConsentForm(val activity : Activity) : StartupEvent()
-    data object LoadConsentInfo : StartupEvent()
+    data class LoadConsentInfo(val activity: Activity? = null) : StartupEvent()
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupActivity.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupActivity.kt
@@ -43,7 +43,7 @@ class StartupActivity : AppCompatActivity() {
             permissionLauncher.launch(input = provider.requiredPermissions)
         }
 
-        viewModel.onEvent(event = StartupEvent.OpenConsentForm(activity = this@StartupActivity))
+        viewModel.onEvent(event = StartupEvent.LoadConsentInfo(activity = this@StartupActivity))
     }
 
     fun navigateToNext() {


### PR DESCRIPTION
## Summary
- show consent dialog after consent information loads
- trigger consent info loading in onboarding and startup screens
- keep main activity consent check

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68455f677f8c832dbd0586c5fad0453c