### PR TITLE
Add unit tests for more view models

### DIFF
--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/main/TestMainViewModel.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/main/TestMainViewModel.kt
@@ -42,6 +42,7 @@ class TestMainViewModel {
     fun `navigation items loaded on init`() = runTest(dispatcherExtension.testDispatcher) {
         val flow = flow<DataState<Int, Errors>> { }
         setup(flow, dispatcherExtension.testDispatcher)
+        dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
         val items = viewModel.uiState.value.data?.navigationDrawerItems
         assertThat(items?.size).isEqualTo(4)
     }

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/main/TestMainViewModel.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/main/TestMainViewModel.kt
@@ -1,0 +1,62 @@
+package com.d4rk.android.apps.apptoolkit.app.main
+
+import com.d4rk.android.apps.apptoolkit.app.core.MainDispatcherExtension
+import com.d4rk.android.apps.apptoolkit.app.core.TestDispatchers
+import com.d4rk.android.apps.apptoolkit.app.main.domain.action.MainEvent
+import com.d4rk.android.apps.apptoolkit.app.main.ui.MainViewModel
+import com.d4rk.android.libs.apptoolkit.R
+import com.d4rk.android.libs.apptoolkit.app.main.domain.usecases.PerformInAppUpdateUseCase
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Errors
+import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import com.google.common.truth.Truth.assertThat
+
+class TestMainViewModel {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val dispatcherExtension = MainDispatcherExtension()
+    }
+
+    private lateinit var dispatcherProvider: TestDispatchers
+    private lateinit var viewModel: MainViewModel
+    private lateinit var updateUseCase: PerformInAppUpdateUseCase
+
+    private fun setup(flow: Flow<DataState<Int, Errors>>, dispatcher: TestDispatcher) {
+        dispatcherProvider = TestDispatchers(dispatcher)
+        updateUseCase = mockk()
+        coEvery { updateUseCase.invoke(Unit) } returns flow
+        viewModel = MainViewModel(updateUseCase, dispatcherProvider)
+    }
+
+    @Test
+    fun `navigation items loaded on init`() = runTest(dispatcherExtension.testDispatcher) {
+        val flow = flow<DataState<Int, Errors>> { }
+        setup(flow, dispatcherExtension.testDispatcher)
+        val items = viewModel.uiState.value.data?.navigationDrawerItems
+        assertThat(items?.size).isEqualTo(4)
+    }
+
+    @Test
+    fun `check update error shows snackbar`() = runTest(dispatcherExtension.testDispatcher) {
+        val flow = flow {
+            emit(DataState.Error<Int, Errors>(error = Errors.UseCase.FAILED_TO_UPDATE_APP))
+        }
+        setup(flow, dispatcherExtension.testDispatcher)
+        viewModel.onEvent(MainEvent.CheckForUpdates)
+        dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
+        val snackbar = viewModel.uiState.value.snackbar
+        assertThat(snackbar).isNotNull()
+        val msg = snackbar!!.message as UiTextHelper.StringResource
+        assertThat(msg.resourceId).isEqualTo(R.string.snack_update_failed)
+    }
+}

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/about/ui/TestAboutViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/about/ui/TestAboutViewModel.kt
@@ -1,0 +1,32 @@
+package com.d4rk.android.libs.apptoolkit.app.about.ui
+
+import com.d4rk.android.libs.apptoolkit.R
+import com.d4rk.android.libs.apptoolkit.core.MainDispatcherExtension
+import com.d4rk.android.libs.apptoolkit.core.TestDispatchers
+import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import kotlinx.coroutines.test.runTest
+
+class TestAboutViewModel {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val dispatcherExtension = MainDispatcherExtension()
+    }
+
+    @Test
+    fun `copy device info shows snackbar`() = runTest(dispatcherExtension.testDispatcher) {
+        val dispatcherProvider = TestDispatchers(dispatcherExtension.testDispatcher)
+        val viewModel = AboutViewModel(dispatcherProvider)
+        viewModel.onEvent(AboutEvents.CopyDeviceInfo)
+        dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
+        val state = viewModel.uiState.value
+        assertThat(state.data?.showDeviceInfoCopiedSnackbar).isTrue()
+        val snackbar = state.snackbar!!
+        val msg = snackbar.message as UiTextHelper.StringResource
+        assertThat(msg.resourceId).isEqualTo(R.string.snack_device_info_copied)
+    }
+}

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/TestOnboardingViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/TestOnboardingViewModel.kt
@@ -1,0 +1,21 @@
+package com.d4rk.android.libs.apptoolkit.app.oboarding.ui
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Test
+import com.d4rk.android.libs.apptoolkit.app.oboarding.ui.OnboardingViewModel
+
+class TestOnboardingViewModel {
+
+    @Test
+    fun `default tab index is zero`() {
+        val viewModel = OnboardingViewModel()
+        assertThat(viewModel.currentTabIndex).isEqualTo(0)
+    }
+
+    @Test
+    fun `tab index can be changed`() {
+        val viewModel = OnboardingViewModel()
+        viewModel.currentTabIndex = 1
+        assertThat(viewModel.currentTabIndex).isEqualTo(1)
+    }
+}

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/permissions/ui/TestPermissionsViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/permissions/ui/TestPermissionsViewModel.kt
@@ -1,0 +1,63 @@
+package com.d4rk.android.libs.apptoolkit.app.permissions.ui
+
+import android.content.Context
+import com.d4rk.android.libs.apptoolkit.app.permissions.domain.actions.PermissionsEvent
+import com.d4rk.android.libs.apptoolkit.app.permissions.utils.interfaces.PermissionsProvider
+import com.d4rk.android.libs.apptoolkit.app.settings.settings.domain.model.SettingsCategory
+import com.d4rk.android.libs.apptoolkit.app.settings.settings.domain.model.SettingsConfig
+import com.d4rk.android.libs.apptoolkit.core.MainDispatcherExtension
+import com.d4rk.android.libs.apptoolkit.core.TestDispatchers
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
+import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+class TestPermissionsViewModel {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val dispatcherExtension = MainDispatcherExtension()
+    }
+
+    private lateinit var dispatcherProvider: TestDispatchers
+    private lateinit var viewModel: PermissionsViewModel
+    private lateinit var provider: PermissionsProvider
+
+    private fun setup(config: SettingsConfig, dispatcher: TestDispatcher) {
+        dispatcherProvider = TestDispatchers(dispatcher)
+        provider = mockk()
+        every { provider.providePermissionsConfig(any()) } returns config
+        viewModel = PermissionsViewModel(provider, dispatcherProvider)
+    }
+
+    @Test
+    fun `load permissions success`() = runTest(dispatcherExtension.testDispatcher) {
+        val config = SettingsConfig(title = "title", categories = listOf(SettingsCategory(title = "c")))
+        setup(config, dispatcherExtension.testDispatcher)
+        val context = mockk<Context>(relaxed = true)
+        viewModel.onEvent(PermissionsEvent.Load(context))
+        dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
+        val state = viewModel.uiState.value
+        assertThat(state.screenState).isInstanceOf(ScreenState.Success::class.java)
+        assertThat(state.data?.categories?.size).isEqualTo(1)
+    }
+
+    @Test
+    fun `load permissions empty`() = runTest(dispatcherExtension.testDispatcher) {
+        val config = SettingsConfig(title = "title", categories = emptyList())
+        setup(config, dispatcherExtension.testDispatcher)
+        val context = mockk<Context>(relaxed = true)
+        viewModel.onEvent(PermissionsEvent.Load(context))
+        dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
+        val state = viewModel.uiState.value
+        assertThat(state.screenState).isInstanceOf(ScreenState.NoData::class.java)
+        val error = state.errors.first().message as UiTextHelper.DynamicString
+        assertThat(error.text).isEqualTo("No settings found")
+    }
+}

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/TestGeneralSettingsViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/TestGeneralSettingsViewModel.kt
@@ -1,0 +1,42 @@
+package com.d4rk.android.libs.apptoolkit.app.settings.general.ui
+
+import com.d4rk.android.libs.apptoolkit.R
+import com.d4rk.android.libs.apptoolkit.core.MainDispatcherExtension
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
+import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
+import com.d4rk.android.libs.apptoolkit.app.settings.general.domain.actions.GeneralSettingsEvent
+import com.d4rk.android.libs.apptoolkit.app.settings.general.ui.GeneralSettingsViewModel
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+class TestGeneralSettingsViewModel {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val dispatcherExtension = MainDispatcherExtension()
+    }
+
+    @Test
+    fun `load content success`() = runTest(dispatcherExtension.testDispatcher) {
+        val viewModel = GeneralSettingsViewModel()
+        viewModel.onEvent(GeneralSettingsEvent.Load("key"))
+        dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
+        val state = viewModel.uiState.value
+        assertThat(state.screenState).isInstanceOf(ScreenState.Success::class.java)
+        assertThat(state.data?.contentKey).isEqualTo("key")
+    }
+
+    @Test
+    fun `load content invalid`() = runTest(dispatcherExtension.testDispatcher) {
+        val viewModel = GeneralSettingsViewModel()
+        viewModel.onEvent(GeneralSettingsEvent.Load(null))
+        dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
+        val state = viewModel.uiState.value
+        assertThat(state.screenState).isInstanceOf(ScreenState.NoData::class.java)
+        val error = state.errors.first().message as UiTextHelper.StringResource
+        assertThat(error.resourceId).isEqualTo(R.string.error_invalid_content_key)
+    }
+}

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/TestSettingsViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/TestSettingsViewModel.kt
@@ -1,0 +1,65 @@
+package com.d4rk.android.libs.apptoolkit.app.settings.settings.ui
+
+import android.content.Context
+import com.d4rk.android.libs.apptoolkit.R
+import com.d4rk.android.libs.apptoolkit.app.settings.settings.domain.actions.SettingsEvent
+import com.d4rk.android.libs.apptoolkit.app.settings.settings.domain.model.SettingsCategory
+import com.d4rk.android.libs.apptoolkit.app.settings.settings.domain.model.SettingsConfig
+import com.d4rk.android.libs.apptoolkit.app.settings.settings.ui.SettingsViewModel
+import com.d4rk.android.libs.apptoolkit.app.settings.utils.interfaces.SettingsProvider
+import com.d4rk.android.libs.apptoolkit.core.MainDispatcherExtension
+import com.d4rk.android.libs.apptoolkit.core.TestDispatchers
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
+import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.test.TestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+class TestSettingsViewModel {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val dispatcherExtension = MainDispatcherExtension()
+    }
+
+    private lateinit var dispatcherProvider: TestDispatchers
+    private lateinit var viewModel: SettingsViewModel
+    private lateinit var provider: SettingsProvider
+
+    private fun setup(config: SettingsConfig, dispatcher: TestDispatcher) {
+        dispatcherProvider = TestDispatchers(dispatcher)
+        provider = mockk()
+        every { provider.provideSettingsConfig(any()) } returns config
+        viewModel = SettingsViewModel(provider, dispatcherProvider)
+    }
+
+    @Test
+    fun `load settings success`() = runTest(dispatcherExtension.testDispatcher) {
+        val config = SettingsConfig(title = "title", categories = listOf(SettingsCategory(title = "c")))
+        setup(config, dispatcherExtension.testDispatcher)
+        val context = mockk<Context>(relaxed = true)
+        viewModel.onEvent(SettingsEvent.Load(context))
+        dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
+        val state = viewModel.uiState.value
+        assertThat(state.screenState).isInstanceOf(ScreenState.Success::class.java)
+        assertThat(state.data?.categories?.size).isEqualTo(1)
+    }
+
+    @Test
+    fun `load settings empty`() = runTest(dispatcherExtension.testDispatcher) {
+        val config = SettingsConfig(title = "title", categories = emptyList())
+        setup(config, dispatcherExtension.testDispatcher)
+        val context = mockk<Context>(relaxed = true)
+        viewModel.onEvent(SettingsEvent.Load(context))
+        dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
+        val state = viewModel.uiState.value
+        assertThat(state.screenState).isInstanceOf(ScreenState.NoData::class.java)
+        val error = state.errors.first().message as UiTextHelper.StringResource
+        assertThat(error.resourceId).isEqualTo(R.string.error_no_settings_found)
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for MainViewModel in the app module
- cover SettingsViewModel, PermissionsViewModel and GeneralSettingsViewModel
- add AboutViewModel and OnboardingViewModel tests

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68659ada5608832dacf575a21d12e520