### PR TITLE
Preserve onboarding pager state

### DIFF
--- a/apptoolkit/src/main/AndroidManifest.xml
+++ b/apptoolkit/src/main/AndroidManifest.xml
@@ -16,7 +16,6 @@
 
         <activity
             android:name=".app.oboarding.ui.OnboardingActivity"
-            android:noHistory="true"
             android:windowSoftInputMode="adjustResize" />
 
         <activity

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/OnboardingActivity.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/OnboardingActivity.kt
@@ -33,6 +33,7 @@ class OnboardingActivity : ComponentActivity() {
     override fun onResume() {
         super.onResume()
         checkUserConsent()
+        // Recheck permissions when returning to this activity
     }
 
     private fun checkUserConsent() {

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/OnboardingScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/OnboardingScreen.kt
@@ -43,6 +43,10 @@ import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
+import androidx.lifecycle.viewmodel.compose.viewModel
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
 
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterial3Api::class)
 @Composable
@@ -52,7 +56,13 @@ fun OnboardingScreen() {
     val pages: List<OnboardingPage> =
         remember { onboardingProvider.getOnboardingPages(context = context) }
     val coroutineScope: CoroutineScope = rememberCoroutineScope()
-    val pagerState: PagerState = rememberPagerState { pages.size }
+    val viewModel: OnboardingViewModel = viewModel()
+    val pagerState: PagerState = rememberPagerState(
+        initialPage = viewModel.currentTabIndex,
+    ) { pages.size }
+    LaunchedEffect(pagerState.currentPage) {
+        viewModel.currentTabIndex = pagerState.currentPage
+    }
     val dataStore: CommonDataStore = CommonDataStore.getInstance(context = context)
     val view = LocalView.current
     val onSkipRequested = {

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/OnboardingViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/OnboardingViewModel.kt
@@ -1,0 +1,10 @@
+package com.d4rk.android.libs.apptoolkit.app.oboarding.ui
+
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.ViewModel
+
+class OnboardingViewModel : ViewModel() {
+    var currentTabIndex by mutableStateOf(0)
+}


### PR DESCRIPTION
## Summary
- keep OnboardingActivity alive by removing `noHistory`
- store pager position in new `OnboardingViewModel`
- use the view model when creating pager state
- call `checkUserConsent()` again on activity resume

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68531965dd90832d8c75ea6772c24183