### PR TITLE
Add Issue Reporter translations

### DIFF
--- a/apptoolkit/src/main/res/values-ar-rEG/strings.xml
+++ b/apptoolkit/src/main/res/values-ar-rEG/strings.xml
@@ -120,6 +120,22 @@
 
     <string name="advanced">متقدم</string>
     <string name="summary_preference_settings_advanced">استكشف المزيد من الإعدادات المتقدمة</string>
+    <string name="issue_title_label">العنوان</string>
+    <string name="issue_description_label">الوصف</string>
+    <string name="issue_section_label">المشكلة</string>
+    <string name="login_section_label">تسجيل الدخول</string>
+    <string name="use_github_account">أرسل باستخدام حساب GitHub</string>
+    <string name="send_anonymously">أرسل مجهولاً</string>
+    <string name="optional_placeholder">(اختياري)</string>
+    <string name="issue_username_label">اسم المستخدم</string>
+    <string name="issue_password_label">كلمة المرور</string>
+    <string name="issue_email_label">البريد الإلكتروني</string>
+    <string name="issue_send">إرسال</string>
+    <string name="cd_expand_device_info">توسيع أو طي معلومات الجهاز</string>
+    <string name="view_on_github">إعادة التوجيه إلى GitHub</string>
+    <string name="snack_report_success">تم إرسال التقرير بنجاح</string>
+    <string name="snack_report_failed">فشل في إرسال التقرير</string>
+    <string name="error_invalid_report">لا يمكن أن يكون العنوان والوصف فارغين</string>
 
     <string name="error_reporting">الإبلاغ عن الأخطاء</string>
     <string name="bug_report">تقرير خطأ</string>

--- a/apptoolkit/src/main/res/values-bg-rBG/strings.xml
+++ b/apptoolkit/src/main/res/values-bg-rBG/strings.xml
@@ -120,6 +120,22 @@
 
     <string name="advanced">Разширени</string>
     <string name="summary_preference_settings_advanced">Разгледайте повече разширени настройки</string>
+    <string name="issue_title_label">Заглавие</string>
+    <string name="issue_description_label">Описание</string>
+    <string name="issue_section_label">Проблем</string>
+    <string name="login_section_label">Вход</string>
+    <string name="use_github_account">Изпрати чрез GitHub профил</string>
+    <string name="send_anonymously">Изпрати анонимно</string>
+    <string name="optional_placeholder">(По избор)</string>
+    <string name="issue_username_label">Потребителско име</string>
+    <string name="issue_password_label">Парола</string>
+    <string name="issue_email_label">Имейл</string>
+    <string name="issue_send">Изпрати</string>
+    <string name="cd_expand_device_info">Покажи или скрий информацията за устройството</string>
+    <string name="view_on_github">Пренасочи към GitHub</string>
+    <string name="snack_report_success">Докладът е изпратен успешно</string>
+    <string name="snack_report_failed">Неуспешно изпращане на доклада</string>
+    <string name="error_invalid_report">Заглавието и описанието не могат да бъдат празни</string>
 
     <string name="error_reporting">Докладване на грешки</string>
     <string name="bug_report">Доклад за грешка</string>

--- a/apptoolkit/src/main/res/values-bn-rBD/strings.xml
+++ b/apptoolkit/src/main/res/values-bn-rBD/strings.xml
@@ -120,6 +120,22 @@
 
     <string name="advanced">অ্যাডভান্সড</string>
     <string name="summary_preference_settings_advanced">আরও অ্যাডভান্সড সেটিংস অন্বেষণ করুন</string>
+    <string name="issue_title_label">শিরোনাম</string>
+    <string name="issue_description_label">বর্ণনা</string>
+    <string name="issue_section_label">সমস্যা</string>
+    <string name="login_section_label">লগইন</string>
+    <string name="use_github_account">GitHub অ্যাকাউন্ট ব্যবহার করে পাঠান</string>
+    <string name="send_anonymously">গোপনভাবে পাঠান</string>
+    <string name="optional_placeholder">(ঐচ্ছিক)</string>
+    <string name="issue_username_label">ব্যবহারকারীর নাম</string>
+    <string name="issue_password_label">পাসওয়ার্ড</string>
+    <string name="issue_email_label">ইমেল</string>
+    <string name="issue_send">পাঠান</string>
+    <string name="cd_expand_device_info">ডিভাইসের তথ্য প্রসারিত বা সংকুচিত করুন</string>
+    <string name="view_on_github">GitHub-এ পুনঃনির্দেশ করুন</string>
+    <string name="snack_report_success">রিপোর্ট সফলভাবে পাঠানো হয়েছে</string>
+    <string name="snack_report_failed">রিপোর্ট পাঠাতে ব্যর্থ হয়েছে</string>
+    <string name="error_invalid_report">শিরোনাম ও বর্ণনা খালি হতে পারে না</string>
 
     <string name="error_reporting">ত্রুটি প্রতিবেদন</string>
     <string name="bug_report">বাগ রিপোর্ট</string>

