### PR TITLE
Add localized 'more options' strings

### DIFF
--- a/apptoolkit/src/main/res/values-ar-rEG/strings.xml
+++ b/apptoolkit/src/main/res/values-ar-rEG/strings.xml
@@ -47,6 +47,7 @@
     <string name="onboarding_final_description">شكرًا لتخصيص تجربتك. أنت الآن جاهز لاستكشاف جميع الميزات. استمتع!</string>
 
     <string name="navigation_drawer_open">فتح قائمة التنقل</string>
+    <string name="content_description_more_options">المزيد من الخيارات</string>
     <string name="go_back">العودة</string>
     <string name="toast_review_already_done">شكرا على التصنيف!</string>
 

--- a/apptoolkit/src/main/res/values-bg-rBG/strings.xml
+++ b/apptoolkit/src/main/res/values-bg-rBG/strings.xml
@@ -47,6 +47,7 @@
     <string name="onboarding_final_description">Благодарим ти, че персонализира своето преживяване. Вече си готов да изследваш всички функции. Приятно ползване!</string>
 
     <string name="navigation_drawer_open">Отворете навигационното меню</string>
+    <string name="content_description_more_options">Още опции</string>
     <string name="go_back">Назад</string>
     <string name="toast_review_already_done">Благодаря за оценката!</string>
 

--- a/apptoolkit/src/main/res/values-bn-rBD/strings.xml
+++ b/apptoolkit/src/main/res/values-bn-rBD/strings.xml
@@ -47,6 +47,7 @@
     <string name="onboarding_final_description">আপনার অভিজ্ঞতা ব্যক্তিগতকৃত করার জন্য ধন্যবাদ। আপনি এখন সমস্ত বৈশিষ্ট্য অন্বেষণ করতে প্রস্তুত। উপভোগ করুন!</string>
 
     <string name="navigation_drawer_open">নেভিগেশন ড্রয়ার খুলুন</string>
+    <string name="content_description_more_options">আরও বিকল্প</string>
     <string name="go_back">ফিরে যান</string>
     <string name="toast_review_already_done">রেটিং জন্য ধন্যবাদ!</string>
 

--- a/apptoolkit/src/main/res/values-de-rDE/strings.xml
+++ b/apptoolkit/src/main/res/values-de-rDE/strings.xml
@@ -47,6 +47,7 @@
     <string name="onboarding_final_description">Danke, dass du deine Erfahrung personalisiert hast. Du bist jetzt bereit, alle Funktionen zu erkunden. Viel Spaß!</string>
 
     <string name="navigation_drawer_open">Navigationsmenü öffnen</string>
+    <string name="content_description_more_options">Weitere Optionen</string>
     <string name="go_back">Zurück</string>
     <string name="toast_review_already_done">Danke für die Bewertung!</string>
 

--- a/apptoolkit/src/main/res/values-es-rGQ/strings.xml
+++ b/apptoolkit/src/main/res/values-es-rGQ/strings.xml
@@ -47,6 +47,7 @@
     <string name="onboarding_final_description">Gracias por personalizar tu experiencia. Ya estás listo para explorar todas las funciones. ¡Disfruta!</string>
 
     <string name="navigation_drawer_open">Abrir el menú de navegación</string>
+    <string name="content_description_more_options">Más opciones</string>
     <string name="go_back">Volver</string>
     <string name="toast_review_already_done">¡Gracias por la calificación!</string>
 

--- a/apptoolkit/src/main/res/values-es-rMX/strings.xml
+++ b/apptoolkit/src/main/res/values-es-rMX/strings.xml
@@ -47,6 +47,7 @@
     <string name="onboarding_final_description">Gracias por personalizar tu experiencia. Ya estás listo para explorar todas las funciones. ¡Disfruta!</string>
 
     <string name="navigation_drawer_open">Abrir menú de navegación</string>
+    <string name="content_description_more_options">Más opciones</string>
     <string name="go_back">Regresar</string>
     <string name="toast_review_already_done">¡Gracias por la calificación!</string>
 

--- a/apptoolkit/src/main/res/values-fil-rPH/strings.xml
+++ b/apptoolkit/src/main/res/values-fil-rPH/strings.xml
@@ -47,6 +47,7 @@
     <string name="onboarding_final_description">Salamat sa pag-personalize ng iyong karanasan. Handa ka na ngayong tuklasin ang lahat ng feature. Magsaya!</string>
 
     <string name="navigation_drawer_open">Buksan ang navigation drawer</string>
