### PR TITLE
Translate new issue strings

### DIFF
--- a/apptoolkit/src/main/res/values-ar-rEG/strings.xml
+++ b/apptoolkit/src/main/res/values-ar-rEG/strings.xml
@@ -136,6 +136,14 @@
     <string name="snack_report_success">تم إرسال التقرير بنجاح</string>
     <string name="snack_report_failed">فشل في إرسال التقرير</string>
     <string name="error_invalid_report">لا يمكن أن يكون العنوان والوصف فارغين</string>
+    <string name="issue_submitted_successfully">تم تقديم القضية بنجاح</string>
+    <string name="open_issue_in_browser">مفتوح في المتصفح</string>
+    <string name="open_button_label">قضية مفتوحة</string>
+    <string name="issue_submitted">تم تقديم مشكلتك!</string>
+    <string name="error_unauthorized">غير مصرح به: رمز غير صالح</string>
+    <string name="error_forbidden">ممنوع: أذونات غير كافية</string>
+    <string name="error_gone">أزياء نقطة نهاية API</string>
+    <string name="error_unprocessable">بيانات غير صالحة لإنشاء المشكلات</string>
 
     <string name="error_reporting">الإبلاغ عن الأخطاء</string>
     <string name="bug_report">تقرير خطأ</string>

--- a/apptoolkit/src/main/res/values-bg-rBG/strings.xml
+++ b/apptoolkit/src/main/res/values-bg-rBG/strings.xml
@@ -136,6 +136,14 @@
     <string name="snack_report_success">Докладът е изпратен успешно</string>
     <string name="snack_report_failed">Неуспешно изпращане на доклада</string>
     <string name="error_invalid_report">Заглавието и описанието не могат да бъдат празни</string>
+    <string name="issue_submitted_successfully">Емисия, изпратена успешно</string>
+    <string name="open_issue_in_browser">Отворен в браузъра</string>
+    <string name="open_button_label">Отворен брой</string>
+    <string name="issue_submitted">Проблемът ви беше изпратен!</string>
+    <string name="error_unauthorized">Неправомерен: Невалиден жетон</string>
+    <string name="error_forbidden">Забранено: Недостатъчни разрешения</string>
+    <string name="error_gone">API крайната точка е отстранена</string>
+    <string name="error_unprocessable">Невалидни данни за създаване на издания</string>
 
     <string name="error_reporting">Докладване на грешки</string>
     <string name="bug_report">Доклад за грешка</string>

--- a/apptoolkit/src/main/res/values-bn-rBD/strings.xml
+++ b/apptoolkit/src/main/res/values-bn-rBD/strings.xml
@@ -136,6 +136,14 @@
     <string name="snack_report_success">রিপোর্ট সফলভাবে পাঠানো হয়েছে</string>
     <string name="snack_report_failed">রিপোর্ট পাঠাতে ব্যর্থ হয়েছে</string>
     <string name="error_invalid_report">শিরোনাম ও বর্ণনা খালি হতে পারে না</string>
+    <string name="issue_submitted_successfully">ইস্যু সফলভাবে জমা দেওয়া</string>
+    <string name="open_issue_in_browser">ব্রাউজারে খুলুন</string>
+    <string name="open_button_label">খোলা সমস্যা</string>
+    <string name="issue_submitted">আপনার সমস্যা জমা দেওয়া হয়েছিল!</string>
+    <string name="error_unauthorized">অননুমোদিত: অবৈধ টোকেন</string>
+    <string name="error_forbidden">নিষিদ্ধ: অপর্যাপ্ত অনুমতি</string>
+    <string name="error_gone">এপিআই শেষ পয়েন্ট সরানো হয়েছে</string>
+    <string name="error_unprocessable">ইস্যু তৈরির জন্য অবৈধ ডেটা</string>
 
     <string name="error_reporting">ত্রুটি প্রতিবেদন</string>
     <string name="bug_report">বাগ রিপোর্ট</string>

--- a/apptoolkit/src/main/res/values-de-rDE/strings.xml
+++ b/apptoolkit/src/main/res/values-de-rDE/strings.xml
@@ -136,6 +136,14 @@
     <string name="snack_report_success">Bericht erfolgreich gesendet</string>
     <string name="snack_report_failed">Senden des Berichts fehlgeschlagen</string>
     <string name="error_invalid_report">Titel und Beschreibung dürfen nicht leer sein</string>