--- a/apptoolkit/src/main/res/values-de-rDE/strings.xml
+++ b/apptoolkit/src/main/res/values-de-rDE/strings.xml
@@ -120,6 +120,22 @@
 
     <string name="advanced">Erweitert</string>
     <string name="summary_preference_settings_advanced">Erkunden Sie erweiterte Einstellungen</string>
+    <string name="issue_title_label">Titel</string>
+    <string name="issue_description_label">Beschreibung</string>
+    <string name="issue_section_label">Problem</string>
+    <string name="login_section_label">Anmeldung</string>
+    <string name="use_github_account">Über GitHub-Konto senden</string>
+    <string name="send_anonymously">Anonym senden</string>
+    <string name="optional_placeholder">(Optional)</string>
+    <string name="issue_username_label">Benutzername</string>
+    <string name="issue_password_label">Passwort</string>
+    <string name="issue_email_label">E-Mail</string>
+    <string name="issue_send">Senden</string>
+    <string name="cd_expand_device_info">Geräteinformationen ein- oder ausblenden</string>
+    <string name="view_on_github">Zu GitHub weiterleiten</string>
+    <string name="snack_report_success">Bericht erfolgreich gesendet</string>
+    <string name="snack_report_failed">Senden des Berichts fehlgeschlagen</string>
+    <string name="error_invalid_report">Titel und Beschreibung dürfen nicht leer sein</string>
 
     <string name="error_reporting">Fehlerberichte</string>
     <string name="bug_report">Fehlerbericht</string>

--- a/apptoolkit/src/main/res/values-es-rGQ/strings.xml
+++ b/apptoolkit/src/main/res/values-es-rGQ/strings.xml
@@ -120,6 +120,22 @@
 
     <string name="advanced">Avanzado</string>
     <string name="summary_preference_settings_advanced">Explora configuraciones avanzadas</string>
+    <string name="issue_title_label">Título</string>
+    <string name="issue_description_label">Descripción</string>
+    <string name="issue_section_label">Incidencia</string>
+    <string name="login_section_label">Iniciar sesión</string>
+    <string name="use_github_account">Enviar usando la cuenta de GitHub</string>
+    <string name="send_anonymously">Enviar de forma anónima</string>
+    <string name="optional_placeholder">(Opcional)</string>
+    <string name="issue_username_label">Nombre de usuario</string>
+    <string name="issue_password_label">Contraseña</string>
+    <string name="issue_email_label">Correo electrónico</string>
+    <string name="issue_send">Enviar</string>
+    <string name="cd_expand_device_info">Expandir o contraer información del dispositivo</string>
+    <string name="view_on_github">Redirigir a GitHub</string>
+    <string name="snack_report_success">Informe enviado correctamente</string>
+    <string name="snack_report_failed">Error al enviar el informe</string>
+    <string name="error_invalid_report">El título y la descripción no pueden estar vacíos</string>
 
     <string name="error_reporting">Informe de errores</string>
     <string name="bug_report">Informe de fallos</string>

--- a/apptoolkit/src/main/res/values-es-rMX/strings.xml
+++ b/apptoolkit/src/main/res/values-es-rMX/strings.xml
@@ -120,6 +120,22 @@
 
     <string name="advanced">Avanzado</string>
     <string name="summary_preference_settings_advanced">Explora configuraciones más avanzadas</string>
+    <string name="issue_title_label">Título</string>
+    <string name="issue_description_label">Descripción</string>
+    <string name="issue_section_label">Incidencia</string>
+    <string name="login_section_label">Iniciar sesión</string>
+    <string name="use_github_account">Enviar usando la cuenta de GitHub</string>
+    <string name="send_anonymously">Enviar de forma anónima</string>
+    <string name="optional_placeholder">(Opcional)</string>
+    <string name="issue_username_label">Nombre de usuario</string>
+    <string name="issue_password_label">Contraseña</string>
+    <string name="issue_email_label">Correo electrónico</string>
+    <string name="issue_send">Enviar</string>
+    <string name="cd_expand_device_info">Expandir o contraer información del dispositivo</string>
+    <string name="view_on_github">Redirigir a GitHub</string>
+    <string name="snack_report_success">Informe enviado correctamente</string>
+    <string name="snack_report_failed">Error al enviar el informe</string>
+    <string name="error_invalid_report">El título y la descripción no pueden estar vacíos</string>
 
     <string name="error_reporting">Informe de errores</string>
     <string name="bug_report">Informe de error</string>

--- a/apptoolkit/src/main/res/values-fil-rPH/strings.xml
+++ b/apptoolkit/src/main/res/values-fil-rPH/strings.xml
@@ -120,6 +120,22 @@
 
     <string name="advanced">Advanced</string>
     <string name="summary_preference_settings_advanced">Galugarin ang mas maraming advanced na setting</string>
