### PR TITLE
Translate new settings strings across locales

### DIFF
--- a/apptoolkit/src/main/res/values-ar-rEG/strings.xml
+++ b/apptoolkit/src/main/res/values-ar-rEG/strings.xml
@@ -101,6 +101,8 @@
     <string name="navigation">التنقل</string>
     <string name="startup_page">صفحة البدء</string>
     <string name="summary_preference_settings_startup_page">اختر الشاشة التي سيتم عرضها عند بدء تشغيل التطبيق.</string>
+    <string name="show_labels_on_bottom_bar">عرض الملصقات على الشريط السفلي</string>
+    <string name="summary_preference_settings_show_labels_on_bottom_bar">عرض عناوين العناصر أدناه الرموز في شريط التنقل السفلي</string>
 
     <string name="language">اللغة</string>
     <string name="summary_preference_settings_language">يغير اللغة المستخدمة في التطبيق</string>

--- a/apptoolkit/src/main/res/values-bg-rBG/strings.xml
+++ b/apptoolkit/src/main/res/values-bg-rBG/strings.xml
@@ -101,6 +101,8 @@
     <string name="navigation">Навигация</string>
     <string name="startup_page">Начална страница</string>
     <string name="summary_preference_settings_startup_page">Изберете екрана, който ще се показва при стартиране на приложението.</string>
+    <string name="show_labels_on_bottom_bar">Показване на етикети на долната лента</string>
+    <string name="summary_preference_settings_show_labels_on_bottom_bar">Показване на заглавия на елемент под иконите в долната навигационна лента</string>
 
     <string name="language">Език</string>
     <string name="summary_preference_settings_language">Променете езика на приложението</string>

--- a/apptoolkit/src/main/res/values-bn-rBD/strings.xml
+++ b/apptoolkit/src/main/res/values-bn-rBD/strings.xml
@@ -101,6 +101,8 @@
     <string name="navigation">নেভিগেশন</string>
     <string name="startup_page">স্টার্টআপ পৃষ্ঠা</string>
     <string name="summary_preference_settings_startup_page">অ্যাপ শুরু হওয়ার সময় প্রদর্শিত স্ক্রিনটি পছন্দ করুন।</string>
+    <string name="show_labels_on_bottom_bar">নীচের বারে লেবেলগুলি দেখান</string>
+    <string name="summary_preference_settings_show_labels_on_bottom_bar">নীচের নেভিগেশন বারে আইকনগুলির নীচে আইটেম শিরোনাম প্রদর্শন করুন</string>
 
     <string name="language">ভাষা</string>
     <string name="summary_preference_settings_language">অ্যাপে ব্যবহৃত ভাষা পরিবর্তন করে</string>

--- a/apptoolkit/src/main/res/values-de-rDE/strings.xml
+++ b/apptoolkit/src/main/res/values-de-rDE/strings.xml
@@ -101,6 +101,8 @@
     <string name="navigation">Navigation</string>
     <string name="startup_page">Startseite</string>
     <string name="summary_preference_settings_startup_page">Wählen Sie den Bildschirm, der beim Start der App angezeigt wird.</string>
+    <string name="show_labels_on_bottom_bar">Etiketten an der unteren Bar anzeigen</string>
+    <string name="summary_preference_settings_show_labels_on_bottom_bar">Zeigen Sie die Elementtitel unter den Symbole in der unteren Navigationsleiste an</string>
 
     <string name="language">Sprache</string>
     <string name="summary_preference_settings_language">Ändert die Sprache der App</string>

--- a/apptoolkit/src/main/res/values-es-rGQ/strings.xml
+++ b/apptoolkit/src/main/res/values-es-rGQ/strings.xml
@@ -101,6 +101,8 @@
     <string name="navigation">Navegación</string>
     <string name="startup_page">Página de inicio</string>
     <string name="summary_preference_settings_startup_page">Elige la pantalla que se mostrará al iniciar la aplicación.</string>
+    <string name="show_labels_on_bottom_bar">Mostrar etiquetas en la barra inferior</string>
+    <string name="summary_preference_settings_show_labels_on_bottom_bar">Mostrar títulos de elementos a continuación iconos en la barra de navegación inferior</string>
 
     <string name="language">Idioma</string>
     <string name="summary_preference_settings_language">Cambia el idioma utilizado en la aplicación</string>

