### PR TITLE
Implement issue reporter sending logic

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppToolkitModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppToolkitModule.kt
@@ -6,6 +6,7 @@ import com.d4rk.android.libs.apptoolkit.app.help.domain.data.model.HelpScreenCon
 import com.d4rk.android.libs.apptoolkit.app.startup.utils.interfaces.providers.StartupProvider
 import com.d4rk.android.libs.apptoolkit.app.support.domain.usecases.QueryProductDetailsUseCase
 import com.d4rk.android.libs.apptoolkit.app.support.ui.SupportViewModel
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.IssueReporterViewModel
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
@@ -16,6 +17,10 @@ val appToolkitModule : Module = module {
     single<QueryProductDetailsUseCase> { QueryProductDetailsUseCase() }
     viewModel {
         SupportViewModel(queryProductDetailsUseCase = get() , dispatcherProvider = get())
+    }
+
+    viewModel {
+        IssueReporterViewModel(dispatcherProvider = get() , httpClient = get())
     }
 
     single<HelpScreenConfig> { HelpScreenConfig(versionName = BuildConfig.VERSION_NAME , versionCode = BuildConfig.VERSION_CODE) }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/IssueReporterActivity.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/IssueReporterActivity.kt
@@ -1,7 +1,6 @@
 package com.d4rk.android.libs.apptoolkit.app.issuereporter
 
 import android.os.Bundle
-import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.foundation.layout.Column
@@ -12,43 +11,43 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
+import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.input.PasswordVisualTransformation
 import com.d4rk.android.libs.apptoolkit.R
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.actions.IssueReporterEvent
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.UiIssueReporterScreen
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
+import com.d4rk.android.libs.apptoolkit.core.ui.components.snackbar.DefaultSnackbarHandler
+import org.koin.androidx.viewmodel.ext.android.viewModel
 
 open class IssueReporterActivity : AppCompatActivity() {
+    private val viewModel: IssueReporterViewModel by viewModel()
     @OptIn(ExperimentalMaterial3Api::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContent {
-            IssueReporterScreen()
+            IssueReporterScreen(viewModel = viewModel)
         }
     }
 }
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun IssueReporterScreen() {
-    val title = remember { mutableStateOf("") }
-    val description = remember { mutableStateOf("") }
-    val username = remember { mutableStateOf("") }
-    val password = remember { mutableStateOf("") }
-    val email = remember { mutableStateOf("") }
-
-    Scaffold { padding ->
-        Column(
-            modifier = Modifier.fillMaxSize().padding(padding),
-        ) {
-            TextField(value = title.value, onValueChange = { title.value = it }, label = { Text(stringResource(id = R.string.issue_title_label)) })
-            TextField(value = description.value, onValueChange = { description.value = it }, label = { Text(stringResource(id = R.string.issue_description_label)) })
-            TextField(value = username.value, onValueChange = { username.value = it }, label = { Text(stringResource(id = R.string.issue_username_label)) })
-            TextField(value = password.value, onValueChange = { password.value = it }, label = { Text(stringResource(id = R.string.issue_password_label)) }, visualTransformation = PasswordVisualTransformation())
-            TextField(value = email.value, onValueChange = { email.value = it }, label = { Text(stringResource(id = R.string.issue_email_label)) })
-            Button(onClick = { /* TODO send */ }) {
+fun IssueReporterScreen(viewModel: IssueReporterViewModel) {
+    val snackbarHostState = remember { SnackbarHostState() }
+    val screenState: UiStateScreen<UiIssueReporterScreen> by viewModel.uiState.collectAsState()
+    val data = screenState.data ?: UiIssueReporterScreen()
+    Scaffold(snackbarHost = { DefaultSnackbarHandler(screenState = screenState, snackbarHostState = snackbarHostState, getDismissEvent = { IssueReporterEvent.DismissSnackbar }, onEvent = { viewModel.onEvent(it) }) }) { padding ->
+        Column(modifier = Modifier.fillMaxSize().padding(padding)) {
+            TextField(value = data.title, onValueChange = { viewModel.onEvent(IssueReporterEvent.UpdateTitle(it)) }, label = { Text(stringResource(id = R.string.issue_title_label)) })
+            TextField(value = data.description, onValueChange = { viewModel.onEvent(IssueReporterEvent.UpdateDescription(it)) }, label = { Text(stringResource(id = R.string.issue_description_label)) })
+            TextField(value = data.email, onValueChange = { viewModel.onEvent(IssueReporterEvent.UpdateEmail(it)) }, label = { Text(stringResource(id = R.string.issue_email_label)) })
+            Button(onClick = { viewModel.onEvent(IssueReporterEvent.Send(context = this@IssueReporterActivity)) }) {
                 Text(text = stringResource(id = R.string.issue_send))
             }
         }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/IssueReporterViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/IssueReporterViewModel.kt
@@ -1,0 +1,112 @@
+package com.d4rk.android.libs.apptoolkit.app.issuereporter
+
+import android.content.Context
+import com.d4rk.android.libs.apptoolkit.R
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.data.IssueReporterRepository
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.actions.IssueReporterAction
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.actions.IssueReporterEvent
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.UiIssueReporterScreen
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.model.DeviceInfo
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.model.Report
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.model.github.ExtraInfo
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.model.github.GithubTarget
+import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiSnackbar
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.dismissSnackbar
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.showSnackbar
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.updateData
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.updateState
+import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.ScreenMessageType
+import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
+import io.ktor.client.HttpClient
+
+class IssueReporterViewModel(
+    private val dispatcherProvider: DispatcherProvider,
+    private val httpClient: HttpClient
+) : ScreenViewModel<UiIssueReporterScreen, IssueReporterEvent, IssueReporterAction>(
+    initialState = UiStateScreen(data = UiIssueReporterScreen())
+) {
+
+    private val repository = IssueReporterRepository(httpClient)
+    private val target = GithubTarget(username = "D4rK7355608", repository = "AppToolkit")
+
+    override fun onEvent(event: IssueReporterEvent) {
+        when (event) {
+            is IssueReporterEvent.UpdateTitle -> updateTitle(event.value)
+            is IssueReporterEvent.UpdateDescription -> updateDescription(event.value)
+            is IssueReporterEvent.UpdateEmail -> updateEmail(event.value)
+            is IssueReporterEvent.Send -> sendReport(event.context)
+            IssueReporterEvent.DismissSnackbar -> screenState.dismissSnackbar()
+        }
+    }
+
+    private fun updateTitle(value: String) {
+        screenState.updateData(newState = screenState.value.screenState) { current ->
+            current.copy(title = value)
+        }
+    }
+
+    private fun updateDescription(value: String) {
+        screenState.updateData(newState = screenState.value.screenState) { current ->
+            current.copy(description = value)
+        }
+    }
+
+    private fun updateEmail(value: String) {
+        screenState.updateData(newState = screenState.value.screenState) { current ->
+            current.copy(email = value)
+        }
+    }
+
+    private fun sendReport(context: Context) {
+        val data = screenState.value.data ?: return
+        if (data.title.isBlank() || data.description.isBlank()) {
+            screenState.showSnackbar<UiIssueReporterScreen>(
+                snackbar = UiSnackbar(
+                    message = UiTextHelper.StringResource(R.string.error_invalid_report),
+                    timeStamp = System.currentTimeMillis(),
+                    isError = true,
+                    type = ScreenMessageType.SNACKBAR
+                )
+            )
+            return
+        }
+        launch(dispatcherProvider.io) {
+            screenState.updateState(ScreenState.IsLoading())
+            val deviceInfo = DeviceInfo(context)
+            val extraInfo = ExtraInfo()
+            val report = Report(
+                title = data.title,
+                description = data.description,
+                deviceInfo = deviceInfo,
+                extraInfo = extraInfo,
+                email = data.email.ifBlank { null }
+            )
+            val success = runCatching { repository.sendReport(report, target) }.getOrDefault(false)
+            if (success) {
+                screenState.showSnackbar<UiIssueReporterScreen>(
+                    snackbar = UiSnackbar(
+                        message = UiTextHelper.StringResource(R.string.snack_report_success),
+                        isError = false,
+                        timeStamp = System.currentTimeMillis(),
+                        type = ScreenMessageType.SNACKBAR
+                    )
+                )
+                screenState.updateState(ScreenState.Success())
+            } else {
+                screenState.showSnackbar<UiIssueReporterScreen>(
+                    snackbar = UiSnackbar(
+                        message = UiTextHelper.StringResource(R.string.snack_report_failed),
+                        isError = true,
+                        timeStamp = System.currentTimeMillis(),
+                        type = ScreenMessageType.SNACKBAR
+                    )
+                )
+                screenState.updateState(ScreenState.Error())
+            }
+        }
+    }
+}

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/data/IssueReporterRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/data/IssueReporterRepository.kt
@@ -1,0 +1,36 @@
+package com.d4rk.android.libs.apptoolkit.app.issuereporter.data
+
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.model.Report
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.model.github.GithubTarget
+import io.ktor.client.HttpClient
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+
+class IssueReporterRepository(private val client: HttpClient) {
+
+    @Serializable
+    private data class CreateIssueRequest(
+        val title: String,
+        val body: String,
+        val labels: List<String>? = null,
+        @SerialName("assignees") val assignees: List<String>? = null
+    )
+
+    suspend fun sendReport(report: Report, target: GithubTarget, token: String? = null): Boolean {
+        val url = "https://api.github.com/repos/${target.username}/${target.repository}/issues"
+        val response: HttpResponse = client.post(url) {
+            contentType(ContentType.Application.Json)
+            token?.let { header("Authorization", "Bearer $it") }
+            setBody(Json.encodeToString(CreateIssueRequest(title = report.title, body = report.getDescription())))
+        }
+        return response.status == HttpStatusCode.Created
+    }
+}

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/domain/actions/IssueReporterAction.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/domain/actions/IssueReporterAction.kt
@@ -1,0 +1,5 @@
+package com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.actions
+
+import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.ActionEvent
+
+sealed interface IssueReporterAction : ActionEvent

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/domain/actions/IssueReporterEvent.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/domain/actions/IssueReporterEvent.kt
@@ -1,0 +1,12 @@
+package com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.actions
+
+import android.content.Context
+import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.UiEvent
+
+sealed interface IssueReporterEvent : UiEvent {
+    data class UpdateTitle(val value: String) : IssueReporterEvent
+    data class UpdateDescription(val value: String) : IssueReporterEvent
+    data class UpdateEmail(val value: String) : IssueReporterEvent
+    data class Send(val context: Context) : IssueReporterEvent
+    data object DismissSnackbar : IssueReporterEvent
+}

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/domain/model/UiIssueReporterScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/domain/model/UiIssueReporterScreen.kt
@@ -1,0 +1,10 @@
+package com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model
+
+/**
+ * UI state holder for the Issue Reporter screen.
+ */
+data class UiIssueReporterScreen(
+    val title: String = "",
+    val description: String = "",
+    val email: String = ""
+)

--- a/apptoolkit/src/main/res/values/strings.xml
+++ b/apptoolkit/src/main/res/values/strings.xml
@@ -259,4 +259,7 @@
     <string name="issue_password_label">Password</string>
     <string name="issue_email_label">Email</string>
     <string name="issue_send">Send</string>
+    <string name="snack_report_success">Report sent successfully</string>
+    <string name="snack_report_failed">Failed to send report</string>
+    <string name="error_invalid_report">Title and description cannot be empty</string>
 </resources>


### PR DESCRIPTION
## Summary
- add `IssueReporterViewModel` with sending logic using Ktor
- create repository and domain classes for issue reporter
- integrate view model with `IssueReporterActivity`
- expose view model in `appToolkitModule`
- add feedback strings

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fc6445824832da93f4bd34e558169