+    <string name="issue_title_label">Pamagat</string>
+    <string name="issue_description_label">Paglalarawan</string>
+    <string name="issue_section_label">Isyu</string>
+    <string name="login_section_label">Mag-login</string>
+    <string name="use_github_account">Ipadala gamit ang GitHub account</string>
+    <string name="send_anonymously">Ipadala nang hindi nagpapakilala</string>
+    <string name="optional_placeholder">(Opsyonal)</string>
+    <string name="issue_username_label">Username</string>
+    <string name="issue_password_label">Password</string>
+    <string name="issue_email_label">Email</string>
+    <string name="issue_send">Ipadala</string>
+    <string name="cd_expand_device_info">Palawakin o itago ang impormasyon ng device</string>
+    <string name="view_on_github">I-redirect sa GitHub</string>
+    <string name="snack_report_success">Matagumpay na naipadala ang ulat</string>
+    <string name="snack_report_failed">Nabigo ang pagpapadala ng ulat</string>
+    <string name="error_invalid_report">Hindi maaaring walang laman ang pamagat at paglalarawan</string>
 
     <string name="error_reporting">Pag-uulat ng error</string>
     <string name="bug_report">Ulat ng bug</string>

--- a/apptoolkit/src/main/res/values-fr-rFR/strings.xml
+++ b/apptoolkit/src/main/res/values-fr-rFR/strings.xml
@@ -120,6 +120,22 @@
 
     <string name="advanced">Avancé</string>
     <string name="summary_preference_settings_advanced">Explorez des paramètres avancés</string>
+    <string name="issue_title_label">Titre</string>
+    <string name="issue_description_label">Description</string>
+    <string name="issue_section_label">Problème</string>
+    <string name="login_section_label">Connexion</string>
+    <string name="use_github_account">Envoyer avec le compte GitHub</string>
+    <string name="send_anonymously">Envoyer anonymement</string>
+    <string name="optional_placeholder">(Facultatif)</string>
+    <string name="issue_username_label">Nom d'utilisateur</string>
+    <string name="issue_password_label">Mot de passe</string>
+    <string name="issue_email_label">E-mail</string>
+    <string name="issue_send">Envoyer</string>
+    <string name="cd_expand_device_info">Développer ou réduire les informations de l'appareil</string>
+    <string name="view_on_github">Rediriger vers GitHub</string>
+    <string name="snack_report_success">Rapport envoyé avec succès</string>
+    <string name="snack_report_failed">Échec de l'envoi du rapport</string>
+    <string name="error_invalid_report">Le titre et la description ne peuvent pas être vides</string>
 
     <string name="error_reporting">Rapport d\'erreurs</string>
     <string name="bug_report">Rapport de bug</string>

--- a/apptoolkit/src/main/res/values-hi-rIN/strings.xml
+++ b/apptoolkit/src/main/res/values-hi-rIN/strings.xml
@@ -120,6 +120,22 @@
 
     <string name="advanced">उन्नत</string>
     <string name="summary_preference_settings_advanced">और अधिक उन्नत सेटिंग्स का अन्वेषण करें</string>
+    <string name="issue_title_label">शीर्षक</string>
+    <string name="issue_description_label">विवरण</string>
+    <string name="issue_section_label">समस्या</string>
+    <string name="login_section_label">लॉगिन</string>
+    <string name="use_github_account">GitHub खाता उपयोग करके भेजें</string>
+    <string name="send_anonymously">बेनामी भेजें</string>
+    <string name="optional_placeholder">(वैकल्पिक)</string>
+    <string name="issue_username_label">यूज़रनेम</string>
+    <string name="issue_password_label">पासवर्ड</string>
+    <string name="issue_email_label">ईमेल</string>
+    <string name="issue_send">भेजें</string>
+    <string name="cd_expand_device_info">डिवाइस की जानकारी विस्तारित या संक्षिप्त करें</string>
+    <string name="view_on_github">GitHub पर रीडायरेक्ट करें</string>
+    <string name="snack_report_success">रिपोर्ट सफलतापूर्वक भेजी गई</string>
+    <string name="snack_report_failed">रिपोर्ट भेजने में विफल</string>
+    <string name="error_invalid_report">शीर्षक और विवरण खाली नहीं हो सकते</string>
 
     <string name="error_reporting">त्रुटि रिपोर्टिंग</string>
     <string name="bug_report">बग रिपोर्ट</string>

--- a/apptoolkit/src/main/res/values-hu-rHU/strings.xml
+++ b/apptoolkit/src/main/res/values-hu-rHU/strings.xml
@@ -120,6 +120,22 @@
 
     <string name="advanced">Haladó</string>
     <string name="summary_preference_settings_advanced">Fedezd fel a további haladó beállításokat</string>
