### PR TITLE
Move startup arrays to app module

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppModule.kt
@@ -2,6 +2,8 @@ package com.d4rk.android.apps.apptoolkit.core.di.modules
 
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.IntentSenderRequest
+import android.content.Context
+import com.d4rk.android.apps.apptoolkit.R
 import com.d4rk.android.apps.apptoolkit.app.apps.domain.usecases.FetchDeveloperAppsUseCase
 import com.d4rk.android.apps.apptoolkit.app.apps.ui.AppsListViewModel
 import com.d4rk.android.apps.apptoolkit.app.apps.ui.FavoriteAppsViewModel
@@ -14,6 +16,7 @@ import com.d4rk.android.libs.apptoolkit.data.client.KtorClient
 import com.d4rk.android.libs.apptoolkit.data.core.ads.AdsCoreManager
 import com.google.android.play.core.appupdate.AppUpdateManager
 import com.google.android.play.core.appupdate.AppUpdateManagerFactory
+import org.koin.core.qualifier.named
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.viewModel
 import org.koin.core.parameter.parametersOf
@@ -23,6 +26,14 @@ val appModule : Module = module {
     single<DataStore> { DataStore.getInstance(context = get()) }
     single<AdsCoreManager> { AdsCoreManager(context = get() , get()) }
     single { KtorClient().createClient() }
+
+    single<List<String>>(named("startup_entries")) {
+        get<Context>().resources.getStringArray(R.array.preference_startup_entries).toList()
+    }
+
+    single<List<String>>(named("startup_values")) {
+        get<Context>().resources.getStringArray(R.array.preference_startup_values).toList()
+    }
 
     single<OnboardingProvider> { AppOnboardingProvider() }
 

--- a/app/src/main/res/values/arrays.xml
+++ b/app/src/main/res/values/arrays.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string-array name="preference_startup_entries">
+        <item>@string/all_apps</item>
+        <item>@string/favorite_apps</item>
+    </string-array>
+
+    <string-array name="preference_startup_values">
+        <item>apps_list</item>
+        <item>favorite_apps</item>
+    </string-array>
+</resources>

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/display/components/dialogs/SelectStartupScreenAlertDialog.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/display/components/dialogs/SelectStartupScreenAlertDialog.kt
@@ -20,7 +20,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.stringArrayResource
 import androidx.compose.ui.res.stringResource
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.core.ui.components.dialogs.BasicAlertDialog
@@ -28,6 +27,8 @@ import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.sections.Info
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.MediumVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
+import org.koin.compose.koinInject
+import org.koin.core.qualifier.named
 import kotlinx.coroutines.flow.firstOrNull
 
 @Composable
@@ -35,8 +36,8 @@ fun SelectStartupScreenAlertDialog(onDismiss: () -> Unit, onStartupSelected: (St
     val context = LocalContext.current
     val dataStore = CommonDataStore.getInstance(context)
     val selectedPage = remember { mutableStateOf("") }
-    val entries = stringArrayResource(id = R.array.preference_startup_entries).toList()
-    val values = stringArrayResource(id = R.array.preference_startup_values).toList()
+    val entries: List<String> = koinInject(qualifier = named("startup_entries"))
+    val values: List<String> = koinInject(qualifier = named("startup_values"))
 
     BasicAlertDialog(
         onDismiss = onDismiss,

--- a/apptoolkit/src/main/res/values/arrays.xml
+++ b/apptoolkit/src/main/res/values/arrays.xml
@@ -58,13 +58,4 @@
         <item>vi</item>
     </string-array>
 
-    <string-array name="preference_startup_entries">
-        <item>@string/all_apps</item>
-        <item>@string/favorite_apps</item>
-    </string-array>
-
-    <string-array name="preference_startup_values">
-        <item>apps_list</item>
-        <item>favorite_apps</item>
-    </string-array>
 </resources>


### PR DESCRIPTION
## Summary
- provide startup screen string arrays in the `app` module
- inject the arrays via Koin
- update `SelectStartupScreenAlertDialog` to use the injected values

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854e9836e34832da82f90e993a09a6a