### PR TITLE
Fix error tests expecting extra emission

### DIFF
--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModelBase.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModelBase.kt
@@ -83,10 +83,10 @@ open class TestFavoriteAppsViewModelBase {
             val first = awaitItem()
             assertTrue(first.screenState is ScreenState.IsLoading)
             testDispatcher.scheduler.advanceUntilIdle()
-
-            val second = awaitItem()
+            expectNoEvents()
             // Error flow doesn't update state, so it should remain loading
-            assertTrue(second.screenState is ScreenState.IsLoading)
+            val current = viewModel.uiState.value
+            assertTrue(current.screenState is ScreenState.IsLoading)
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModelBase.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModelBase.kt
@@ -103,11 +103,11 @@ open class TestAppsListViewModelBase {
             assertTrue(first.screenState is ScreenState.IsLoading) { "First emission should be IsLoading but was ${first.screenState}" }
             println("advancing dispatcher...")
             testDispatcher.scheduler.advanceUntilIdle()
-
-            val second = awaitItem()
-            println("\u2139\uFE0F [EMISSION 2] $second")
+            expectNoEvents()
+            println("checking state after dispatcher idle...")
+            val current = viewModel.uiState.value
             // Error flow leaves state unchanged, so it should remain loading
-            assertTrue(second.screenState is ScreenState.IsLoading) { "State should remain Loading on error" }
+            assertTrue(current.screenState is ScreenState.IsLoading) { "State should remain Loading on error" }
             cancelAndIgnoreRemainingEvents()
         }
         println("\uD83C\uDFC1 [TEST END] testError")


### PR DESCRIPTION
## Summary
- handle absence of extra emissions in error tests

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868d25a9070832d9d2f8632c979927a