+    <string name="issue_title_label">Cím</string>
+    <string name="issue_description_label">Leírás</string>
+    <string name="issue_section_label">Hiba</string>
+    <string name="login_section_label">Bejelentkezés</string>
+    <string name="use_github_account">Küldés GitHub fiókkal</string>
+    <string name="send_anonymously">Küldés névtelenül</string>
+    <string name="optional_placeholder">(Opcionális)</string>
+    <string name="issue_username_label">Felhasználónév</string>
+    <string name="issue_password_label">Jelszó</string>
+    <string name="issue_email_label">E-mail</string>
+    <string name="issue_send">Küldés</string>
+    <string name="cd_expand_device_info">Eszközinformációk kibontása vagy összecsukása</string>
+    <string name="view_on_github">Átirányítás GitHubra</string>
+    <string name="snack_report_success">A jelentés sikeresen elküldve</string>
+    <string name="snack_report_failed">A jelentés elküldése nem sikerült</string>
+    <string name="error_invalid_report">A cím és a leírás nem lehet üres</string>
 
     <string name="error_reporting">Hibajelentés</string>
     <string name="bug_report">Hibajelentés</string>

--- a/apptoolkit/src/main/res/values-in-rID/strings.xml
+++ b/apptoolkit/src/main/res/values-in-rID/strings.xml
@@ -120,6 +120,22 @@
 
     <string name="advanced">Lanjutan</string>
     <string name="summary_preference_settings_advanced">Jelajahi lebih banyak pengaturan lanjutan</string>
+    <string name="issue_title_label">Judul</string>
+    <string name="issue_description_label">Deskripsi</string>
+    <string name="issue_section_label">Masalah</string>
+    <string name="login_section_label">Masuk</string>
+    <string name="use_github_account">Kirim menggunakan akun GitHub</string>
+    <string name="send_anonymously">Kirim secara anonim</string>
+    <string name="optional_placeholder">(Opsional)</string>
+    <string name="issue_username_label">Nama pengguna</string>
+    <string name="issue_password_label">Kata sandi</string>
+    <string name="issue_email_label">Email</string>
+    <string name="issue_send">Kirim</string>
+    <string name="cd_expand_device_info">Perluas atau ciutkan informasi perangkat</string>
+    <string name="view_on_github">Arahkan ke GitHub</string>
+    <string name="snack_report_success">Laporan berhasil dikirim</string>
+    <string name="snack_report_failed">Gagal mengirim laporan</string>
+    <string name="error_invalid_report">Judul dan deskripsi tidak boleh kosong</string>
 
     <string name="error_reporting">Pelaporan kesalahan</string>
     <string name="bug_report">Laporan bug</string>

--- a/apptoolkit/src/main/res/values-it-rIT/strings.xml
+++ b/apptoolkit/src/main/res/values-it-rIT/strings.xml
@@ -120,6 +120,22 @@
 
     <string name="advanced">Avanzate</string>
     <string name="summary_preference_settings_advanced">Esplora impostazioni avanzate</string>
+    <string name="issue_title_label">Titolo</string>
+    <string name="issue_description_label">Descrizione</string>
+    <string name="issue_section_label">Problema</string>
+    <string name="login_section_label">Accesso</string>
+    <string name="use_github_account">Invia con l'account GitHub</string>
+    <string name="send_anonymously">Invia in modo anonimo</string>
+    <string name="optional_placeholder">(Opzionale)</string>
+    <string name="issue_username_label">Nome utente</string>
+    <string name="issue_password_label">Password</string>
+    <string name="issue_email_label">Email</string>
+    <string name="issue_send">Invia</string>
+    <string name="cd_expand_device_info">Espandi o riduci le informazioni sul dispositivo</string>
+    <string name="view_on_github">Reindirizza a GitHub</string>
+    <string name="snack_report_success">Segnalazione inviata con successo</string>
+    <string name="snack_report_failed">Invio della segnalazione non riuscito</string>
+    <string name="error_invalid_report">Titolo e descrizione non possono essere vuoti</string>
 
     <string name="error_reporting">Segnalazione errori</string>
     <string name="bug_report">Segnalazione bug</string>

--- a/apptoolkit/src/main/res/values-ja-rJP/strings.xml
+++ b/apptoolkit/src/main/res/values-ja-rJP/strings.xml
@@ -120,6 +120,22 @@
 
     <string name="advanced">詳細設定</string>
     <string name="summary_preference_settings_advanced">さらに高度な設定を探索する</string>
