### PR TITLE
Fix serialization for CreateIssueRequest

### DIFF
--- a/apptoolkit/build.gradle.kts
+++ b/apptoolkit/build.gradle.kts
@@ -3,6 +3,7 @@ plugins {
     alias(notation = libs.plugins.kotlin.android)
     alias(notation = libs.plugins.compose.compiler)
     alias(notation = libs.plugins.about.libraries)
+    alias(notation = libs.plugins.kotlin.serialization)
     `maven-publish`
 }
 


### PR DESCRIPTION
## Summary
- apply kotlinx-serialization Gradle plugin to the library module

## Testing
- `./gradlew build -x test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_684fdd9e4540832d8c16c231b6a39700