+    <string name="issue_submitted_successfully">Ausgabe erfolgreich eingereicht</string>
+    <string name="open_issue_in_browser">Im Browser geöffnet</string>
+    <string name="open_button_label">Offene Ausgabe</string>
+    <string name="issue_submitted">Ihr Problem wurde eingereicht!</string>
+    <string name="error_unauthorized">Nicht autorisiert: Ungültiges Token</string>
+    <string name="error_forbidden">Verboten: unzureichende Berechtigungen</string>
+    <string name="error_gone">API -Endpunkt entfernt</string>
+    <string name="error_unprocessable">Ungültige Daten zur Erstellung von Problemen</string>
 
     <string name="error_reporting">Fehlerberichte</string>
     <string name="bug_report">Fehlerbericht</string>

--- a/apptoolkit/src/main/res/values-es-rGQ/strings.xml
+++ b/apptoolkit/src/main/res/values-es-rGQ/strings.xml
@@ -136,6 +136,14 @@
     <string name="snack_report_success">Informe enviado correctamente</string>
     <string name="snack_report_failed">Error al enviar el informe</string>
     <string name="error_invalid_report">El título y la descripción no pueden estar vacíos</string>
+    <string name="issue_submitted_successfully">Problema enviado con éxito</string>
+    <string name="open_issue_in_browser">Abrir en el navegador</string>
+    <string name="open_button_label">Problema abierto</string>
+    <string name="issue_submitted">¡Su problema fue enviado!</string>
+    <string name="error_unauthorized">Unauthorized: Invalid token</string>
+    <string name="error_forbidden">Prohibido: permisos insuficientes</string>
+    <string name="error_gone">Punto final de la API eliminado</string>
+    <string name="error_unprocessable">Datos no válidos para la creación de problemas</string>
 
     <string name="error_reporting">Informe de errores</string>
     <string name="bug_report">Informe de fallos</string>

--- a/apptoolkit/src/main/res/values-es-rMX/strings.xml
+++ b/apptoolkit/src/main/res/values-es-rMX/strings.xml
@@ -136,6 +136,14 @@
     <string name="snack_report_success">Informe enviado correctamente</string>
     <string name="snack_report_failed">Error al enviar el informe</string>
     <string name="error_invalid_report">El título y la descripción no pueden estar vacíos</string>
+    <string name="issue_submitted_successfully">Problema enviado con éxito</string>
+    <string name="open_issue_in_browser">Abrir en el navegador</string>
+    <string name="open_button_label">Problema abierto</string>
+    <string name="issue_submitted">¡Su problema fue enviado!</string>
+    <string name="error_unauthorized">Unauthorized: Invalid token</string>
+    <string name="error_forbidden">Prohibido: permisos insuficientes</string>
+    <string name="error_gone">Punto final de la API eliminado</string>
+    <string name="error_unprocessable">Datos no válidos para la creación de problemas</string>
 
     <string name="error_reporting">Informe de errores</string>
     <string name="bug_report">Informe de error</string>

--- a/apptoolkit/src/main/res/values-fil-rPH/strings.xml
+++ b/apptoolkit/src/main/res/values-fil-rPH/strings.xml
@@ -136,6 +136,14 @@
     <string name="snack_report_success">Matagumpay na naipadala ang ulat</string>
     <string name="snack_report_failed">Nabigo ang pagpapadala ng ulat</string>
     <string name="error_invalid_report">Hindi maaaring walang laman ang pamagat at paglalarawan</string>
+    <string name="issue_submitted_successfully">Matagumpay na isinumite ang isyu</string>
+    <string name="open_issue_in_browser">Buksan sa browser</string>
+    <string name="open_button_label">Bukas na isyu</string>
+    <string name="issue_submitted">Isinumite ang iyong isyu!</string>
+    <string name="error_unauthorized">Hindi awtorisado: Di -wastong token</string>
+    <string name="error_forbidden">Ipinagbabawal: Hindi sapat na pahintulot</string>
+    <string name="error_gone">Inalis ang endpoint ng API</string>
+    <string name="error_unprocessable">Di -wastong data para sa paglikha ng isyu</string>
 
     <string name="error_reporting">Pag-uulat ng error</string>
     <string name="bug_report">Ulat ng bug</string>

