### PR TITLE
Add missing translations for favorites message

### DIFF
--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -12,6 +12,7 @@
     <!-- Home screen -->
     <string name="all_apps">ﺕﺎﻘﻴﺒﻄﺘﻟﺍ ﻊﻴﻤﺟ</string>
     <string name="favorite_apps">ﺔﻠﻀﻔﻤﻟﺍ</string>
+    <string name="no_apps_added_to_favorites">ﻻ توجد تطبيقات مضافة إلى المفضلة</string>
     <string name="error_failed_to_fetch_our_apps">فشل في جلب قوائم تطبيقاتنا</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -12,6 +12,7 @@
     <!-- Home screen -->
     <string name="all_apps">Всички приложения</string>
     <string name="favorite_apps">Любими</string>
+    <string name="no_apps_added_to_favorites">Няма добавени приложения към любимите</string>
     <string name="error_failed_to_fetch_our_apps">Неуспешно зареждане на списъка с нашите приложения</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -12,6 +12,7 @@
     <!-- Home screen -->
     <string name="all_apps">সমস্ত অ্যাপ্লিকেশন</string>
     <string name="favorite_apps">প্রিয়</string>
+    <string name="no_apps_added_to_favorites">পছন্দসই কোনও অ্যাপস যুক্ত করা হয়নি</string>
     <string name="error_failed_to_fetch_our_apps">আমাদের অ্যাপের তালিকা আনতে ব্যর্থ</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -12,6 +12,7 @@
     <!-- Home screen -->
     <string name="all_apps">Alle Apps</string>
     <string name="favorite_apps">Favoriten</string>
+    <string name="no_apps_added_to_favorites">Keine Apps zu Favoriten hinzugefügt</string>
     <string name="error_failed_to_fetch_our_apps">Fehler beim Abrufen unserer App-Listen</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -12,6 +12,7 @@
     <!-- Home screen -->
     <string name="all_apps">Todas las aplicaciones</string>
     <string name="favorite_apps">Favoritos</string>
+    <string name="no_apps_added_to_favorites">No hay aplicaciones agregadas a los favoritos</string>
     <string name="error_failed_to_fetch_our_apps">Error al obtener los listados de nuestras aplicaciones</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -12,6 +12,7 @@
     <!-- Home screen -->
     <string name="all_apps">Todas las aplicaciones</string>
     <string name="favorite_apps">Favoritos</string>
+    <string name="no_apps_added_to_favorites">No hay aplicaciones agregadas a los favoritos</string>
     <string name="error_failed_to_fetch_our_apps">No se pudieron cargar nuestras listas de aplicaciones</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -12,6 +12,7 @@
     <!-- Home screen -->
     <string name="all_apps">Lahat ng mga app</string>
     <string name="favorite_apps">Mga Paborito</string>
+    <string name="no_apps_added_to_favorites">Walang mga app na idinagdag sa mga paborito</string>
     <string name="error_failed_to_fetch_our_apps">Nabigong makuha ang aming mga listahan ng app</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -12,6 +12,7 @@
     <!-- Home screen -->
     <string name="all_apps">Toutes les applications</string>
     <string name="favorite_apps">Favoris</string>
+    <string name="no_apps_added_to_favorites">Aucune application ajoutée aux favoris</string>
     <string name="error_failed_to_fetch_our_apps">Échec de la récupération de nos listes d\'applications</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -12,6 +12,7 @@
     <!-- Home screen -->
     <string name="all_apps">सभी ऐप्स</string>
     <string name="favorite_apps">पसंदीदा</string>
+    <string name="no_apps_added_to_favorites">पसंदीदा में कोई ऐप नहीं जोड़ा गया</string>
     <string name="error_failed_to_fetch_our_apps">हमारे ऐप लिस्टिंग को लाने में विफल</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -12,6 +12,7 @@
     <!-- Home screen -->
     <string name="all_apps">Minden alkalmazás</string>
     <string name="favorite_apps">Kedvencek</string>
+    <string name="no_apps_added_to_favorites">Nincs hozzáadott alkalmazás a kedvencekhez</string>
     <string name="error_failed_to_fetch_our_apps">Nem sikerült lekérni alkalmazáslistáinkat</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -12,6 +12,7 @@
     <!-- Home screen -->
     <string name="all_apps">Semua aplikasi</string>
     <string name="favorite_apps">Favorit</string>
+    <string name="no_apps_added_to_favorites">Tidak ada aplikasi yang ditambahkan ke favorit</string>
     <string name="error_failed_to_fetch_our_apps">Gagal mengambil daftar aplikasi kami</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -12,6 +12,7 @@
     <!-- Home screen -->
     <string name="all_apps">Tutte le app</string>
     <string name="favorite_apps">Preferiti</string>
+    <string name="no_apps_added_to_favorites">Nessuna app aggiunta ai preferiti</string>
     <string name="error_failed_to_fetch_our_apps">Impossibile recuperare gli elenchi delle nostre app</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -12,6 +12,7 @@
     <!-- Home screen -->
     <string name="all_apps">すべてのアプリ</string>
     <string name="favorite_apps">お気に入り</string>
