### PR TITLE
Fix SupportViewModel tests

### DIFF
--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/support/ui/TestSupportViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/support/ui/TestSupportViewModel.kt
@@ -36,14 +36,13 @@ class TestSupportViewModel : TestSupportViewModelBase() {
         }
         setup(flow = flow, testDispatcher = dispatcherExtension.testDispatcher)
 
-        // Act
-        viewModel.onEvent(SupportEvent.QueryProductDetails(billingClient))
-
         // Assert using the helper from the base class
         viewModel.uiState.testSuccess(
             expectedSize = details.size,
             testDispatcher = dispatcherExtension.testDispatcher,
-        )
+        ) {
+            viewModel.onEvent(SupportEvent.QueryProductDetails(billingClient))
+        }
     }
 
     @Test
@@ -59,10 +58,11 @@ class TestSupportViewModel : TestSupportViewModelBase() {
         }
         setup(flow = flow, testDispatcher = dispatcherExtension.testDispatcher)
 
-        // Act
-        viewModel.onEvent(SupportEvent.QueryProductDetails(billingClient))
-
         // Assert using the helper from the base class
-        viewModel.uiState.testError(testDispatcher = dispatcherExtension.testDispatcher)
+        viewModel.uiState.testError(
+            testDispatcher = dispatcherExtension.testDispatcher,
+        ) {
+            viewModel.onEvent(SupportEvent.QueryProductDetails(billingClient))
+        }
     }
 }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/support/ui/TestSupportViewModelBase.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/support/ui/TestSupportViewModelBase.kt
@@ -39,8 +39,13 @@ open class TestSupportViewModelBase {
         viewModel = SupportViewModel(useCase, dispatcherProvider)
     }
 
-    protected suspend fun Flow<UiStateScreen<UiSupportScreen>>.testSuccess(expectedSize: Int, testDispatcher: TestDispatcher) {
+    protected suspend fun Flow<UiStateScreen<UiSupportScreen>>.testSuccess(
+        expectedSize: Int,
+        testDispatcher: TestDispatcher,
+        trigger: () -> Unit = {},
+    ) {
         this@testSuccess.test {
+            trigger()
             val first = awaitItem()
             assertTrue(first.screenState is ScreenState.IsLoading)
             testDispatcher.scheduler.advanceUntilIdle()
@@ -52,8 +57,12 @@ open class TestSupportViewModelBase {
         }
     }
 
-    protected suspend fun Flow<UiStateScreen<UiSupportScreen>>.testError(testDispatcher: TestDispatcher) {
+    protected suspend fun Flow<UiStateScreen<UiSupportScreen>>.testError(
+        testDispatcher: TestDispatcher,
+        trigger: () -> Unit = {},
+    ) {
         this@testError.test {
+            trigger()
             val first = awaitItem()
             assertTrue(first.screenState is ScreenState.IsLoading)
             testDispatcher.scheduler.advanceUntilIdle()


### PR DESCRIPTION
## Summary
- adjust SupportViewModel test utilities so events are triggered after collecting
- update tests to trigger query event from inside assertions

## Testing
- `./gradlew :apptoolkit:test -Dtest.single=TestSupportViewModel` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68657bad0af0832da896d3c53b864260