--- a/apptoolkit/src/main/res/values-fr-rFR/strings.xml
+++ b/apptoolkit/src/main/res/values-fr-rFR/strings.xml
@@ -136,6 +136,14 @@
     <string name="snack_report_success">Rapport envoyé avec succès</string>
     <string name="snack_report_failed">Échec de l\'envoi du rapport</string>
     <string name="error_invalid_report">Le titre et la description ne peuvent pas être vides</string>
+    <string name="issue_submitted_successfully">Numéro soumis avec succès</string>
+    <string name="open_issue_in_browser">Ouvert dans le navigateur</string>
+    <string name="open_button_label">Problème d'ouverture</string>
+    <string name="issue_submitted">Votre problème a été soumis!</string>
+    <string name="error_unauthorized">Non autorisé: jeton non valide</string>
+    <string name="error_forbidden">Interdit: autorisation insuffisante</string>
+    <string name="error_gone">Point de terminaison API supprimé</string>
+    <string name="error_unprocessable">Données non valides pour la création de problèmes</string>
 
     <string name="error_reporting">Rapport d\'erreurs</string>
     <string name="bug_report">Rapport de bug</string>

--- a/apptoolkit/src/main/res/values-hi-rIN/strings.xml
+++ b/apptoolkit/src/main/res/values-hi-rIN/strings.xml
@@ -136,6 +136,14 @@
     <string name="snack_report_success">रिपोर्ट सफलतापूर्वक भेजी गई</string>
     <string name="snack_report_failed">रिपोर्ट भेजने में विफल</string>
     <string name="error_invalid_report">शीर्षक और विवरण खाली नहीं हो सकते</string>
+    <string name="issue_submitted_successfully">मुद्दा सफलतापूर्वक प्रस्तुत किया गया</string>
+    <string name="open_issue_in_browser">ब्राउज़र में खोलें</string>
+    <string name="open_button_label">मुद्दा खोलें</string>
+    <string name="issue_submitted">आपका मुद्दा प्रस्तुत किया गया था!</string>
+    <string name="error_unauthorized">अनधिकृत: अमान्य टोकन</string>
+    <string name="error_forbidden">निषिद्ध: अपर्याप्त अनुमतियाँ</string>
+    <string name="error_gone">एपीआई समापन बिंदु हटा दिया गया</string>
+    <string name="error_unprocessable">मुद्दा निर्माण के लिए अमान्य डेटा</string>
 
     <string name="error_reporting">त्रुटि रिपोर्टिंग</string>
     <string name="bug_report">बग रिपोर्ट</string>

--- a/apptoolkit/src/main/res/values-hu-rHU/strings.xml
+++ b/apptoolkit/src/main/res/values-hu-rHU/strings.xml
@@ -136,6 +136,14 @@
     <string name="snack_report_success">A jelentés sikeresen elküldve</string>
     <string name="snack_report_failed">A jelentés elküldése nem sikerült</string>
     <string name="error_invalid_report">A cím és a leírás nem lehet üres</string>
+    <string name="issue_submitted_successfully">A kiadás sikeresen benyújtva</string>
+    <string name="open_issue_in_browser">Nyissa meg a böngészőben</string>
+    <string name="open_button_label">Nyitott kérdés</string>
+    <string name="issue_submitted">A kérdését benyújtották!</string>
+    <string name="error_unauthorized">Jogosulatlan: Érvénytelen token</string>
+    <string name="error_forbidden">Tiltott: Nem elegendő engedély</string>
+    <string name="error_gone">Az API végpontja eltávolítva</string>
+    <string name="error_unprocessable">Érvénytelen adatok a kiadás létrehozásához</string>
 
     <string name="error_reporting">Hibajelentés</string>
     <string name="bug_report">Hibajelentés</string>

--- a/apptoolkit/src/main/res/values-in-rID/strings.xml
+++ b/apptoolkit/src/main/res/values-in-rID/strings.xml
@@ -136,6 +136,14 @@
     <string name="snack_report_success">Laporan berhasil dikirim</string>
     <string name="snack_report_failed">Gagal mengirim laporan</string>
     <string name="error_invalid_report">Judul dan deskripsi tidak boleh kosong</string>