+    <string name="no_apps_added_to_favorites">お気に入りに追加されるアプリはありません</string>
     <string name="error_failed_to_fetch_our_apps">アプリ一覧の取得に失敗しました</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -12,6 +12,7 @@
     <!-- Home screen -->
     <string name="all_apps">모든 앱</string>
     <string name="favorite_apps">즐겨 찾기</string>
+    <string name="no_apps_added_to_favorites">즐겨 찾기에 추가 된 앱이 없습니다</string>
     <string name="error_failed_to_fetch_our_apps">저희 앱 목록을 가져오는 데 실패했습니다.</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -12,6 +12,7 @@
     <!-- Home screen -->
     <string name="all_apps">Wszystkie aplikacje</string>
     <string name="favorite_apps">Ulubione</string>
+    <string name="no_apps_added_to_favorites">Nie dodano aplikacji do ulubionych</string>
     <string name="error_failed_to_fetch_our_apps">Nie udało się pobrać list naszych aplikacji</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -12,6 +12,7 @@
     <!-- Home screen -->
     <string name="all_apps">Todos os aplicativos</string>
     <string name="favorite_apps">Favoritos</string>
+    <string name="no_apps_added_to_favorites">Nenhum aplicativo adicionado aos favoritos</string>
     <string name="error_failed_to_fetch_our_apps">Falha ao buscar nossas listagens de aplicativos</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -12,6 +12,7 @@
     <!-- Home screen -->
     <string name="all_apps">Toate aplicațiile</string>
     <string name="favorite_apps">Favorite</string>
+    <string name="no_apps_added_to_favorites">Nu se adaugă aplicații la favorite</string>
     <string name="error_failed_to_fetch_our_apps">Nu s-au putut prelua listele aplicațiilor noastre</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -12,6 +12,7 @@
     <!-- Home screen -->
     <string name="all_apps">Все приложения</string>
     <string name="favorite_apps">Фавориты</string>
+    <string name="no_apps_added_to_favorites">Приложения не добавляются в фавориты</string>
     <string name="error_failed_to_fetch_our_apps">Не удалось загрузить списки наших приложений</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -12,6 +12,7 @@
     <!-- Home screen -->
     <string name="all_apps">Alla appar</string>
     <string name="favorite_apps">Favoriter</string>
+    <string name="no_apps_added_to_favorites">Inga appar läggs till i favoriterna</string>
     <string name="error_failed_to_fetch_our_apps">Kunde inte hämta våra applistningar</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -12,6 +12,7 @@
     <!-- Home screen -->
     <string name="all_apps">แอพทั้งหมด</string>
     <string name="favorite_apps">รายการโปรด</string>
+    <string name="no_apps_added_to_favorites">ไม่มีการเพิ่มแอพในรายการโปรด</string>
     <string name="error_failed_to_fetch_our_apps">ไม่สามารถดึงข้อมูลรายการแอปของเราได้</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -12,6 +12,7 @@
     <!-- Home screen -->
     <string name="all_apps">Tüm uygulamalar</string>
     <string name="favorite_apps">Favoriler</string>
+    <string name="no_apps_added_to_favorites">Favorilere eklenen uygulama yok</string>
     <string name="error_failed_to_fetch_our_apps">Uygulama listelerimiz alınamadı</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -12,6 +12,7 @@
     <!-- Home screen -->
     <string name="all_apps">Всі програми</string>
     <string name="favorite_apps">Фаворити</string>
+    <string name="no_apps_added_to_favorites">До улюблених не додається додатків</string>
     <string name="error_failed_to_fetch_our_apps">Не вдалося завантажити списки наших програм</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -12,6 +12,7 @@
     <!-- Home screen -->
     <string name="all_apps">ﺲﭙﯾﺍ ﻡﺎﻤﺗ</string>
     <string name="favorite_apps">ﮦﺪﯾﺪﻨﺴﭘ</string>
+    <string name="no_apps_added_to_favorites">کوئی ایپس شامل نہیں کی گئیں</string>
     <string name="error_failed_to_fetch_our_apps">ہماری ایپ فہرستیں حاصل کرنے میں ناکام</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -12,6 +12,7 @@
     <!-- Home screen -->
     <string name="all_apps">Tất cả các ứng dụng</string>
     <string name="favorite_apps">Yêu thích</string>
+    <string name="no_apps_added_to_favorites">Không có ứng dụng nào được thêm vào yêu thích</string>
     <string name="error_failed_to_fetch_our_apps">Không thể tìm nạp danh sách ứng dụng của chúng tôi</string>
 
     <!-- Help screen -->

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -12,6 +12,7 @@
     <!-- Home screen -->
     <string name="all_apps">所有應用程序</string>
     <string name="favorite_apps">最愛</string>
+    <string name="no_apps_added_to_favorites">沒有添加到收藏夾的應用程序</string>
     <string name="error_failed_to_fetch_our_apps">無法擷取我們的應用程式清單</string>
 
     <!-- Help screen -->


### PR DESCRIPTION
## Summary
- add `no_apps_added_to_favorites` translations for all languages

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68553e075108832db91f9f055a489781