### PR TITLE
Add unit tests for Support and Favorite apps view models

### DIFF
--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModel.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModel.kt
@@ -1,0 +1,53 @@
+package com.d4rk.android.apps.apptoolkit.app.apps.favorites
+
+import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
+import com.d4rk.android.apps.apptoolkit.app.core.MainDispatcherExtension
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Error
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+class TestFavoriteAppsViewModel : TestFavoriteAppsViewModelBase() {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val dispatcherExtension = MainDispatcherExtension()
+    }
+
+    @Test
+    fun `load favorites - success`() = runTest(dispatcherExtension.testDispatcher) {
+        val apps = listOf(AppInfo("App1", "pkg1", "url1"), AppInfo("App2", "pkg2", "url2"))
+        val flow = flow {
+            emit(DataState.Loading<List<AppInfo>, Error>())
+            emit(DataState.Success<List<AppInfo>, Error>(apps))
+        }
+        setup(fetchFlow = flow, initialFavorites = setOf("pkg1"), testDispatcher = dispatcherExtension.testDispatcher)
+        viewModel.uiState.testSuccess(expectedSize = 1, testDispatcher = dispatcherExtension.testDispatcher)
+    }
+
+    @Test
+    fun `load favorites - empty`() = runTest(dispatcherExtension.testDispatcher) {
+        val apps = listOf(AppInfo("App1", "pkg1", "url1"))
+        val flow = flow {
+            emit(DataState.Loading<List<AppInfo>, Error>())
+            emit(DataState.Success<List<AppInfo>, Error>(apps))
+        }
+        setup(fetchFlow = flow, initialFavorites = emptySet(), testDispatcher = dispatcherExtension.testDispatcher)
+        viewModel.uiState.testEmpty(testDispatcher = dispatcherExtension.testDispatcher)
+    }
+
+    @Test
+    fun `toggle favorite`() = runTest(dispatcherExtension.testDispatcher) {
+        val apps = listOf(AppInfo("App", "pkg", "url"))
+        val flow = flow {
+            emit(DataState.Loading<List<AppInfo>, Error>())
+            emit(DataState.Success<List<AppInfo>, Error>(apps))
+        }
+        setup(fetchFlow = flow, initialFavorites = setOf("pkg"), testDispatcher = dispatcherExtension.testDispatcher)
+        toggleAndAssert(packageName = "pkg", expected = false, testDispatcher = dispatcherExtension.testDispatcher)
+        toggleAndAssert(packageName = "pkg", expected = true, testDispatcher = dispatcherExtension.testDispatcher)
+    }
+}

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModel.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModel.kt
@@ -43,7 +43,6 @@ class TestFavoriteAppsViewModel : TestFavoriteAppsViewModelBase() {
     fun `toggle favorite`() = runTest(dispatcherExtension.testDispatcher) {
         val apps = listOf(AppInfo("App", "pkg", "url"))
         val flow = flow {
-            emit(DataState.Loading<List<AppInfo>, Error>())
             emit(DataState.Success<List<AppInfo>, Error>(apps))
         }
         setup(fetchFlow = flow, initialFavorites = setOf("pkg"), testDispatcher = dispatcherExtension.testDispatcher)

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModelBase.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModelBase.kt
@@ -1,0 +1,87 @@
+package com.d4rk.android.apps.apptoolkit.app.apps.favorites
+
+import app.cash.turbine.test
+import com.d4rk.android.apps.apptoolkit.app.apps.favorites.ui.FavoriteAppsViewModel
+import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
+import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.ui.UiHomeScreen
+import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.usecases.FetchDeveloperAppsUseCase
+import com.d4rk.android.apps.apptoolkit.app.core.TestDispatchers
+import com.d4rk.android.apps.apptoolkit.core.data.datastore.DataStore
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.RootError
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.TestDispatcher
+import org.junit.jupiter.api.Assertions.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+open class TestFavoriteAppsViewModelBase {
+
+    protected lateinit var dispatcherProvider: TestDispatchers
+    protected lateinit var viewModel: FavoriteAppsViewModel
+    private lateinit var fetchUseCase: FetchDeveloperAppsUseCase
+    private lateinit var dataStore: DataStore
+
+    protected fun setup(
+        fetchFlow: Flow<DataState<List<AppInfo>, RootError>>,
+        initialFavorites: Set<String> = emptySet(),
+        testDispatcher: TestDispatcher
+    ) {
+        dispatcherProvider = TestDispatchers(testDispatcher)
+        fetchUseCase = mockk()
+        dataStore = mockk(relaxed = true)
+        val favoritesFlow = MutableStateFlow(initialFavorites)
+        every { dataStore.favoriteApps } returns favoritesFlow
+        coEvery { dataStore.toggleFavoriteApp(any()) } coAnswers {
+            val pkg = it.invocation.args[0] as String
+            val current = favoritesFlow.value.toMutableSet()
+            if (!current.add(pkg)) current.remove(pkg)
+            favoritesFlow.value = current
+        }
+        coEvery { fetchUseCase.invoke() } returns fetchFlow
+
+        viewModel = FavoriteAppsViewModel(fetchUseCase, dataStore, dispatcherProvider)
+    }
+
+    protected suspend fun Flow<UiStateScreen<UiHomeScreen>>.testSuccess(
+        expectedSize: Int,
+        testDispatcher: TestDispatcher
+    ) {
+        this@testSuccess.test {
+            val first = awaitItem()
+            assertTrue(first.screenState is ScreenState.IsLoading)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val second = awaitItem()
+            assertTrue(second.screenState is ScreenState.Success)
+            assertThat(second.data?.apps?.size).isEqualTo(expectedSize)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    protected suspend fun Flow<UiStateScreen<UiHomeScreen>>.testEmpty(testDispatcher: TestDispatcher) {
+        this@testEmpty.test {
+            val first = awaitItem()
+            assertTrue(first.screenState is ScreenState.IsLoading)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val second = awaitItem()
+            assertTrue(second.screenState is ScreenState.NoData)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    protected fun toggleAndAssert(packageName: String, expected: Boolean, testDispatcher: TestDispatcher) {
+        viewModel.toggleFavorite(packageName)
+        testDispatcher.scheduler.advanceUntilIdle()
+        val favorites = viewModel.favorites.value
+        assertThat(favorites.contains(packageName)).isEqualTo(expected)
+    }
+}

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/support/ui/TestSupportViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/support/ui/TestSupportViewModel.kt
@@ -1,9 +1,12 @@
 package com.d4rk.android.libs.apptoolkit.app.support.ui
 
 import com.android.billingclient.api.ProductDetails
+import com.d4rk.android.libs.apptoolkit.app.support.domain.actions.SupportEvent
 import com.d4rk.android.libs.apptoolkit.core.MainDispatcherExtension
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Errors
+import io.mockk.every
+import io.mockk.mockk
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
@@ -19,9 +22,13 @@ class TestSupportViewModel : TestSupportViewModelBase() {
 
     @Test
     fun `query product details success`() = runTest(dispatcherExtension.testDispatcher) {
+        val low = mockk<ProductDetails>()
+        every { low.productId } returns "low"
+        val high = mockk<ProductDetails>()
+        every { high.productId } returns "high"
         val details = mapOf(
-            "low" to ProductDetails.newBuilder().setProductId("low").build(),
-            "high" to ProductDetails.newBuilder().setProductId("high").build()
+            "low" to low,
+            "high" to high
         )
         val flow = flow {
             emit(DataState.Loading<Map<String, ProductDetails>, Errors>())

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/support/ui/TestSupportViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/support/ui/TestSupportViewModel.kt
@@ -1,14 +1,19 @@
 package com.d4rk.android.libs.apptoolkit.app.support.ui
 
 import com.android.billingclient.api.ProductDetails
+import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.support.domain.actions.SupportEvent
 import com.d4rk.android.libs.apptoolkit.core.MainDispatcherExtension
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Errors
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
+import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
+import com.google.common.truth.Truth.assertThat
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 
@@ -35,18 +40,46 @@ class TestSupportViewModel : TestSupportViewModelBase() {
             emit(DataState.Success<Map<String, ProductDetails>, Errors>(details))
         }
         setup(flow = flow, testDispatcher = dispatcherExtension.testDispatcher)
-        viewModel.onEvent(SupportEvent.QueryProductDetails(billingClient))
-        viewModel.uiState.testSuccess(expectedSize = details.size, testDispatcher = dispatcherExtension.testDispatcher)
+
+        viewModel.uiState.test {
+            viewModel.onEvent(SupportEvent.QueryProductDetails(billingClient))
+
+            val first = awaitItem()
+            assertTrue(first.screenState is ScreenState.IsLoading)
+            dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
+
+            val second = awaitItem()
+            assertTrue(second.screenState is ScreenState.Success)
+            assertThat(second.data?.productDetails?.size).isEqualTo(details.size)
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 
     @Test
     fun `query product details error`() = runTest(dispatcherExtension.testDispatcher) {
         val flow = flow {
             emit(DataState.Loading<Map<String, ProductDetails>, Errors>())
-            emit(DataState.Error<Map<String, ProductDetails>, Errors>(null, Errors.UseCase.FAILED_TO_LOAD_SKU_DETAILS))
+            emit(
+                DataState.Error<Map<String, ProductDetails>, Errors>(
+                    null,
+                    Errors.UseCase.FAILED_TO_LOAD_SKU_DETAILS
+                )
+            )
         }
         setup(flow = flow, testDispatcher = dispatcherExtension.testDispatcher)
-        viewModel.onEvent(SupportEvent.QueryProductDetails(billingClient))
-        viewModel.uiState.testError(testDispatcher = dispatcherExtension.testDispatcher)
+
+        viewModel.uiState.test {
+            viewModel.onEvent(SupportEvent.QueryProductDetails(billingClient))
+
+            val first = awaitItem()
+            assertTrue(first.screenState is ScreenState.IsLoading)
+            dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
+
+            val second = awaitItem()
+            assertTrue(second.screenState is ScreenState.Error)
+            val msg = second.errors.first().message as UiTextHelper.StringResource
+            assertThat(msg.resourceId).isEqualTo(R.string.error_failed_to_load_sku_details)
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/support/ui/TestSupportViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/support/ui/TestSupportViewModel.kt
@@ -41,18 +41,14 @@ class TestSupportViewModel : TestSupportViewModelBase() {
         }
         setup(flow = flow, testDispatcher = dispatcherExtension.testDispatcher)
 
-        viewModel.uiState.test {
-            viewModel.onEvent(SupportEvent.QueryProductDetails(billingClient))
+        // Act
+        viewModel.onEvent(SupportEvent.QueryProductDetails(billingClient))
 
-            val first = awaitItem()
-            assertTrue(first.screenState is ScreenState.IsLoading)
-            dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
-
-            val second = awaitItem()
-            assertTrue(second.screenState is ScreenState.Success)
-            assertThat(second.data?.productDetails?.size).isEqualTo(details.size)
-            cancelAndIgnoreRemainingEvents()
-        }
+        // Assert using the helper from the base class
+        viewModel.uiState.testSuccess(
+            expectedSize = details.size,
+            testDispatcher = dispatcherExtension.testDispatcher,
+        )
     }
 
     @Test
@@ -68,18 +64,10 @@ class TestSupportViewModel : TestSupportViewModelBase() {
         }
         setup(flow = flow, testDispatcher = dispatcherExtension.testDispatcher)
 
-        viewModel.uiState.test {
-            viewModel.onEvent(SupportEvent.QueryProductDetails(billingClient))
+        // Act
+        viewModel.onEvent(SupportEvent.QueryProductDetails(billingClient))
 
-            val first = awaitItem()
-            assertTrue(first.screenState is ScreenState.IsLoading)
-            dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
-
-            val second = awaitItem()
-            assertTrue(second.screenState is ScreenState.Error)
-            val msg = second.errors.first().message as UiTextHelper.StringResource
-            assertThat(msg.resourceId).isEqualTo(R.string.error_failed_to_load_sku_details)
-            cancelAndIgnoreRemainingEvents()
-        }
+        // Assert using the helper from the base class
+        viewModel.uiState.testError(testDispatcher = dispatcherExtension.testDispatcher)
     }
 }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/support/ui/TestSupportViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/support/ui/TestSupportViewModel.kt
@@ -1,0 +1,45 @@
+package com.d4rk.android.libs.apptoolkit.app.support.ui
+
+import com.android.billingclient.api.ProductDetails
+import com.d4rk.android.libs.apptoolkit.core.MainDispatcherExtension
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Errors
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+class TestSupportViewModel : TestSupportViewModelBase() {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val dispatcherExtension = MainDispatcherExtension()
+    }
+
+    @Test
+    fun `query product details success`() = runTest(dispatcherExtension.testDispatcher) {
+        val details = mapOf(
+            "low" to ProductDetails.newBuilder().setProductId("low").build(),
+            "high" to ProductDetails.newBuilder().setProductId("high").build()
+        )
+        val flow = flow {
+            emit(DataState.Loading<Map<String, ProductDetails>, Errors>())
+            emit(DataState.Success<Map<String, ProductDetails>, Errors>(details))
+        }
+        setup(flow = flow, testDispatcher = dispatcherExtension.testDispatcher)
+        viewModel.onEvent(SupportEvent.QueryProductDetails(billingClient))
+        viewModel.uiState.testSuccess(expectedSize = details.size, testDispatcher = dispatcherExtension.testDispatcher)
+    }
+
+    @Test
+    fun `query product details error`() = runTest(dispatcherExtension.testDispatcher) {
+        val flow = flow {
+            emit(DataState.Loading<Map<String, ProductDetails>, Errors>())
+            emit(DataState.Error<Map<String, ProductDetails>, Errors>(null, Errors.UseCase.FAILED_TO_LOAD_SKU_DETAILS))
+        }
+        setup(flow = flow, testDispatcher = dispatcherExtension.testDispatcher)
+        viewModel.onEvent(SupportEvent.QueryProductDetails(billingClient))
+        viewModel.uiState.testError(testDispatcher = dispatcherExtension.testDispatcher)
+    }
+}

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/support/ui/TestSupportViewModelBase.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/support/ui/TestSupportViewModelBase.kt
@@ -1,0 +1,67 @@
+package com.d4rk.android.libs.apptoolkit.app.support.ui
+
+import app.cash.turbine.test
+import com.android.billingclient.api.BillingClient
+import com.android.billingclient.api.ProductDetails
+import com.d4rk.android.libs.apptoolkit.R
+import com.d4rk.android.libs.apptoolkit.core.TestDispatchers
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Errors
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
+import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
+import com.d4rk.android.libs.apptoolkit.app.support.domain.usecases.QueryProductDetailsUseCase
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.test.TestDispatcher
+import org.junit.jupiter.api.Assertions.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+open class TestSupportViewModelBase {
+
+    protected lateinit var dispatcherProvider: TestDispatchers
+    protected lateinit var viewModel: SupportViewModel
+    protected lateinit var useCase: QueryProductDetailsUseCase
+    protected lateinit var billingClient: BillingClient
+
+    protected fun setup(
+        flow: Flow<DataState<Map<String, ProductDetails>, Errors>>,
+        testDispatcher: TestDispatcher
+    ) {
+        dispatcherProvider = TestDispatchers(testDispatcher)
+        useCase = mockk()
+        billingClient = mockk()
+        coEvery { useCase.invoke(any()) } returns flow
+        viewModel = SupportViewModel(useCase, dispatcherProvider)
+    }
+
+    protected suspend fun Flow<UiStateScreen<UiSupportScreen>>.testSuccess(expectedSize: Int, testDispatcher: TestDispatcher) {
+        this@testSuccess.test {
+            val first = awaitItem()
+            assertTrue(first.screenState is ScreenState.IsLoading)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val second = awaitItem()
+            assertTrue(second.screenState is ScreenState.Success)
+            assertThat(second.data?.productDetails?.size).isEqualTo(expectedSize)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    protected suspend fun Flow<UiStateScreen<UiSupportScreen>>.testError(testDispatcher: TestDispatcher) {
+        this@testError.test {
+            val first = awaitItem()
+            assertTrue(first.screenState is ScreenState.IsLoading)
+            testDispatcher.scheduler.advanceUntilIdle()
+
+            val second = awaitItem()
+            assertTrue(second.screenState is ScreenState.Error)
+            val msg = second.errors.first().message as UiTextHelper.StringResource
+            assertThat(msg.resourceId).isEqualTo(R.string.error_failed_to_load_sku_details)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/support/ui/TestSupportViewModelBase.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/support/ui/TestSupportViewModelBase.kt
@@ -10,6 +10,7 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Errors
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
+import com.d4rk.android.libs.apptoolkit.app.support.domain.model.UiSupportScreen
 import com.d4rk.android.libs.apptoolkit.app.support.domain.usecases.QueryProductDetailsUseCase
 import com.google.common.truth.Truth.assertThat
 import io.mockk.coEvery


### PR DESCRIPTION
## Summary
- add a base test class and unit tests for `FavoriteAppsViewModel`
- add a base test class and unit tests for `SupportViewModel`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6864c89f9be4832da1636f45d7a80a7b