+    <string name="issue_submitted_successfully">Masalah yang berhasil diserahkan</string>
+    <string name="open_issue_in_browser">Buka di browser</string>
+    <string name="open_button_label">Masalah terbuka</string>
+    <string name="issue_submitted">Masalah Anda telah diajukan!</string>
+    <string name="error_unauthorized">Tidak sah: token tidak valid</string>
+    <string name="error_forbidden">Terlarang: Izin yang tidak mencukupi</string>
+    <string name="error_gone">Titik akhir API dihapus</string>
+    <string name="error_unprocessable">Data tidak valid untuk pembuatan masalah</string>
 
     <string name="error_reporting">Pelaporan kesalahan</string>
     <string name="bug_report">Laporan bug</string>

--- a/apptoolkit/src/main/res/values-it-rIT/strings.xml
+++ b/apptoolkit/src/main/res/values-it-rIT/strings.xml
@@ -136,6 +136,14 @@
     <string name="snack_report_success">Segnalazione inviata con successo</string>
     <string name="snack_report_failed">Invio della segnalazione non riuscito</string>
     <string name="error_invalid_report">Titolo e descrizione non possono essere vuoti</string>
+    <string name="issue_submitted_successfully">Emissione presentata con successo</string>
+    <string name="open_issue_in_browser">Aprire nel browser</string>
+    <string name="open_button_label">Problema aperto</string>
+    <string name="issue_submitted">Il tuo problema è stato inviato!</string>
+    <string name="error_unauthorized">Non autorizzato: token non valido</string>
+    <string name="error_forbidden">Proibito: autorizzazioni insufficienti</string>
+    <string name="error_gone">Endpoint API rimosso</string>
+    <string name="error_unprocessable">Dati non validi per la creazione di problemi</string>
 
     <string name="error_reporting">Segnalazione errori</string>
     <string name="bug_report">Segnalazione bug</string>

--- a/apptoolkit/src/main/res/values-ja-rJP/strings.xml
+++ b/apptoolkit/src/main/res/values-ja-rJP/strings.xml
@@ -136,6 +136,14 @@
     <string name="snack_report_success">レポートが送信されました</string>
     <string name="snack_report_failed">レポートの送信に失敗しました</string>
     <string name="error_invalid_report">タイトルと説明は空にできません</string>
+    <string name="issue_submitted_successfully">問題が正常に提出されました</string>
+    <string name="open_issue_in_browser">ブラウザで開きます</string>
+    <string name="open_button_label">開かれた問題</string>
+    <string name="issue_submitted">あなたの問題が提出されました！</string>
+    <string name="error_unauthorized">不正：無効なトークン</string>
+    <string name="error_forbidden">禁止：不十分な権限</string>
+    <string name="error_gone">APIエンドポイントが削除されました</string>
+    <string name="error_unprocessable">問題作成のための無効なデータ</string>
 
     <string name="error_reporting">エラー報告</string>
     <string name="bug_report">バグ報告</string>

--- a/apptoolkit/src/main/res/values-ko-rKR/strings.xml
+++ b/apptoolkit/src/main/res/values-ko-rKR/strings.xml
@@ -136,6 +136,14 @@
     <string name="snack_report_success">보고서가 성공적으로 전송되었습니다</string>
     <string name="snack_report_failed">보고서 전송 실패</string>
     <string name="error_invalid_report">제목과 설명은 비워 둘 수 없습니다</string>
+    <string name="issue_submitted_successfully">문제가 성공적으로 제출되었습니다</string>
+    <string name="open_issue_in_browser">브라우저에서 열립니다</string>
+    <string name="open_button_label">열린 문제</string>
+    <string name="issue_submitted">귀하의 문제가 제출되었습니다!</string>
+    <string name="error_unauthorized">무단 : 유효하지 않은 토큰</string>
+    <string name="error_forbidden">금지 : 불충분 한 권한</string>
+    <string name="error_gone">API 엔드 포인트가 제거되었습니다</string>
+    <string name="error_unprocessable">이슈 생성을위한 잘못된 데이터</string>
 
     <string name="error_reporting">오류 보고</string>
     <string name="bug_report">버그 신고</string>

--- a/apptoolkit/src/main/res/values-pl-rPL/strings.xml
+++ b/apptoolkit/src/main/res/values-pl-rPL/strings.xml
@@ -136,6 +136,14 @@
     <string name="snack_report_success">Zgłoszenie wysłane pomyślnie</string>
     <string name="snack_report_failed">Nie udało się wysłać zgłoszenia</string>
     <string name="error_invalid_report">Tytuł i opis nie mogą być puste</string>