--- a/apptoolkit/src/main/res/values-es-rMX/strings.xml
+++ b/apptoolkit/src/main/res/values-es-rMX/strings.xml
@@ -101,6 +101,8 @@
     <string name="navigation">Navegación</string>
     <string name="startup_page">Página de inicio</string>
     <string name="summary_preference_settings_startup_page">Elige la pantalla que se mostrará cuando se inicie la aplicación.</string>
+    <string name="show_labels_on_bottom_bar">Mostrar etiquetas en la barra inferior</string>
+    <string name="summary_preference_settings_show_labels_on_bottom_bar">Mostrar títulos de elementos a continuación iconos en la barra de navegación inferior</string>
 
     <string name="language">Idioma</string>
     <string name="summary_preference_settings_language">Cambia el idioma utilizado en la aplicación</string>

--- a/apptoolkit/src/main/res/values-fil-rPH/strings.xml
+++ b/apptoolkit/src/main/res/values-fil-rPH/strings.xml
@@ -101,6 +101,8 @@
     <string name="navigation">Nabigasyon</string>
     <string name="startup_page">Startup page</string>
     <string name="summary_preference_settings_startup_page">Piliin ang screen na ipapakita kapag nagsimula ang app.</string>
+    <string name="show_labels_on_bottom_bar">Ipakita ang mga label sa ilalim na bar</string>
+    <string name="summary_preference_settings_show_labels_on_bottom_bar">Ipakita ang mga pamagat ng item sa ibaba ng mga icon sa ilalim ng nabigasyon bar</string>
 
     <string name="language">Wika</string>
     <string name="summary_preference_settings_language">Binabago ang wikang ginagamit sa app</string>

--- a/apptoolkit/src/main/res/values-fr-rFR/strings.xml
+++ b/apptoolkit/src/main/res/values-fr-rFR/strings.xml
@@ -101,6 +101,8 @@
     <string name="navigation">Navigation</string>
     <string name="startup_page">Page de démarrage</string>
     <string name="summary_preference_settings_startup_page">Choisissez l\'écran à afficher au démarrage de l\'application.</string>
+    <string name="show_labels_on_bottom_bar">Afficher les étiquettes sur la barre inférieure</string>
+    <string name="summary_preference_settings_show_labels_on_bottom_bar">Afficher les titres des icônes ci-dessous dans la barre de navigation inférieure</string>
 
     <string name="language">Langue</string>
     <string name="summary_preference_settings_language">Change la langue utilisée dans l\'application</string>

--- a/apptoolkit/src/main/res/values-hi-rIN/strings.xml
+++ b/apptoolkit/src/main/res/values-hi-rIN/strings.xml
@@ -101,6 +101,8 @@
     <string name="navigation">नेविगेशन</string>
     <string name="startup_page">स्टार्टअप पेज</string>
     <string name="summary_preference_settings_startup_page">ऐप शुरू होने पर प्रदर्शित होने वाली स्क्रीन चुनें।</string>
+    <string name="show_labels_on_bottom_bar">नीचे बार पर लेबल दिखाएं</string>
+    <string name="summary_preference_settings_show_labels_on_bottom_bar">नीचे नेविगेशन बार में आइकन के नीचे आइटम शीर्षक प्रदर्शित करें</string>
 
     <string name="language">भाषा</string>
     <string name="summary_preference_settings_language">ऐप में उपयोग की जाने वाली भाषा बदलें</string>

--- a/apptoolkit/src/main/res/values-hu-rHU/strings.xml
+++ b/apptoolkit/src/main/res/values-hu-rHU/strings.xml
@@ -101,6 +101,8 @@
     <string name="navigation">Navigáció</string>
     <string name="startup_page">Indítóoldal</string>
     <string name="summary_preference_settings_startup_page">Válaszd ki a képernyőt, amely megjelenik az alkalmazás indításakor.</string>
+    <string name="show_labels_on_bottom_bar">Mutassa be a címkéket az alsó sávon</string>
+    <string name="summary_preference_settings_show_labels_on_bottom_bar">Az elemcímek megjelenítése az ikonok alatt az alsó navigációs sávban</string>
 
     <string name="language">Nyelv</string>
     <string name="summary_preference_settings_language">Módosítja az alkalmazásban használt nyelvet</string>