+    <string name="issue_title_label">タイトル</string>
+    <string name="issue_description_label">説明</string>
+    <string name="issue_section_label">問題</string>
+    <string name="login_section_label">ログイン</string>
+    <string name="use_github_account">GitHubアカウントで送信</string>
+    <string name="send_anonymously">匿名で送信</string>
+    <string name="optional_placeholder">(任意)</string>
+    <string name="issue_username_label">ユーザー名</string>
+    <string name="issue_password_label">パスワード</string>
+    <string name="issue_email_label">メール</string>
+    <string name="issue_send">送信</string>
+    <string name="cd_expand_device_info">デバイス情報を展開/折りたたむ</string>
+    <string name="view_on_github">GitHubにリダイレクト</string>
+    <string name="snack_report_success">レポートが送信されました</string>
+    <string name="snack_report_failed">レポートの送信に失敗しました</string>
+    <string name="error_invalid_report">タイトルと説明は空にできません</string>
 
     <string name="error_reporting">エラー報告</string>
     <string name="bug_report">バグ報告</string>

--- a/apptoolkit/src/main/res/values-ko-rKR/strings.xml
+++ b/apptoolkit/src/main/res/values-ko-rKR/strings.xml
@@ -120,6 +120,22 @@
 
     <string name="advanced">고급</string>
     <string name="summary_preference_settings_advanced">더 많은 고급 설정 살펴보기</string>
+    <string name="issue_title_label">제목</string>
+    <string name="issue_description_label">설명</string>
+    <string name="issue_section_label">문제</string>
+    <string name="login_section_label">로그인</string>
+    <string name="use_github_account">GitHub 계정으로 보내기</string>
+    <string name="send_anonymously">익명으로 보내기</string>
+    <string name="optional_placeholder">(선택 사항)</string>
+    <string name="issue_username_label">사용자 이름</string>
+    <string name="issue_password_label">비밀번호</string>
+    <string name="issue_email_label">이메일</string>
+    <string name="issue_send">보내기</string>
+    <string name="cd_expand_device_info">디바이스 정보를 확장하거나 접기</string>
+    <string name="view_on_github">GitHub로 리디렉션</string>
+    <string name="snack_report_success">보고서가 성공적으로 전송되었습니다</string>
+    <string name="snack_report_failed">보고서 전송 실패</string>
+    <string name="error_invalid_report">제목과 설명은 비워 둘 수 없습니다</string>
 
     <string name="error_reporting">오류 보고</string>
     <string name="bug_report">버그 신고</string>

--- a/apptoolkit/src/main/res/values-pl-rPL/strings.xml
+++ b/apptoolkit/src/main/res/values-pl-rPL/strings.xml
@@ -120,6 +120,22 @@
 
     <string name="advanced">Zaawansowane</string>
     <string name="summary_preference_settings_advanced">Odkryj więcej zaawansowanych ustawień</string>
+    <string name="issue_title_label">Tytuł</string>
+    <string name="issue_description_label">Opis</string>
+    <string name="issue_section_label">Zgłoszenie</string>
+    <string name="login_section_label">Logowanie</string>
+    <string name="use_github_account">Wyślij za pomocą konta GitHub</string>
+    <string name="send_anonymously">Wyślij anonimowo</string>
+    <string name="optional_placeholder">(Opcjonalnie)</string>
+    <string name="issue_username_label">Nazwa użytkownika</string>
+    <string name="issue_password_label">Hasło</string>
+    <string name="issue_email_label">Email</string>
+    <string name="issue_send">Wyślij</string>
+    <string name="cd_expand_device_info">Rozwiń lub zwiń informacje o urządzeniu</string>
+    <string name="view_on_github">Przekieruj do GitHub</string>
+    <string name="snack_report_success">Zgłoszenie wysłane pomyślnie</string>
+    <string name="snack_report_failed">Nie udało się wysłać zgłoszenia</string>
+    <string name="error_invalid_report">Tytuł i opis nie mogą być puste</string>
 
     <string name="error_reporting">Zgłaszanie błędów</string>
     <string name="bug_report">Raport o błędzie</string>

--- a/apptoolkit/src/main/res/values-pt-rBR/strings.xml
+++ b/apptoolkit/src/main/res/values-pt-rBR/strings.xml
@@ -120,6 +120,22 @@
 
     <string name="advanced">Avançado</string>
     <string name="summary_preference_settings_advanced">Explore mais configurações avançadas</string>
+    <string name="issue_title_label">Título</string>
+    <string name="issue_description_label">Descrição</string>
+    <string name="issue_section_label">Problema</string>
+    <string name="login_section_label">Login</string>
+    <string name="use_github_account">Enviar usando a conta do GitHub</string>
+    <string name="send_anonymously">Enviar anonimamente</string>
+    <string name="optional_placeholder">(Opcional)</string>
+    <string name="issue_username_label">Nome de usuário</string>
+    <string name="issue_password_label">Senha</string>
+    <string name="issue_email_label">E-mail</string>
+    <string name="issue_send">Enviar</string>
+    <string name="cd_expand_device_info">Expandir ou recolher informações do dispositivo</string>
+    <string name="view_on_github">Redirecionar para o GitHub</string>
+    <string name="snack_report_success">Relatório enviado com sucesso</string>
+    <string name="snack_report_failed">Falha ao enviar relatório</string>
+    <string name="error_invalid_report">O título e a descrição não podem estar vazios</string>
 
     <string name="error_reporting">Relatar erros</string>
     <string name="bug_report">Relatar bug</string>

