### PR TITLE
Fix favorite star state

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/ui/AppsListScreen.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/ui/AppsListScreen.kt
@@ -4,7 +4,6 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
-import com.d4rk.android.apps.apptoolkit.core.data.datastore.DataStore
 import com.d4rk.android.apps.apptoolkit.app.apps.domain.actions.HomeEvent
 import com.d4rk.android.apps.apptoolkit.app.apps.domain.model.ui.UiHomeScreen
 import com.d4rk.android.apps.apptoolkit.app.apps.ui.components.AppsList
@@ -12,15 +11,13 @@ import com.d4rk.android.apps.apptoolkit.app.apps.ui.components.screens.loading.H
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.NoDataScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.ScreenStateHandler
-import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
 fun AppsListScreen(paddingValues : PaddingValues) {
     val viewModel : AppsListViewModel = koinViewModel()
     val screenState : UiStateScreen<UiHomeScreen> by viewModel.uiState.collectAsState()
-    val dataStore: DataStore = koinInject()
-    val favorites by dataStore.favoriteApps.collectAsState(initial = emptySet())
+    val favorites by viewModel.favorites.collectAsState()
     // Content does not trigger in-app review directly; handled in MainActivity
 
     ScreenStateHandler(screenState = screenState , onLoading = {

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/ui/AppsListViewModel.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/ui/AppsListViewModel.kt
@@ -13,7 +13,9 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.updateData
 import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 
 class AppsListViewModel(
@@ -21,6 +23,12 @@ class AppsListViewModel(
     private val dispatcherProvider : DispatcherProvider,
     private val dataStore: DataStore
 ) : ScreenViewModel<UiHomeScreen , HomeEvent , HomeAction>(initialState = UiStateScreen(screenState = ScreenState.IsLoading() , data = UiHomeScreen())) {
+
+    val favorites = dataStore.favoriteApps.stateIn(
+        scope = screenModelScope,
+        started = SharingStarted.Eagerly,
+        initialValue = emptySet()
+    )
 
     init {
         onEvent(event = HomeEvent.FetchApps)

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/ui/FavoriteAppsScreen.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/ui/FavoriteAppsScreen.kt
@@ -26,7 +26,7 @@ fun FavoriteAppsScreen(paddingValues: PaddingValues) {
         })},
 
         onSuccess = { uiHomeScreen ->
-            val favorites by viewModel.dataStore.favoriteApps.collectAsState(initial = emptySet())
+            val favorites by viewModel.favorites.collectAsState()
             AppsList(
                 uiHomeScreen = uiHomeScreen,
                 favorites = favorites,


### PR DESCRIPTION
## Summary
- track favorites in each ViewModel via StateFlow
- surface these state flows to the UI so star icons update instantly

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6854ebe3530c832dad7af4f2326bb040