--- a/apptoolkit/src/main/res/values-in-rID/strings.xml
+++ b/apptoolkit/src/main/res/values-in-rID/strings.xml
@@ -101,6 +101,8 @@
     <string name="navigation">Navigasi</string>
     <string name="startup_page">Halaman awal</string>
     <string name="summary_preference_settings_startup_page">Pilih layar yang akan ditampilkan saat aplikasi dimulai.</string>
+    <string name="show_labels_on_bottom_bar">Tampilkan label di bar bawah</string>
+    <string name="summary_preference_settings_show_labels_on_bottom_bar">Tampilkan Judul Item Di Bawah Ikon Di Bilah Navigasi Bawah</string>
 
     <string name="language">Bahasa</string>
     <string name="summary_preference_settings_language">Mengubah bahasa yang digunakan dalam aplikasi</string>

--- a/apptoolkit/src/main/res/values-it-rIT/strings.xml
+++ b/apptoolkit/src/main/res/values-it-rIT/strings.xml
@@ -101,6 +101,8 @@
     <string name="navigation">Navigazione</string>
     <string name="startup_page">Pagina di avvio</string>
     <string name="summary_preference_settings_startup_page">Scegli la schermata da visualizzare all\'avvio dell\'app.</string>
+    <string name="show_labels_on_bottom_bar">Mostra etichette sulla barra inferiore</string>
+    <string name="summary_preference_settings_show_labels_on_bottom_bar">Visualizza i titoli degli elementi sotto le icone nella barra di navigazione in basso</string>
 
     <string name="language">Lingua</string>
     <string name="summary_preference_settings_language">Modifica la lingua utilizzata nell\'app</string>

--- a/apptoolkit/src/main/res/values-ja-rJP/strings.xml
+++ b/apptoolkit/src/main/res/values-ja-rJP/strings.xml
@@ -101,6 +101,8 @@
     <string name="navigation">ナビゲーション</string>
     <string name="startup_page">スタートアップページ</string>
     <string name="summary_preference_settings_startup_page">アプリ起動時に表示される画面を選択する</string>
+    <string name="show_labels_on_bottom_bar">ボトムバーにラベルを表示します</string>
+    <string name="summary_preference_settings_show_labels_on_bottom_bar">下のナビゲーションバーの下にアイテムのタイトルを表示</string>
 
     <string name="language">言語</string>
     <string name="summary_preference_settings_language">アプリ内で使用される言語を変更する</string>

--- a/apptoolkit/src/main/res/values-ko-rKR/strings.xml
+++ b/apptoolkit/src/main/res/values-ko-rKR/strings.xml
@@ -101,6 +101,8 @@
     <string name="navigation">탐색</string>
     <string name="startup_page">시작 페이지</string>
     <string name="summary_preference_settings_startup_page">앱 시작 시 표시될 화면을 선택하세요.</string>
+    <string name="show_labels_on_bottom_bar">하단 막대에 레이블을 표시하십시오</string>
+    <string name="summary_preference_settings_show_labels_on_bottom_bar">하단 탐색 표시 줄 아래 아이콘 아래 아이템 제목 표시</string>
 
     <string name="language">언어</string>
     <string name="summary_preference_settings_language">앱에서 사용되는 언어를 변경합니다.</string>

--- a/apptoolkit/src/main/res/values-pl-rPL/strings.xml
+++ b/apptoolkit/src/main/res/values-pl-rPL/strings.xml
@@ -101,6 +101,8 @@
     <string name="navigation">Nawigacja</string>
     <string name="startup_page">Strona startowa</string>
     <string name="summary_preference_settings_startup_page">Wybierz ekran, który ma być wyświetlany przy uruchomieniu aplikacji.</string>
+    <string name="show_labels_on_bottom_bar">Pokaż etykiety na dolnym pasku</string>
+    <string name="summary_preference_settings_show_labels_on_bottom_bar">Wyświetl tytuły elementów poniżej ikon w dolnej pasku nawigacji</string>
 
     <string name="language">Język</string>
     <string name="summary_preference_settings_language">Zmień język używany w aplikacji</string>