+    <string name="content_description_more_options">Higit pang mga pagpipilian</string>
     <string name="go_back">Bumalik</string>
     <string name="toast_review_already_done">Salamat sa rating!</string>
 

--- a/apptoolkit/src/main/res/values-fr-rFR/strings.xml
+++ b/apptoolkit/src/main/res/values-fr-rFR/strings.xml
@@ -47,6 +47,7 @@
     <string name="onboarding_final_description">Merci d\'avoir personnalisé votre expérience. Vous êtes maintenant prêt à explorer toutes les fonctionnalités. Amusez-vous !</string>
 
     <string name="navigation_drawer_open">Ouvrir le menu de navigation</string>
+    <string name="content_description_more_options">Plus d\'options</string>
     <string name="go_back">Retour</string>
     <string name="toast_review_already_done">Merci de la notation!</string>
 

--- a/apptoolkit/src/main/res/values-hi-rIN/strings.xml
+++ b/apptoolkit/src/main/res/values-hi-rIN/strings.xml
@@ -47,6 +47,7 @@
     <string name="onboarding_final_description">अपने अनुभव को वैयक्तिकृत करने के लिए धन्यवाद। अब आप सभी सुविधाओं का पता लगाने के लिए तैयार हैं। आनंद लें!</string>
 
     <string name="navigation_drawer_open">नेविगेशन ड्रॉअर खोलें</string>
+    <string name="content_description_more_options">अधिक विकल्प</string>
     <string name="go_back">वापस जाओ</string>
     <string name="toast_review_already_done">रेटिंग के लिए धन्यवाद!</string>
 

--- a/apptoolkit/src/main/res/values-hu-rHU/strings.xml
+++ b/apptoolkit/src/main/res/values-hu-rHU/strings.xml
@@ -47,6 +47,7 @@
     <string name="onboarding_final_description">Köszönjük, hogy személyre szabta az élményét. Most már készen áll az összes funkció felfedezésére. Jó szórakozást!</string>
 
     <string name="navigation_drawer_open">Navigációs menü megnyitása</string>
+    <string name="content_description_more_options">További lehetőségek</string>
     <string name="go_back">Vissza</string>
     <string name="toast_review_already_done">Köszönöm a besorolást!</string>
 

--- a/apptoolkit/src/main/res/values-in-rID/strings.xml
+++ b/apptoolkit/src/main/res/values-in-rID/strings.xml
@@ -47,6 +47,7 @@
     <string name="onboarding_final_description">Terima kasih telah mempersonalisasi pengalaman Anda. Sekarang Anda siap untuk menjelajahi semua fitur. Selamat menikmati!</string>
 
     <string name="navigation_drawer_open">Buka menu navigasi</string>
+    <string name="content_description_more_options">Lebih banyak opsi</string>
     <string name="go_back">Kembali</string>
     <string name="toast_review_already_done">Terima kasih atas peringkatnya!</string>
 

--- a/apptoolkit/src/main/res/values-it-rIT/strings.xml
+++ b/apptoolkit/src/main/res/values-it-rIT/strings.xml
@@ -47,6 +47,7 @@
     <string name="onboarding_final_description">Grazie per aver personalizzato la tua esperienza. Ora sei pronto a esplorare tutte le funzionalità. Divertiti!</string>
 
     <string name="navigation_drawer_open">Apri il menu di navigazione</string>
+    <string name="content_description_more_options">Più opzioni</string>
     <string name="go_back">Torna indietro</string>
     <string name="toast_review_already_done">Grazie per la valutazione!</string>
 

--- a/apptoolkit/src/main/res/values-ja-rJP/strings.xml
+++ b/apptoolkit/src/main/res/values-ja-rJP/strings.xml
@@ -47,6 +47,7 @@
     <string name="onboarding_final_description">エクスペリエンスをパーソナライズしていただきありがとうございます。これで、すべての機能を探索する準備ができました。お楽しみください！</string>
 
     <string name="navigation_drawer_open">ナビゲーションドロワーを開く</string>
+    <string name="content_description_more_options">その他のオプション</string>
     <string name="go_back">戻る</string>
     <string name="toast_review_already_done">評価してくれてありがとう！</string>
 

