### PR TITLE
Fix dispatcher usage in tests

### DIFF
--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModel.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModel.kt
@@ -26,8 +26,8 @@ class TestAppsListViewModel : TestAppsListViewModelBase() {
             emit(DataState.Loading<List<AppInfo>, Error>())
             emit(DataState.Success<List<AppInfo>, Error>(apps))
         }
-        setup(fetchFlow = flow)
-        viewModel.uiState.testSuccess(expectedSize = apps.size)
+        setup(fetchFlow = flow, testDispatcher = dispatcherExtension.testDispatcher)
+        viewModel.uiState.testSuccess(expectedSize = apps.size, testDispatcher = dispatcherExtension.testDispatcher)
     }
 
     @Test
@@ -36,8 +36,8 @@ class TestAppsListViewModel : TestAppsListViewModelBase() {
             emit(DataState.Loading<List<AppInfo>, Error>())
             emit(DataState.Success<List<AppInfo>, Error>(emptyList()))
         }
-        setup(fetchFlow = flow)
-        viewModel.uiState.testEmpty()
+        setup(fetchFlow = flow, testDispatcher = dispatcherExtension.testDispatcher)
+        viewModel.uiState.testEmpty(testDispatcher = dispatcherExtension.testDispatcher)
     }
 
     @Test
@@ -47,8 +47,8 @@ class TestAppsListViewModel : TestAppsListViewModelBase() {
             emit(DataState.Loading<List<AppInfo>, Error>())
             emit(DataState.Success<List<AppInfo>, Error>(apps))
         }
-        setup(fetchFlow = flow)
-        toggleAndAssert(packageName = "pkg", expected = true)
-        toggleAndAssert(packageName = "pkg", expected = false)
+        setup(fetchFlow = flow, testDispatcher = dispatcherExtension.testDispatcher)
+        toggleAndAssert(packageName = "pkg", expected = true, testDispatcher = dispatcherExtension.testDispatcher)
+        toggleAndAssert(packageName = "pkg", expected = false, testDispatcher = dispatcherExtension.testDispatcher)
     }
 }


### PR DESCRIPTION
## Summary
- fix the test dispatcher handling in AppsListViewModel unit tests
- ensure toggleFavorite coroutine completes before assertions

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862c593f460832dbeac3a7078b5ca48