### PR TITLE
Fix startup dialog default selection

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/components/navigation/AppNavigationHost.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/components/navigation/AppNavigationHost.kt
@@ -29,7 +29,7 @@ fun AppNavigationHost(
 ) {
     val context = LocalContext.current
     val dataStore = CommonDataStore.getInstance(context)
-    val startupRoute by dataStore.getStartupPage().collectAsState(initial = NavigationRoutes.ROUTE_APPS_LIST)
+    val startupRoute by dataStore.getStartupPage(default = NavigationRoutes.ROUTE_APPS_LIST).collectAsState(initial = NavigationRoutes.ROUTE_APPS_LIST)
 
     NavigationHost(
         navController = navController , startDestination = if (startupRoute.isNotBlank()) startupRoute else NavigationRoutes.ROUTE_APPS_LIST

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/display/components/dialogs/SelectStartupScreenAlertDialog.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/display/components/dialogs/SelectStartupScreenAlertDialog.kt
@@ -39,7 +39,7 @@ fun SelectStartupScreenAlertDialog(onDismiss: () -> Unit, onStartupSelected: (St
     val selectedPage = remember { mutableStateOf("") }
     val entries: List<String> = koinInject(qualifier = named("startup_entries"))
     val values: List<String> = koinInject(qualifier = named("startup_values"))
-    val startupRoute by dataStore.getStartupPage().collectAsState(initial = values.first())
+    val startupRoute by dataStore.getStartupPage(default = values.first()).collectAsState(initial = values.first())
 
     LaunchedEffect(startupRoute) {
         selectedPage.value = startupRoute

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/datastore/CommonDataStore.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/datastore/CommonDataStore.kt
@@ -60,8 +60,8 @@ open class CommonDataStore(context : Context) {
     }
 
     private val startupPageKey = stringPreferencesKey(name = DataStoreNamesConstants.DATA_STORE_STARTUP_PAGE)
-    fun getStartupPage() : Flow<String> = dataStore.data.map { preferences ->
-        preferences[startupPageKey] ?: ""
+    fun getStartupPage(default: String = "") : Flow<String> = dataStore.data.map { preferences ->
+        preferences[startupPageKey] ?: default
     }
 
     suspend fun saveStartup(isFirstTime : Boolean) {


### PR DESCRIPTION
## Summary
- ensure `CommonDataStore` can return a default startup page
- use the default when reading the current startup page

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68552b332d78832daca21883cf2fde7a