--- a/apptoolkit/src/main/res/values-ro-rRO/strings.xml
+++ b/apptoolkit/src/main/res/values-ro-rRO/strings.xml
@@ -120,6 +120,22 @@
 
     <string name="advanced">Avansat</string>
     <string name="summary_preference_settings_advanced">Explorează mai multe setări avansate</string>
+    <string name="issue_title_label">Titlu</string>
+    <string name="issue_description_label">Descriere</string>
+    <string name="issue_section_label">Problemă</string>
+    <string name="login_section_label">Autentificare</string>
+    <string name="use_github_account">Trimite folosind contul GitHub</string>
+    <string name="send_anonymously">Trimite anonim</string>
+    <string name="optional_placeholder">(Opțional)</string>
+    <string name="issue_username_label">Nume de utilizator</string>
+    <string name="issue_password_label">Parolă</string>
+    <string name="issue_email_label">Email</string>
+    <string name="issue_send">Trimite</string>
+    <string name="cd_expand_device_info">Extinde sau restrânge informațiile dispozitivului</string>
+    <string name="view_on_github">Redirecționează către GitHub</string>
+    <string name="snack_report_success">Raport trimis cu succes</string>
+    <string name="snack_report_failed">Trimiterea raportului a eșuat</string>
+    <string name="error_invalid_report">Titlul și descrierea nu pot fi goale</string>
 
     <string name="error_reporting">Raportare erori</string>
     <string name="bug_report">Raportare bug</string>

--- a/apptoolkit/src/main/res/values-ru-rRU/strings.xml
+++ b/apptoolkit/src/main/res/values-ru-rRU/strings.xml
@@ -120,6 +120,22 @@
 
     <string name="advanced">Дополнительно</string>
     <string name="summary_preference_settings_advanced">Изучите дополнительные настройки</string>
+    <string name="issue_title_label">Заголовок</string>
+    <string name="issue_description_label">Описание</string>
+    <string name="issue_section_label">Проблема</string>
+    <string name="login_section_label">Войти</string>
+    <string name="use_github_account">Отправить через аккаунт GitHub</string>
+    <string name="send_anonymously">Отправить анонимно</string>
+    <string name="optional_placeholder">(Необязательно)</string>
+    <string name="issue_username_label">Имя пользователя</string>
+    <string name="issue_password_label">Пароль</string>
+    <string name="issue_email_label">Электронная почта</string>
+    <string name="issue_send">Отправить</string>
+    <string name="cd_expand_device_info">Развернуть или свернуть информацию об устройстве</string>
+    <string name="view_on_github">Перейти на GitHub</string>
+    <string name="snack_report_success">Отчет успешно отправлен</string>
+    <string name="snack_report_failed">Не удалось отправить отчет</string>
+    <string name="error_invalid_report">Заголовок и описание не могут быть пустыми</string>
 
     <string name="error_reporting">Отчёт об ошибках</string>
     <string name="bug_report">Отчёт о баге</string>

--- a/apptoolkit/src/main/res/values-sv-rSE/strings.xml
+++ b/apptoolkit/src/main/res/values-sv-rSE/strings.xml
@@ -120,6 +120,22 @@
 
     <string name="advanced">Avancerat</string>
     <string name="summary_preference_settings_advanced">Utforska mer avancerade inställningar</string>
+    <string name="issue_title_label">Titel</string>
+    <string name="issue_description_label">Beskrivning</string>
+    <string name="issue_section_label">Problem</string>
+    <string name="login_section_label">Logga in</string>
+    <string name="use_github_account">Skicka med GitHub-konto</string>
+    <string name="send_anonymously">Skicka anonymt</string>
+    <string name="optional_placeholder">(Valfritt)</string>
+    <string name="issue_username_label">Användarnamn</string>
+    <string name="issue_password_label">Lösenord</string>
+    <string name="issue_email_label">E-post</string>
+    <string name="issue_send">Skicka</string>
+    <string name="cd_expand_device_info">Expandera eller fäll ihop enhetsinformation</string>
+    <string name="view_on_github">Omdirigera till GitHub</string>
+    <string name="snack_report_success">Rapporten skickades</string>
+    <string name="snack_report_failed">Det gick inte att skicka rapporten</string>
+    <string name="error_invalid_report">Titel och beskrivning får inte vara tomma</string>
 
     <string name="error_reporting">Felrapportering</string>
     <string name="bug_report">Felrapport</string>

