### PR TITLE
Add translations for home screen labels

### DIFF
--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -10,6 +10,8 @@
     <string name="onboarding_personalization_description">يوضح هذا التطبيق كيف يمكن استخدام مكتبة AppToolkit الخاصة بنا لبناء تطبيقات متعددة الاستخدامات ومركزة على المستخدم. استكشف تطبيقاتنا للاطلاع على الميزات والتطبيقات المختلفة للمكتبة.</string>
 
     <!-- Home screen -->
+    <string name="all_apps">ﺕﺎﻘﻴﺒﻄﺘﻟﺍ ﻊﻴﻤﺟ</string>
+    <string name="favorite_apps">ﺔﻠﻀﻔﻤﻟﺍ</string>
     <string name="error_failed_to_fetch_our_apps">فشل في جلب قوائم تطبيقاتنا</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -10,6 +10,8 @@
     <string name="onboarding_personalization_description">Това демонстрационно приложение показва как библиотеката AppToolkit може да се използва за създаване на гъвкави и ориентирани към потребителя приложения. Разгледайте нашите приложения, за да видите различни функции и реализации.</string>
 
     <!-- Home screen -->
+    <string name="all_apps">Всички приложения</string>
+    <string name="favorite_apps">Любими</string>
     <string name="error_failed_to_fetch_our_apps">Неуспешно зареждане на списъка с нашите приложения</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -10,6 +10,8 @@
     <string name="onboarding_personalization_description">এই অ্যাপটি দেখায় কীভাবে আমাদের অ্যাপটুলকিট লাইব্রেরি ব্যবহার করে বহুমুখী এবং ব্যবহারকারী-কেন্দ্রিক অ্যাপ্লিকেশন তৈরি করা যায়। লাইব্রেরির বিভিন্ন বৈশিষ্ট্য এবং বাস্তবায়ন দেখতে আমাদের অ্যাপগুলি অন্বেষণ করুন।</string>
 
     <!-- Home screen -->
+    <string name="all_apps">সমস্ত অ্যাপ্লিকেশন</string>
+    <string name="favorite_apps">প্রিয়</string>
     <string name="error_failed_to_fetch_our_apps">আমাদের অ্যাপের তালিকা আনতে ব্যর্থ</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -10,6 +10,8 @@
     <string name="onboarding_personalization_description">Diese App demonstriert, wie unsere AppToolkit-Bibliothek verwendet werden kann, um vielseitige und benutzerorientierte Anwendungen zu erstellen. Entdecken Sie unsere Apps, um verschiedene Funktionen und Implementierungen der Bibliothek zu sehen.</string>
 
     <!-- Home screen -->
+    <string name="all_apps">Alle Apps</string>
+    <string name="favorite_apps">Favoriten</string>
     <string name="error_failed_to_fetch_our_apps">Fehler beim Abrufen unserer App-Listen</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -10,6 +10,8 @@
     <string name="onboarding_personalization_description">Esta aplicación demuestra cómo se puede utilizar nuestra biblioteca AppToolkit para crear aplicaciones versátiles y centradas en el usuario. Explore nuestras aplicaciones para ver diferentes características e implementaciones de la biblioteca.</string>
 
     <!-- Home screen -->
+    <string name="all_apps">Todas las aplicaciones</string>
+    <string name="favorite_apps">Favoritos</string>
     <string name="error_failed_to_fetch_our_apps">Error al obtener los listados de nuestras aplicaciones</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -10,6 +10,8 @@
     <string name="onboarding_personalization_description">Esta aplicación demuestra cómo nuestra biblioteca AppToolkit puede ser utilizada para construir aplicaciones versátiles y centradas en el usuario. Explora nuestras aplicaciones para ver diferentes características e implementaciones de la biblioteca.</string>
 
     <!-- Home screen -->