--- a/apptoolkit/src/main/res/values-ko-rKR/strings.xml
+++ b/apptoolkit/src/main/res/values-ko-rKR/strings.xml
@@ -47,6 +47,7 @@
     <string name="onboarding_final_description">환경을 맞춤 설정해 주셔서 감사합니다. 이제 모든 기능을 탐색할 준비가 되었습니다. 즐겁게 사용하세요!</string>
 
     <string name="navigation_drawer_open">탐색 창 열기</string>
+    <string name="content_description_more_options">더 많은 옵션</string>
     <string name="go_back">뒤로 가기</string>
     <string name="toast_review_already_done">평가 주셔서 감사합니다!</string>
 

--- a/apptoolkit/src/main/res/values-pl-rPL/strings.xml
+++ b/apptoolkit/src/main/res/values-pl-rPL/strings.xml
@@ -47,6 +47,7 @@
     <string name="onboarding_final_description">Dziękujemy za spersonalizowanie swoich ustawień. Jesteś teraz gotowy do odkrywania wszystkich funkcji. Baw się dobrze!</string>
 
     <string name="navigation_drawer_open">Otwórz menu nawigacyjne</string>
+    <string name="content_description_more_options">Więcej opcji</string>
     <string name="go_back">Wróć</string>
     <string name="toast_review_already_done">Dzięki za ocenę!</string>
 

--- a/apptoolkit/src/main/res/values-pt-rBR/strings.xml
+++ b/apptoolkit/src/main/res/values-pt-rBR/strings.xml
@@ -47,6 +47,7 @@
     <string name="onboarding_final_description">Obrigado por personalizar sua experiência. Agora você está pronto para explorar todos os recursos. Aproveite!</string>
 
     <string name="navigation_drawer_open">Abrir menu de navegação</string>
+    <string name="content_description_more_options">Mais opções</string>
     <string name="go_back">Voltar</string>
     <string name="toast_review_already_done">Obrigado pela classificação!</string>
 

--- a/apptoolkit/src/main/res/values-ro-rRO/strings.xml
+++ b/apptoolkit/src/main/res/values-ro-rRO/strings.xml
@@ -47,6 +47,7 @@
     <string name="onboarding_final_description">Mulțumim că ți-ai personalizat experiența. Acum ești gata să explorezi toate funcționalitățile. Bucură-te!</string>
 
     <string name="navigation_drawer_open">Deschide meniul de navigare</string>
+    <string name="content_description_more_options">Mai multe opțiuni</string>
     <string name="go_back">Înapoi</string>
     <string name="toast_review_already_done">Mulțumesc pentru evaluare!</string>
 

--- a/apptoolkit/src/main/res/values-ru-rRU/strings.xml
+++ b/apptoolkit/src/main/res/values-ru-rRU/strings.xml
@@ -47,6 +47,7 @@
     <string name="onboarding_final_description">Спасибо за персонализацию вашего опыта. Теперь вы готовы исследовать все функции. Наслаждайтесь!</string>
 
     <string name="navigation_drawer_open">Открыть меню навигации</string>
+    <string name="content_description_more_options">Больше вариантов</string>
     <string name="go_back">Назад</string>
     <string name="toast_review_already_done">Спасибо за рейтинг!</string>
 

--- a/apptoolkit/src/main/res/values-sv-rSE/strings.xml
+++ b/apptoolkit/src/main/res/values-sv-rSE/strings.xml
@@ -47,6 +47,7 @@
     <string name="onboarding_final_description">Tack för att du anpassade din upplevelse. Du är nu redo att utforska alla funktioner. Ha så kul!</string>
 
     <string name="navigation_drawer_open">Öppna navigationsmeny</string>
+    <string name="content_description_more_options">Fler alternativ</string>
     <string name="go_back">Tillbaka</string>
     <string name="toast_review_already_done">Tack för betyg!</string>
 

--- a/apptoolkit/src/main/res/values-th-rTH/strings.xml
+++ b/apptoolkit/src/main/res/values-th-rTH/strings.xml
@@ -47,6 +47,7 @@
     <string name="onboarding_final_description">ขอบคุณสำหรับการปรับแต่งประสบการณ์ของคุณ ตอนนี้คุณพร้อมที่จะสำรวจคุณสมบัติทั้งหมดแล้ว ขอให้สนุก!</string>
 
     <string name="navigation_drawer_open">เปิดเมนูนำทาง</string>