+    <string name="issue_submitted_successfully">Problem złożony pomyślnie</string>
+    <string name="open_issue_in_browser">Otwarte w przeglądarce</string>
+    <string name="open_button_label">Problem otwarty</string>
+    <string name="issue_submitted">Twój problem został przesłany!</string>
+    <string name="error_unauthorized">Nieautoryzowany: Nieprawidłowy token</string>
+    <string name="error_forbidden">Zakazane: niewystarczające uprawnienia</string>
+    <string name="error_gone">Usunięty punkt końcowy API</string>
+    <string name="error_unprocessable">Nieprawidłowe dane dotyczące tworzenia problemów</string>
 
     <string name="error_reporting">Zgłaszanie błędów</string>
     <string name="bug_report">Raport o błędzie</string>

--- a/apptoolkit/src/main/res/values-pt-rBR/strings.xml
+++ b/apptoolkit/src/main/res/values-pt-rBR/strings.xml
@@ -136,6 +136,14 @@
     <string name="snack_report_success">Relatório enviado com sucesso</string>
     <string name="snack_report_failed">Falha ao enviar relatório</string>
     <string name="error_invalid_report">O título e a descrição não podem estar vazios</string>
+    <string name="issue_submitted_successfully">Edição enviada com sucesso</string>
+    <string name="open_issue_in_browser">Aberto no navegador</string>
+    <string name="open_button_label">Emissão aberta</string>
+    <string name="issue_submitted">Seu problema foi enviado!</string>
+    <string name="error_unauthorized">Não autorizado: Token inválido</string>
+    <string name="error_forbidden">Proibido: permissões insuficientes</string>
+    <string name="error_gone">Ponto de extremidade da API removido</string>
+    <string name="error_unprocessable">Dados inválidos para criação de problemas</string>
 
     <string name="error_reporting">Relatar erros</string>
     <string name="bug_report">Relatar bug</string>

--- a/apptoolkit/src/main/res/values-ro-rRO/strings.xml
+++ b/apptoolkit/src/main/res/values-ro-rRO/strings.xml
@@ -136,6 +136,14 @@
     <string name="snack_report_success">Raport trimis cu succes</string>
     <string name="snack_report_failed">Trimiterea raportului a eșuat</string>
     <string name="error_invalid_report">Titlul și descrierea nu pot fi goale</string>
+    <string name="issue_submitted_successfully">Problema depusă cu succes</string>
+    <string name="open_issue_in_browser">Deschis în browser</string>
+    <string name="open_button_label">Problemă deschisă</string>
+    <string name="issue_submitted">Problema dvs. a fost trimisă!</string>
+    <string name="error_unauthorized">Neautorizat: jeton nevalid</string>
+    <string name="error_forbidden">Interzis: permisiuni insuficiente</string>
+    <string name="error_gone">Punctul final API eliminat</string>
+    <string name="error_unprocessable">Date nevalide pentru crearea problemelor</string>
 
     <string name="error_reporting">Raportare erori</string>
     <string name="bug_report">Raportare bug</string>

--- a/apptoolkit/src/main/res/values-ru-rRU/strings.xml
+++ b/apptoolkit/src/main/res/values-ru-rRU/strings.xml
@@ -136,6 +136,14 @@
     <string name="snack_report_success">Отчет успешно отправлен</string>
     <string name="snack_report_failed">Не удалось отправить отчет</string>
     <string name="error_invalid_report">Заголовок и описание не могут быть пустыми</string>
+    <string name="issue_submitted_successfully">Выпуск успешно</string>
+    <string name="open_issue_in_browser">Открыт в браузере</string>
+    <string name="open_button_label">Открытая проблема</string>
+    <string name="issue_submitted">Ваша проблема была отправлена!</string>
+    <string name="error_unauthorized">Несанкционированный: недействительный токен</string>
+    <string name="error_forbidden">Запрещено: недостаточные разрешения</string>
+    <string name="error_gone">Конечная точка API удалена</string>
+    <string name="error_unprocessable">Неверные данные для создания выпуска</string>
 
     <string name="error_reporting">Отчёт об ошибках</string>
     <string name="bug_report">Отчёт о баге</string>