+    <string name="all_apps">Todas las aplicaciones</string>
+    <string name="favorite_apps">Favoritos</string>
     <string name="error_failed_to_fetch_our_apps">No se pudieron cargar nuestras listas de aplicaciones</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -10,6 +10,8 @@
     <string name="onboarding_personalization_description">Ipinapakita ng app na ito kung paano magagamit ang aming AppToolkit library upang bumuo ng mga versatile at user-focused na application. Galugarin ang aming mga app upang makita ang iba\'t ibang feature at implementasyon ng library.</string>
 
     <!-- Home screen -->
+    <string name="all_apps">Lahat ng mga app</string>
+    <string name="favorite_apps">Mga Paborito</string>
     <string name="error_failed_to_fetch_our_apps">Nabigong makuha ang aming mga listahan ng app</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -10,6 +10,8 @@
     <string name="onboarding_personalization_description">Cette application démontre comment notre bibliothèque AppToolkit peut être utilisée pour créer des applications polyvalentes et centrées sur l\'utilisateur. Explorez nos applications pour découvrir différentes fonctionnalités et implémentations de la bibliothèque.</string>
 
     <!-- Home screen -->
+    <string name="all_apps">Toutes les applications</string>
+    <string name="favorite_apps">Favoris</string>
     <string name="error_failed_to_fetch_our_apps">Échec de la récupération de nos listes d\'applications</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -10,6 +10,8 @@
     <string name="onboarding_personalization_description">यह ऐप प्रदर्शित करता है कि बहुमुखी और उपयोगकर्ता-केंद्रित एप्लिकेशन बनाने के लिए हमारी ऐपटूलकिट लाइब्रेरी का उपयोग कैसे किया जा सकता है। लाइब्रेरी की विभिन्न विशेषताओं और कार्यान्वयन को देखने के लिए हमारे ऐप्स का अन्वेषण करें।</string>
 
     <!-- Home screen -->
+    <string name="all_apps">सभी ऐप्स</string>
+    <string name="favorite_apps">पसंदीदा</string>
     <string name="error_failed_to_fetch_our_apps">हमारे ऐप लिस्टिंग को लाने में विफल</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -10,6 +10,8 @@
     <string name="onboarding_personalization_description">Ez az alkalmazás bemutatja, hogyan használható AppToolkit könyvtárunk sokoldalú és felhasználó-központú alkalmazások készítésére. Fedezze fel alkalmazásainkat, hogy megtekinthesse a könyvtár különböző funkcióit és implementációit.</string>
 
     <!-- Home screen -->
+    <string name="all_apps">Minden alkalmazás</string>
+    <string name="favorite_apps">Kedvencek</string>
     <string name="error_failed_to_fetch_our_apps">Nem sikerült lekérni alkalmazáslistáinkat</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -10,6 +10,8 @@
     <string name="onboarding_personalization_description">Aplikasi ini menunjukkan bagaimana pustaka AppToolkit kami dapat digunakan untuk membangun aplikasi yang serbaguna dan berfokus pada pengguna. Jelajahi aplikasi kami untuk melihat berbagai fitur dan implementasi pustaka.</string>
 
     <!-- Home screen -->
+    <string name="all_apps">Semua aplikasi</string>
+    <string name="favorite_apps">Favorit</string>
     <string name="error_failed_to_fetch_our_apps">Gagal mengambil daftar aplikasi kami</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -10,6 +10,8 @@
     <string name="onboarding_personalization_description">Questa app dimostra come la nostra libreria AppToolkit può essere utilizzata per creare applicazioni versatili e incentrate sull\'utente. Esplora le nostre app per vedere diverse funzionalità e implementazioni della libreria.</string>
 
     <!-- Home screen -->
+    <string name="all_apps">Tutte le app</string>
+    <string name="favorite_apps">Preferiti</string>
     <string name="error_failed_to_fetch_our_apps">Impossibile recuperare gli elenchi delle nostre app</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -10,6 +10,8 @@
     <string name="onboarding_personalization_description">このアプリは、当社のAppToolkitライブラリを使用して、多機能でユーザー中心のアプリケーションを構築する方法を示しています。ライブラリのさまざまな機能と実装を確認するには、当社のアプリをご覧ください。</string>
 
     <!-- Home screen -->