+    <string name="content_description_more_options">ตัวเลือกเพิ่มเติม</string>
     <string name="go_back">กลับ</string>
     <string name="toast_review_already_done">ขอบคุณสำหรับการให้คะแนน!</string>
 

--- a/apptoolkit/src/main/res/values-tr-rTR/strings.xml
+++ b/apptoolkit/src/main/res/values-tr-rTR/strings.xml
@@ -47,6 +47,7 @@
     <string name="onboarding_final_description">Deneyiminizi kişiselleştirdiğiniz için teşekkürler. Artık tüm özellikleri keşfetmeye hazırsınız. Keyfini çıkarın!</string>
 
     <string name="navigation_drawer_open">Gezinti çekmecesini aç</string>
+    <string name="content_description_more_options">Daha Fazla Seçenekler</string>
     <string name="go_back">Geri dön</string>
     <string name="toast_review_already_done">Derecelendirdiğiniz için teşekkürler!</string>
 

--- a/apptoolkit/src/main/res/values-uk-rUA/strings.xml
+++ b/apptoolkit/src/main/res/values-uk-rUA/strings.xml
@@ -47,6 +47,7 @@
     <string name="onboarding_final_description">Дякуємо за персоналізацію вашого досвіду. Тепер ви готові досліджувати всі функції. Насолоджуйтесь!</string>
 
     <string name="navigation_drawer_open">Відкрити меню навігації</string>
+    <string name="content_description_more_options">Більше варіантів</string>
     <string name="go_back">Повернутися</string>
     <string name="toast_review_already_done">Дякую за рейтинг!</string>
 

--- a/apptoolkit/src/main/res/values-ur-rPK/strings.xml
+++ b/apptoolkit/src/main/res/values-ur-rPK/strings.xml
@@ -47,6 +47,7 @@
     <string name="onboarding_final_description">اپنے تجربے کو ذاتی بنانے کا شکریہ۔ اب آپ تمام خصوصیات کو دریافت کرنے کے لیے تیار ہیں۔ لطف اٹھائیں!</string>
 
     <string name="navigation_drawer_open">نیویگیشن دراز کھولیں</string>
+    <string name="content_description_more_options">مزید اختیارات</string>
     <string name="go_back">پیچھے جائیں</string>
     <string name="toast_review_already_done">درجہ بندی کے لئے شکریہ!</string>
 

--- a/apptoolkit/src/main/res/values-vi-rVN/strings.xml
+++ b/apptoolkit/src/main/res/values-vi-rVN/strings.xml
@@ -47,6 +47,7 @@
     <string name="onboarding_final_description">Cảm ơn bạn đã cá nhân hóa trải nghiệm của mình. Bây giờ bạn đã sẵn sàng khám phá tất cả các tính năng. Chúc bạn vui vẻ!</string>
 
     <string name="navigation_drawer_open">Mở ngăn điều hướng</string>
+    <string name="content_description_more_options">Nhiều lựa chọn hơn</string>
     <string name="go_back">Quay lại</string>
     <string name="toast_review_already_done">Cảm ơn đã đánh giá!</string>
 

--- a/apptoolkit/src/main/res/values-zh-rTW/strings.xml
+++ b/apptoolkit/src/main/res/values-zh-rTW/strings.xml
@@ -47,6 +47,7 @@
     <string name="onboarding_final_description">感謝您個人化您的體驗。您現在已準備好探索所有功能。祝您使用愉快！</string>
 
     <string name="navigation_drawer_open">打開導覽抽屜</string>
+    <string name="content_description_more_options">更多选项</string>
     <string name="go_back">返回</string>
     <string name="toast_review_already_done">感謝您的評分！</string>
 

--- a/apptoolkit/src/main/res/values/strings.xml
+++ b/apptoolkit/src/main/res/values/strings.xml
@@ -47,8 +47,9 @@
     <string name="onboarding_final_description">Thanks for personalizing your experience. You\'re now ready to explore all the features. Enjoy!</string>
 
     <string name="navigation_drawer_open">Open navigation drawer</string>
-    <string name="go_back">Go back</string>
+
     <string name="content_description_more_options">More options</string>
+    <string name="go_back">Go back</string>
     <string name="toast_review_already_done">Thanks for rating!</string>
 
     <string name="sort_by">Sort by:</string>


### PR DESCRIPTION
## Summary
- translate `content_description_more_options` for every locale
- keep the new string above `go_back` so order matches across languages

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_685522cb3124832d9043afe2260aff98