--- a/apptoolkit/src/main/res/values-sv-rSE/strings.xml
+++ b/apptoolkit/src/main/res/values-sv-rSE/strings.xml
@@ -136,6 +136,14 @@
     <string name="snack_report_success">Rapporten skickades</string>
     <string name="snack_report_failed">Det gick inte att skicka rapporten</string>
     <string name="error_invalid_report">Titel och beskrivning får inte vara tomma</string>
+    <string name="issue_submitted_successfully">Utfärdas framgångsrikt</string>
+    <string name="open_issue_in_browser">Öppet i webbläsaren</string>
+    <string name="open_button_label">Öppen fråga</string>
+    <string name="issue_submitted">Ditt problem lämnades in!</string>
+    <string name="error_unauthorized">Obehörig: Ogiltig token</string>
+    <string name="error_forbidden">Förbjudet: Otillräckliga behörigheter</string>
+    <string name="error_gone">API -slutpunkten borttagen</string>
+    <string name="error_unprocessable">Ogiltiga data för skapande av problem</string>
 
     <string name="error_reporting">Felrapportering</string>
     <string name="bug_report">Felrapport</string>

--- a/apptoolkit/src/main/res/values-th-rTH/strings.xml
+++ b/apptoolkit/src/main/res/values-th-rTH/strings.xml
@@ -136,6 +136,14 @@
     <string name="snack_report_success">ส่งรายงานสำเร็จ</string>
     <string name="snack_report_failed">ส่งรายงานไม่สำเร็จ</string>
     <string name="error_invalid_report">หัวเรื่องและคำอธิบายต้องไม่ว่างเปล่า</string>
+    <string name="issue_submitted_successfully">ปัญหาส่งสำเร็จ</string>
+    <string name="open_issue_in_browser">เปิดในเบราว์เซอร์</string>
+    <string name="open_button_label">ปัญหาเปิด</string>
+    <string name="issue_submitted">ปัญหาของคุณถูกส่ง!</string>
+    <string name="error_unauthorized">ไม่ได้รับอนุญาต: โทเค็นไม่ถูกต้อง</string>
+    <string name="error_forbidden">ต้องห้าม: การอนุญาตไม่เพียงพอ</string>
+    <string name="error_gone">ลบจุดสิ้นสุด API</string>
+    <string name="error_unprocessable">ข้อมูลที่ไม่ถูกต้องสำหรับการสร้างปัญหา</string>
 
     <string name="error_reporting">การรายงานข้อผิดพลาด</string>
     <string name="bug_report">รายงานข้อผิดพลาด</string>

--- a/apptoolkit/src/main/res/values-tr-rTR/strings.xml
+++ b/apptoolkit/src/main/res/values-tr-rTR/strings.xml
@@ -136,6 +136,14 @@
     <string name="snack_report_success">Rapor başarıyla gönderildi</string>
     <string name="snack_report_failed">Rapor gönderilemedi</string>
     <string name="error_invalid_report">Başlık ve açıklama boş olamaz</string>
+    <string name="issue_submitted_successfully">Başarılı bir şekilde gönderilen sorun</string>
+    <string name="open_issue_in_browser">Tarayıcıda açın</string>
+    <string name="open_button_label">Açık sorun</string>
+    <string name="issue_submitted">Sorununuz gönderildi!</string>
+    <string name="error_unauthorized">Yetkisiz: Geçersiz jeton</string>
+    <string name="error_forbidden">Yasak: Yetersiz izinler</string>
+    <string name="error_gone">API uç noktası kaldırıldı</string>
+    <string name="error_unprocessable">Sorun oluşturma için geçersiz veriler</string>
 
     <string name="error_reporting">Hata raporlama</string>
     <string name="bug_report">Hata raporu</string>

--- a/apptoolkit/src/main/res/values-uk-rUA/strings.xml
+++ b/apptoolkit/src/main/res/values-uk-rUA/strings.xml
@@ -136,6 +136,14 @@
     <string name="snack_report_success">Звіт успішно надіслано</string>
     <string name="snack_report_failed">Не вдалося надіслати звіт</string>
     <string name="error_invalid_report">Заголовок і опис не можуть бути порожніми</string>