--- a/apptoolkit/src/main/res/values-th-rTH/strings.xml
+++ b/apptoolkit/src/main/res/values-th-rTH/strings.xml
@@ -120,6 +120,22 @@
 
     <string name="advanced">ขั้นสูง</string>
     <string name="summary_preference_settings_advanced">สำรวจการตั้งค่าขั้นสูงเพิ่มเติม</string>
+    <string name="issue_title_label">ชื่อเรื่อง</string>
+    <string name="issue_description_label">คำอธิบาย</string>
+    <string name="issue_section_label">ปัญหา</string>
+    <string name="login_section_label">เข้าสู่ระบบ</string>
+    <string name="use_github_account">ส่งโดยใช้บัญชี GitHub</string>
+    <string name="send_anonymously">ส่งแบบไม่ระบุตัวตน</string>
+    <string name="optional_placeholder">(ไม่บังคับ)</string>
+    <string name="issue_username_label">ชื่อผู้ใช้</string>
+    <string name="issue_password_label">รหัสผ่าน</string>
+    <string name="issue_email_label">อีเมล</string>
+    <string name="issue_send">ส่ง</string>
+    <string name="cd_expand_device_info">ขยายหรือลดข้อมูลอุปกรณ์</string>
+    <string name="view_on_github">เปลี่ยนเส้นทางไปยัง GitHub</string>
+    <string name="snack_report_success">ส่งรายงานสำเร็จ</string>
+    <string name="snack_report_failed">ส่งรายงานไม่สำเร็จ</string>
+    <string name="error_invalid_report">หัวเรื่องและคำอธิบายต้องไม่ว่างเปล่า</string>
 
     <string name="error_reporting">การรายงานข้อผิดพลาด</string>
     <string name="bug_report">รายงานข้อผิดพลาด</string>

--- a/apptoolkit/src/main/res/values-tr-rTR/strings.xml
+++ b/apptoolkit/src/main/res/values-tr-rTR/strings.xml
@@ -120,6 +120,22 @@
 
     <string name="advanced">Gelişmiş</string>
     <string name="summary_preference_settings_advanced">Daha gelişmiş ayarları keşfedin</string>
+    <string name="issue_title_label">Başlık</string>
+    <string name="issue_description_label">Açıklama</string>
+    <string name="issue_section_label">Sorun</string>
+    <string name="login_section_label">Giriş yap</string>
+    <string name="use_github_account">GitHub hesabıyla gönder</string>
+    <string name="send_anonymously">Anonim gönder</string>
+    <string name="optional_placeholder">(İsteğe bağlı)</string>
+    <string name="issue_username_label">Kullanıcı adı</string>
+    <string name="issue_password_label">Şifre</string>
+    <string name="issue_email_label">E-posta</string>
+    <string name="issue_send">Gönder</string>
+    <string name="cd_expand_device_info">Cihaz bilgisini genişlet veya daralt</string>
+    <string name="view_on_github">GitHub'a yönlendir</string>
+    <string name="snack_report_success">Rapor başarıyla gönderildi</string>
+    <string name="snack_report_failed">Rapor gönderilemedi</string>
+    <string name="error_invalid_report">Başlık ve açıklama boş olamaz</string>
 
     <string name="error_reporting">Hata raporlama</string>
     <string name="bug_report">Hata raporu</string>

--- a/apptoolkit/src/main/res/values-uk-rUA/strings.xml
+++ b/apptoolkit/src/main/res/values-uk-rUA/strings.xml
@@ -120,6 +120,22 @@
 
     <string name="advanced">Додаткові налаштування</string>
     <string name="summary_preference_settings_advanced">Досліджуйте більше розширених налаштувань</string>