--- a/apptoolkit/src/main/res/values-pt-rBR/strings.xml
+++ b/apptoolkit/src/main/res/values-pt-rBR/strings.xml
@@ -101,6 +101,8 @@
     <string name="navigation">Navegação</string>
     <string name="startup_page">Página inicial</string>
     <string name="summary_preference_settings_startup_page">Escolha a tela que será exibida ao iniciar o aplicativo.</string>
+    <string name="show_labels_on_bottom_bar">Mostrar rótulos na barra inferior</string>
+    <string name="summary_preference_settings_show_labels_on_bottom_bar">Exibir títulos dos itens abaixo dos ícones na barra de navegação inferior</string>
 
     <string name="language">Idioma</string>
     <string name="summary_preference_settings_language">Altere o idioma usado no aplicativo</string>

--- a/apptoolkit/src/main/res/values-ro-rRO/strings.xml
+++ b/apptoolkit/src/main/res/values-ro-rRO/strings.xml
@@ -101,6 +101,8 @@
     <string name="navigation">Navigare</string>
     <string name="startup_page">Pagina de pornire</string>
     <string name="summary_preference_settings_startup_page">Alege ecranul care va fi afișat la pornirea aplicației.</string>
+    <string name="show_labels_on_bottom_bar">Afișați etichete pe bara de jos</string>
+    <string name="summary_preference_settings_show_labels_on_bottom_bar">Afișați titlurile elementelor sub pictogramele din bara de navigare de jos</string>
 
     <string name="language">Limbă</string>
     <string name="summary_preference_settings_language">Schimbă limba utilizată în aplicație</string>

--- a/apptoolkit/src/main/res/values-ru-rRU/strings.xml
+++ b/apptoolkit/src/main/res/values-ru-rRU/strings.xml
@@ -101,6 +101,8 @@
     <string name="navigation">Навигация</string>
     <string name="startup_page">Стартовая страница</string>
     <string name="summary_preference_settings_startup_page">Выберите экран, который будет отображаться при запуске приложения.</string>
+    <string name="show_labels_on_bottom_bar">Показать этикетки на нижней панели</string>
+    <string name="summary_preference_settings_show_labels_on_bottom_bar">Отображение заголовков элементов ниже значков в нижней навигационной панели</string>
 
     <string name="language">Язык</string>
     <string name="summary_preference_settings_language">Измените язык, используемый в приложении</string>

--- a/apptoolkit/src/main/res/values-sv-rSE/strings.xml
+++ b/apptoolkit/src/main/res/values-sv-rSE/strings.xml
@@ -101,6 +101,8 @@
     <string name="navigation">Navigering</string>
     <string name="startup_page">Startsida</string>
     <string name="summary_preference_settings_startup_page">Välj vilken skärm som ska visas vid appens start.</string>
+    <string name="show_labels_on_bottom_bar">Visa etiketter på bottenstången</string>
+    <string name="summary_preference_settings_show_labels_on_bottom_bar">Visa objekttitlar under ikoner i den nedre navigationsfältet</string>
 
     <string name="language">Språk</string>
     <string name="summary_preference_settings_language">Ändra det språk som används i appen</string>

--- a/apptoolkit/src/main/res/values-th-rTH/strings.xml
+++ b/apptoolkit/src/main/res/values-th-rTH/strings.xml
@@ -101,6 +101,8 @@
     <string name="navigation">การนำทาง</string>
     <string name="startup_page">หน้าจอเริ่มต้น</string>
     <string name="summary_preference_settings_startup_page">เลือกหน้าจอที่จะแสดงเมื่อเริ่มต้นแอป</string>
+    <string name="show_labels_on_bottom_bar">แสดงฉลากบนแถบด้านล่าง</string>
+    <string name="summary_preference_settings_show_labels_on_bottom_bar">แสดงชื่อรายการด้านล่างไอคอนในแถบการนำทางด้านล่าง</string>
 
     <string name="language">ภาษา</string>
     <string name="summary_preference_settings_language">เปลี่ยนภาษาที่ใช้ในแอป</string>