+    <string name="all_apps">すべてのアプリ</string>
+    <string name="favorite_apps">お気に入り</string>
     <string name="error_failed_to_fetch_our_apps">アプリ一覧の取得に失敗しました</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -10,6 +10,8 @@
     <string name="onboarding_personalization_description">이 앱은 저희 앱툴킷 라이브러리를 사용하여 다양하고 사용자 중심적인 애플리케이션을 구축하는 방법을 보여줍니다. 저희 앱들을 탐색하여 라이브러리의 다양한 기능과 구현 사례를 확인하세요.</string>
 
     <!-- Home screen -->
+    <string name="all_apps">모든 앱</string>
+    <string name="favorite_apps">즐겨 찾기</string>
     <string name="error_failed_to_fetch_our_apps">저희 앱 목록을 가져오는 데 실패했습니다.</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -10,6 +10,8 @@
     <string name="onboarding_personalization_description">Ta aplikacja demonstruje, jak nasza biblioteka AppToolkit może być używana do tworzenia wszechstronnych i zorientowanych na użytkownika aplikacji. Przeglądaj nasze aplikacje, aby zobaczyć różne funkcje i implementacje biblioteki.</string>
 
     <!-- Home screen -->
+    <string name="all_apps">Wszystkie aplikacje</string>
+    <string name="favorite_apps">Ulubione</string>
     <string name="error_failed_to_fetch_our_apps">Nie udało się pobrać list naszych aplikacji</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -10,6 +10,8 @@
     <string name="onboarding_personalization_description">Este aplicativo demonstra como nossa biblioteca AppToolkit pode ser usada para construir aplicativos versáteis e focados no usuário. Explore nossos aplicativos para ver diferentes recursos e implementações da biblioteca.</string>
 
     <!-- Home screen -->
+    <string name="all_apps">Todos os aplicativos</string>
+    <string name="favorite_apps">Favoritos</string>
     <string name="error_failed_to_fetch_our_apps">Falha ao buscar nossas listagens de aplicativos</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -10,6 +10,8 @@
     <string name="onboarding_personalization_description">Această aplicație demonstrează cum biblioteca noastră AppToolkit poate fi utilizată pentru a construi aplicații versatile și axate pe utilizator. Explorați aplicațiile noastre pentru a vedea diferite caracteristici și implementări ale bibliotecii.</string>
 
     <!-- Home screen -->
+    <string name="all_apps">Toate aplicațiile</string>
+    <string name="favorite_apps">Favorite</string>
     <string name="error_failed_to_fetch_our_apps">Nu s-au putut prelua listele aplicațiilor noastre</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -10,6 +10,8 @@
     <string name="onboarding_personalization_description">Это приложение демонстрирует, как наша библиотека AppToolkit может использоваться для создания универсальных и ориентированных на пользователя приложений. Изучите наши приложения, чтобы увидеть различные функции и реализации библиотеки.</string>
 
     <!-- Home screen -->
+    <string name="all_apps">Все приложения</string>
+    <string name="favorite_apps">Фавориты</string>
     <string name="error_failed_to_fetch_our_apps">Не удалось загрузить списки наших приложений</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -10,6 +10,8 @@
     <string name="onboarding_personalization_description">Den här appen demonstrerar hur vårt AppToolkit-bibliotek kan användas för att bygga mångsidiga och användarfokuserade applikationer. Utforska våra appar för att se olika funktioner och implementeringar av biblioteket.</string>
 
     <!-- Home screen -->
+    <string name="all_apps">Alla appar</string>
+    <string name="favorite_apps">Favoriter</string>
     <string name="error_failed_to_fetch_our_apps">Kunde inte hämta våra applistningar</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -10,6 +10,8 @@
     <string name="onboarding_personalization_description">แอปนี้สาธิตวิธีการใช้ไลบรารี AppToolkit ของเราเพื่อสร้างแอปพลิเคชันที่หลากหลายและเน้นผู้ใช้เป็นศูนย์กลาง สำรวจแอปของเราเพื่อดูคุณสมบัติและการนำไลบรารีไปใช้งานในรูปแบบต่างๆ</string>
 
     <!-- Home screen -->