+    <string name="issue_title_label">Заголовок</string>
+    <string name="issue_description_label">Опис</string>
+    <string name="issue_section_label">Проблема</string>
+    <string name="login_section_label">Увійти</string>
+    <string name="use_github_account">Надіслати через обліковий запис GitHub</string>
+    <string name="send_anonymously">Надіслати анонімно</string>
+    <string name="optional_placeholder">(Необов'язково)</string>
+    <string name="issue_username_label">Ім'я користувача</string>
+    <string name="issue_password_label">Пароль</string>
+    <string name="issue_email_label">Електронна пошта</string>
+    <string name="issue_send">Надіслати</string>
+    <string name="cd_expand_device_info">Розгорнути або згорнути інформацію про пристрій</string>
+    <string name="view_on_github">Перенаправити на GitHub</string>
+    <string name="snack_report_success">Звіт успішно надіслано</string>
+    <string name="snack_report_failed">Не вдалося надіслати звіт</string>
+    <string name="error_invalid_report">Заголовок і опис не можуть бути порожніми</string>
 
     <string name="error_reporting">Звіт про помилки</string>
     <string name="bug_report">Звіт про помилку</string>

--- a/apptoolkit/src/main/res/values-ur-rPK/strings.xml
+++ b/apptoolkit/src/main/res/values-ur-rPK/strings.xml
@@ -120,6 +120,22 @@
 
     <string name="advanced">جدید</string>
     <string name="summary_preference_settings_advanced">مزید جدید ترتیبات دریافت کریں</string>
+    <string name="issue_title_label">عنوان</string>
+    <string name="issue_description_label">تفصیل</string>
+    <string name="issue_section_label">مسئلہ</string>
+    <string name="login_section_label">لاگ ان</string>
+    <string name="use_github_account">GitHub اکاؤنٹ استعمال کرکے بھیجیں</string>
+    <string name="send_anonymously">گمنام بھیجیں</string>
+    <string name="optional_placeholder">(اختیاری)</string>
+    <string name="issue_username_label">صارف نام</string>
+    <string name="issue_password_label">پاس ورڈ</string>
+    <string name="issue_email_label">ای میل</string>
+    <string name="issue_send">بھیجیں</string>
+    <string name="cd_expand_device_info">آلہ کی معلومات کو پھیلائیں یا سمیٹیں</string>
+    <string name="view_on_github">GitHub پر ری ڈائریکٹ کریں</string>
+    <string name="snack_report_success">رپورٹ کامیابی سے بھیج دی گئی</string>
+    <string name="snack_report_failed">رپورٹ بھیجنے میں ناکام</string>
+    <string name="error_invalid_report">عنوان اور تفصیل خالی نہیں ہوسکتے</string>
 
     <string name="error_reporting">خرابی کی اطلاع دینا</string>
     <string name="bug_report">بگ رپورٹ</string>

--- a/apptoolkit/src/main/res/values-vi-rVN/strings.xml
+++ b/apptoolkit/src/main/res/values-vi-rVN/strings.xml
@@ -120,6 +120,22 @@
 
     <string name="advanced">Nâng cao</string>
     <string name="summary_preference_settings_advanced">Khám phá thêm các cài đặt nâng cao</string>
+    <string name="issue_title_label">Tiêu đề</string>
+    <string name="issue_description_label">Mô tả</string>
+    <string name="issue_section_label">Vấn đề</string>
+    <string name="login_section_label">Đăng nhập</string>
+    <string name="use_github_account">Gửi bằng tài khoản GitHub</string>
+    <string name="send_anonymously">Gửi ẩn danh</string>
+    <string name="optional_placeholder">(Tùy chọn)</string>
+    <string name="issue_username_label">Tên người dùng</string>
+    <string name="issue_password_label">Mật khẩu</string>
+    <string name="issue_email_label">Email</string>
+    <string name="issue_send">Gửi</string>
+    <string name="cd_expand_device_info">Mở rộng hoặc thu gọn thông tin thiết bị</string>
+    <string name="view_on_github">Chuyển hướng tới GitHub</string>
+    <string name="snack_report_success">Báo cáo đã được gửi thành công</string>
+    <string name="snack_report_failed">Gửi báo cáo thất bại</string>
+    <string name="error_invalid_report">Tiêu đề và mô tả không được để trống</string>
 
     <string name="error_reporting">Báo cáo lỗi</string>
     <string name="bug_report">Báo cáo lỗi</string>

--- a/apptoolkit/src/main/res/values-zh-rTW/strings.xml
+++ b/apptoolkit/src/main/res/values-zh-rTW/strings.xml
@@ -120,6 +120,22 @@
 
     <string name="advanced">進階</string>
     <string name="summary_preference_settings_advanced">探索更多進階設定</string>
+    <string name="issue_title_label">標題</string>
+    <string name="issue_description_label">描述</string>
+    <string name="issue_section_label">問題</string>
+    <string name="login_section_label">登入</string>
+    <string name="use_github_account">使用 GitHub 帳戶傳送</string>
+    <string name="send_anonymously">匿名傳送</string>
+    <string name="optional_placeholder">(可選)</string>
+    <string name="issue_username_label">使用者名稱</string>
+    <string name="issue_password_label">密碼</string>
+    <string name="issue_email_label">電子郵件</string>
+    <string name="issue_send">傳送</string>
+    <string name="cd_expand_device_info">展開或收合裝置資訊</string>
+    <string name="view_on_github">重新導向到 GitHub</string>
+    <string name="snack_report_success">報告已成功送出</string>
+    <string name="snack_report_failed">無法傳送報告</string>
+    <string name="error_invalid_report">標題和描述不能為空</string>
 
     <string name="error_reporting">錯誤回報</string>
     <string name="bug_report">錯誤回報</string>


### PR DESCRIPTION
## Summary
- add localized Issue Reporter strings for many languages

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684fdc7ba2a8832da274aa7e63b2a01e