+    <string name="issue_submitted_successfully">Проблема подано успішно</string>
+    <string name="open_issue_in_browser">Відкрито в браузері</string>
+    <string name="open_button_label">Відкритий випуск</string>
+    <string name="issue_submitted">Ваше питання було подано!</string>
+    <string name="error_unauthorized">Несанкціонований: Недійсний маркер</string>
+    <string name="error_forbidden">Заборонено: недостатньо дозволів</string>
+    <string name="error_gone">Кінцева точка API видалена</string>
+    <string name="error_unprocessable">Недійсні дані для створення випусків</string>
 
     <string name="error_reporting">Звіт про помилки</string>
     <string name="bug_report">Звіт про помилку</string>

--- a/apptoolkit/src/main/res/values-ur-rPK/strings.xml
+++ b/apptoolkit/src/main/res/values-ur-rPK/strings.xml
@@ -136,6 +136,14 @@
     <string name="snack_report_success">رپورٹ کامیابی سے بھیج دی گئی</string>
     <string name="snack_report_failed">رپورٹ بھیجنے میں ناکام</string>
     <string name="error_invalid_report">عنوان اور تفصیل خالی نہیں ہوسکتے</string>
+    <string name="issue_submitted_successfully">مسئلہ کامیابی کے ساتھ جمع کرایا گیا</string>
+    <string name="open_issue_in_browser">براؤزر میں کھلا</string>
+    <string name="open_button_label">کھلا مسئلہ</string>
+    <string name="issue_submitted">آپ کا مسئلہ پیش کیا گیا تھا!</string>
+    <string name="error_unauthorized">غیر مجاز: غلط ٹوکن</string>
+    <string name="error_forbidden">ممنوع: ناکافی اجازتیں</string>
+    <string name="error_gone">API اختتامی نقطہ ہٹا دیا گیا</string>
+    <string name="error_unprocessable">جاری کرنے کے لئے غلط ڈیٹا</string>
 
     <string name="error_reporting">خرابی کی اطلاع دینا</string>
     <string name="bug_report">بگ رپورٹ</string>

--- a/apptoolkit/src/main/res/values-vi-rVN/strings.xml
+++ b/apptoolkit/src/main/res/values-vi-rVN/strings.xml
@@ -136,6 +136,14 @@
     <string name="snack_report_success">Báo cáo đã được gửi thành công</string>
     <string name="snack_report_failed">Gửi báo cáo thất bại</string>
     <string name="error_invalid_report">Tiêu đề và mô tả không được để trống</string>
+    <string name="issue_submitted_successfully">Vấn đề được gửi thành công</string>
+    <string name="open_issue_in_browser">Mở trong trình duyệt</string>
+    <string name="open_button_label">Vấn đề mở</string>
+    <string name="issue_submitted">Vấn đề của bạn đã được gửi!</string>
+    <string name="error_unauthorized">Nhập học: Mã thông báo không hợp lệ</string>
+    <string name="error_forbidden">Cấm: Không đủ quyền</string>
+    <string name="error_gone">Đã xóa điểm cuối API</string>
+    <string name="error_unprocessable">Dữ liệu không hợp lệ để tạo ra vấn đề</string>
 
     <string name="error_reporting">Báo cáo lỗi</string>
     <string name="bug_report">Báo cáo lỗi</string>

--- a/apptoolkit/src/main/res/values-zh-rTW/strings.xml
+++ b/apptoolkit/src/main/res/values-zh-rTW/strings.xml
@@ -136,6 +136,14 @@
     <string name="snack_report_success">報告已成功送出</string>
     <string name="snack_report_failed">無法傳送報告</string>
     <string name="error_invalid_report">標題和描述不能為空</string>
+    <string name="issue_submitted_successfully">問題成功提交</string>
+    <string name="open_issue_in_browser">在瀏覽器中打開</string>
+    <string name="open_button_label">公開問題</string>
+    <string name="issue_submitted">您的問題已提交！</string>
+    <string name="error_unauthorized">未經授權：無效令牌</string>
+    <string name="error_forbidden">禁止：權限不足</string>
+    <string name="error_gone">刪除了API端點</string>
+    <string name="error_unprocessable">發行創建的無效數據</string>
 
     <string name="error_reporting">錯誤回報</string>
     <string name="bug_report">錯誤回報</string>


### PR DESCRIPTION
## Summary
- translate issue submission strings for all languages

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68507e654c38832d9c8dec1a1355549e