+    <string name="all_apps">แอพทั้งหมด</string>
+    <string name="favorite_apps">รายการโปรด</string>
     <string name="error_failed_to_fetch_our_apps">ไม่สามารถดึงข้อมูลรายการแอปของเราได้</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -10,6 +10,8 @@
     <string name="onboarding_personalization_description">Bu uygulama, AppToolkit kütüphanemizin çok yönlü ve kullanıcı odaklı uygulamalar oluşturmak için nasıl kullanılabileceğini gösterir. Kütüphanenin farklı özelliklerini ve uygulamalarını görmek için uygulamalarımızı keşfedin.</string>
 
     <!-- Home screen -->
+    <string name="all_apps">Tüm uygulamalar</string>
+    <string name="favorite_apps">Favoriler</string>
     <string name="error_failed_to_fetch_our_apps">Uygulama listelerimiz alınamadı</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -10,6 +10,8 @@
     <string name="onboarding_personalization_description">Ця програма демонструє, як нашу бібліотеку AppToolkit можна використовувати для створення універсальних та орієнтованих на користувача програм. Ознайомтеся з нашими програмами, щоб побачити різні функції та реалізації бібліотеки.</string>
 
     <!-- Home screen -->
+    <string name="all_apps">Всі програми</string>
+    <string name="favorite_apps">Фаворити</string>
     <string name="error_failed_to_fetch_our_apps">Не вдалося завантажити списки наших програм</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -10,6 +10,8 @@
     <string name="onboarding_personalization_description">یہ ایپ ظاہر کرتی ہے کہ ہماری ایپ ٹول کٹ لائبریری کو ورسٹائل اور صارف پر مرکوز ایپلی کیشنز بنانے کے لیے کیسے استعمال کیا جا سکتا ہے۔ لائبریری کی مختلف خصوصیات اور نفاذ کو دیکھنے کے لیے ہماری ایپس کو دریافت کریں۔</string>
 
     <!-- Home screen -->
+    <string name="all_apps">ﺲﭙﯾﺍ ﻡﺎﻤﺗ</string>
+    <string name="favorite_apps">ﮦﺪﯾﺪﻨﺴﭘ</string>
     <string name="error_failed_to_fetch_our_apps">ہماری ایپ فہرستیں حاصل کرنے میں ناکام</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -10,6 +10,8 @@
     <string name="onboarding_personalization_description">Ứng dụng này minh họa cách thư viện AppToolkit của chúng tôi có thể được sử dụng để xây dựng các ứng dụng linh hoạt và tập trung vào người dùng. Khám phá các ứng dụng của chúng tôi để xem các tính năng và cách triển khai khác nhau của thư viện.</string>
 
     <!-- Home screen -->
+    <string name="all_apps">Tất cả các ứng dụng</string>
+    <string name="favorite_apps">Yêu thích</string>
     <string name="error_failed_to_fetch_our_apps">Không thể tìm nạp danh sách ứng dụng của chúng tôi</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -10,6 +10,8 @@
     <string name="onboarding_personalization_description">此應用程式展示了如何使用我們的 AppToolkit 程式庫來建構多功能且以使用者為中心的應用程式。探索我們的應用程式，以了解程式庫的不同功能和實作方式。</string>
 
     <!-- Home screen -->
+    <string name="all_apps">所有應用程序</string>
+    <string name="favorite_apps">最愛</string>
     <string name="error_failed_to_fetch_our_apps">無法擷取我們的應用程式清單</string>
 
     <!-- Help screen -->


### PR DESCRIPTION
## Summary
- localize `all_apps` and `favorite_apps` for every translation

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68551b356bb8832da21033c440e720e5