--- a/apptoolkit/src/main/res/values-tr-rTR/strings.xml
+++ b/apptoolkit/src/main/res/values-tr-rTR/strings.xml
@@ -101,6 +101,8 @@
     <string name="navigation">Gezinti</string>
     <string name="startup_page">Başlangıç sayfası</string>
     <string name="summary_preference_settings_startup_page">Uygulama başlatıldığında görüntülenecek ekranı seçin.</string>
+    <string name="show_labels_on_bottom_bar">Alt çubukta etiketleri gösterin</string>
+    <string name="summary_preference_settings_show_labels_on_bottom_bar">Alt gezinme çubuğundaki simgelerin altındaki öğe başlıklarını görüntüleyin</string>
 
     <string name="language">Dil</string>
     <string name="summary_preference_settings_language">Uygulamada kullanılan dili değiştirin</string>

--- a/apptoolkit/src/main/res/values-uk-rUA/strings.xml
+++ b/apptoolkit/src/main/res/values-uk-rUA/strings.xml
@@ -101,6 +101,8 @@
     <string name="navigation">Навігація</string>
     <string name="startup_page">Початкова сторінка</string>
     <string name="summary_preference_settings_startup_page">Виберіть екран, який відображатиметься при запуску додатка.</string>
+    <string name="show_labels_on_bottom_bar">Показати етикетки на нижній панелі</string>
+    <string name="summary_preference_settings_show_labels_on_bottom_bar">Дисплея назви елементів нижче Піктограми в нижній панелі навігації</string>
 
     <string name="language">Мова</string>
     <string name="summary_preference_settings_language">Змінити мову додатка</string>

--- a/apptoolkit/src/main/res/values-ur-rPK/strings.xml
+++ b/apptoolkit/src/main/res/values-ur-rPK/strings.xml
@@ -101,6 +101,8 @@
     <string name="navigation">نیویگیشن</string>
     <string name="startup_page">شروعاتی صفحہ</string>
     <string name="summary_preference_settings_startup_page">ایپ شروع ہونے پر دکھائی جانے والی اسکرین منتخب کریں۔</string>
+    <string name="show_labels_on_bottom_bar">نیچے بار پر لیبل دکھائیں</string>
+    <string name="summary_preference_settings_show_labels_on_bottom_bar">نیچے نیویگیشن بار میں شبیہیں کے نیچے آئٹم کے عنوانات دکھائیں</string>
 
     <string name="language">زبان</string>
     <string name="summary_preference_settings_language">ایپ میں استعمال ہونے والی زبان کو تبدیل کرتا ہے</string>

--- a/apptoolkit/src/main/res/values-vi-rVN/strings.xml
+++ b/apptoolkit/src/main/res/values-vi-rVN/strings.xml
@@ -101,6 +101,8 @@
     <string name="navigation">Điều hướng</string>
     <string name="startup_page">Trang khởi động</string>
     <string name="summary_preference_settings_startup_page">Chọn màn hình sẽ hiển thị khi ứng dụng khởi động.</string>
+    <string name="show_labels_on_bottom_bar">Hiển thị nhãn trên thanh dưới cùng</string>
+    <string name="summary_preference_settings_show_labels_on_bottom_bar">Hiển thị các tiêu đề mục dưới các biểu tượng trong thanh điều hướng dưới cùng</string>
 
     <string name="language">Ngôn ngữ</string>
     <string name="summary_preference_settings_language">Thay đổi ngôn ngữ được sử dụng trong ứng dụng</string>

--- a/apptoolkit/src/main/res/values-zh-rTW/strings.xml
+++ b/apptoolkit/src/main/res/values-zh-rTW/strings.xml
@@ -101,6 +101,8 @@
     <string name="navigation">導航</string>
     <string name="startup_page">啟動頁面</string>
     <string name="summary_preference_settings_startup_page">選擇應用程式啟動時要顯示的畫面。</string>
+    <string name="show_labels_on_bottom_bar">在底栏上显示标签</string>
+    <string name="summary_preference_settings_show_labels_on_bottom_bar">在底部导航栏中的图标下方显示项目标题</string>
 
     <string name="language">語言</string>
     <string name="summary_preference_settings_language">變更應用程式的語言</string>


### PR DESCRIPTION
## Summary
- translate bottom bar label settings to all supported languages

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685424821e68832da01a572e981be2d9