### PR TITLE
Add collapsible device info card

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/domain/model/github/GithubLogin.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/domain/model/github/GithubLogin.kt
@@ -1,5 +1,10 @@
 package com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.github
 
+@Deprecated(
+    message = "No longer used since the Compose rework of IssueReporter.",
+    level = DeprecationLevel.WARNING
+)
+// TODO: Remove this class once legacy IssueReporter logic is fully deleted.
 class GithubLogin {
     val username: String?
     val password: String?

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/IssueReporterScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/IssueReporterScreen.kt
@@ -4,22 +4,29 @@ import android.app.Activity
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.text.KeyboardOptions
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.foundation.horizontalScroll
+import androidx.compose.foundation.clickable
+import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.BugReport
 import androidx.compose.material.icons.outlined.Email
 import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.ExpandMore
+import androidx.compose.material.icons.outlined.ExpandLess
 import androidx.compose.material.icons.outlined.Link
 import androidx.compose.material.icons.outlined.Title
 import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
@@ -29,6 +36,8 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -36,6 +45,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.input.ImeAction
 import androidx.compose.ui.unit.dp
 import com.d4rk.android.libs.apptoolkit.R
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.actions.IssueReporterEvent
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.github.GithubTarget
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.ui.UiIssueReporterScreen
@@ -151,13 +161,52 @@ fun IssueReporterScreenContent(
             }
         }
 
+        val context = LocalContext.current
+        var deviceExpanded by rememberSaveable { mutableStateOf(false) }
+
+        Card(shape = MaterialTheme.shapes.medium , modifier = Modifier.fillMaxWidth()) {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                androidx.compose.material3.Surface(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .clickable { deviceExpanded = ! deviceExpanded }
+                        .padding(16.dp),
+                    color = MaterialTheme.colorScheme.surfaceVariant
+                ) {
+                    Row(verticalAlignment = Alignment.CenterVertically) {
+                        Text(
+                            text = stringResource(id = R.string.device_info),
+                            style = MaterialTheme.typography.titleMedium,
+                            modifier = Modifier.weight(1f)
+                        )
+                        Icon(
+                            imageVector = if (deviceExpanded) Icons.Outlined.ExpandLess else Icons.Outlined.ExpandMore,
+                            contentDescription = null
+                        )
+                    }
+                }
+                AnimatedVisibility(visible = deviceExpanded) {
+                    val info = remember { DeviceInfo(context).toString() }
+                    Text(
+                        text = info,
+                        style = MaterialTheme.typography.bodySmall,
+                        modifier = Modifier
+                            .padding(16.dp)
+                            .horizontalScroll(rememberScrollState())
+                    )
+                }
+            }
+        }
+
     }
 }
 
 @Composable
 private fun RadioOption(selected : Boolean , text : String , onClick : () -> Unit) {
-    androidx.compose.material3.RadioButton(
-        selected = selected , onClick = onClick , modifier = Modifier.padding(end = 8.dp)
-    )
-    Text(text = text , style = MaterialTheme.typography.bodyLarge)
+    Row(verticalAlignment = Alignment.CenterVertically, modifier = Modifier.fillMaxWidth()) {
+        androidx.compose.material3.RadioButton(
+            selected = selected , onClick = onClick
+        )
+        Text(text = text , style = MaterialTheme.typography.bodyLarge , modifier = Modifier.padding(start = 8.dp))
+    }
 }


### PR DESCRIPTION
## Summary
- mark unused `GithubLogin` as deprecated
- implement collapsible device info card in IssueReporter screen
- inline radio buttons with their labels

## Testing
- `./gradlew tasks --all`
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fd80d0cd8832d9263b74fba354e23