### PR TITLE
Fix build memory issue

### DIFF
--- a/apptoolkit/build.gradle.kts
+++ b/apptoolkit/build.gradle.kts
@@ -122,7 +122,7 @@ publishing {
         register<MavenPublication>("release") {
             groupId = "com.github.D4rK7355608"
             artifactId = "AppToolkit"
-            version = "1.0.33"
+            version = "1.0.34"
 
             afterEvaluate {
                 from(components["release"])

--- a/gradle.properties
+++ b/gradle.properties
@@ -6,7 +6,8 @@
 # http://www.gradle.org/docs/current/userguide/build_environment.html
 # Specifies the JVM arguments used for the daemon process.
 # The setting is particularly useful for tweaking memory settings.
-org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+org.gradle.jvmargs=-Xmx4096m -Dfile.encoding=UTF-8
+org.gradle.workers.max=2
 # When configured, Gradle will run in incubating parallel mode.
 # This option should only be used with decoupled projects. For more details, visit
 # https://developer.android.com/r/tools/gradle-multi-project-decoupled-projects


### PR DESCRIPTION
## Summary
- allocate more heap space for Gradle
- limit Gradle worker threads
- bump library version to `1.0.34`

## Testing
- `ANDROID_HOME=/opt/android-sdk ./gradlew :app:assembleDebug -x lint -x test --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6855561d1124832d957f8f2b39d4efea