### PR TITLE
Add tests for Settings and GeneralSettings view models

### DIFF
--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/TestGeneralSettingsViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/TestGeneralSettingsViewModel.kt
@@ -39,4 +39,35 @@ class TestGeneralSettingsViewModel {
         val error = state.errors.first().message as UiTextHelper.StringResource
         assertThat(error.resourceId).isEqualTo(R.string.error_invalid_content_key)
     }
+
+    @Test
+    fun `load content blank`() = runTest(dispatcherExtension.testDispatcher) {
+        val viewModel = GeneralSettingsViewModel()
+        viewModel.onEvent(GeneralSettingsEvent.Load(""))
+        dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
+        val state = viewModel.uiState.value
+        assertThat(state.screenState).isInstanceOf(ScreenState.NoData::class.java)
+        val error = state.errors.first().message as UiTextHelper.StringResource
+        assertThat(error.resourceId).isEqualTo(R.string.error_invalid_content_key)
+    }
+
+    @Test
+    fun `state transitions loading success error`() = runTest(dispatcherExtension.testDispatcher) {
+        val viewModel = GeneralSettingsViewModel()
+
+        viewModel.onEvent(GeneralSettingsEvent.Load("key"))
+        // Immediately after triggering, state should be loading
+        var state = viewModel.uiState.value
+        assertThat(state.screenState).isInstanceOf(ScreenState.IsLoading::class.java)
+        dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
+        state = viewModel.uiState.value
+        assertThat(state.screenState).isInstanceOf(ScreenState.Success::class.java)
+
+        viewModel.onEvent(GeneralSettingsEvent.Load(""))
+        state = viewModel.uiState.value
+        assertThat(state.screenState).isInstanceOf(ScreenState.IsLoading::class.java)
+        dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
+        state = viewModel.uiState.value
+        assertThat(state.screenState).isInstanceOf(ScreenState.NoData::class.java)
+    }
 }


### PR DESCRIPTION
## Summary
- add failing provider tests for SettingsViewModel
- add provider null data test for SettingsViewModel
- test blank key and state transitions in GeneralSettingsViewModel

## Testing
- `./gradlew :apptoolkit:testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868cb48d6ac832d88531e0c85316b73