### PR TITLE
Add unit tests for core helpers and view models

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/ui/AboutViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/ui/AboutViewModel.kt
@@ -19,7 +19,10 @@ open class AboutViewModel(private val dispatcherProvider : DispatcherProvider) :
     override fun onEvent(event : AboutEvents) {
         when (event) {
             is AboutEvents.CopyDeviceInfo -> copyDeviceInfo()
-            is AboutEvents.DismissSnackbar -> screenState.dismissSnackbar()
+            is AboutEvents.DismissSnackbar -> {
+                updateUi { copy(showDeviceInfoCopiedSnackbar = false) }
+                screenState.dismissSnackbar()
+            }
         }
     }
 

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/about/ui/TestAboutViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/about/ui/TestAboutViewModel.kt
@@ -45,5 +45,38 @@ class TestAboutViewModel {
 
         val state = viewModel.uiState.value
         assertThat(state.snackbar).isNull()
+        assertThat(state.data?.showDeviceInfoCopiedSnackbar).isFalse()
+    }
+
+    @Test
+    fun `snackbar can be shown again after dismissal`() = runTest(dispatcherExtension.testDispatcher) {
+        val dispatcherProvider = TestDispatchers(dispatcherExtension.testDispatcher)
+        val viewModel = AboutViewModel(dispatcherProvider)
+
+        viewModel.onEvent(AboutEvents.CopyDeviceInfo)
+        dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
+        viewModel.onEvent(AboutEvents.DismissSnackbar)
+        dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.snackbar).isNull()
+
+        viewModel.onEvent(AboutEvents.CopyDeviceInfo)
+        dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
+
+        val stateAfterSecondCopy = viewModel.uiState.value
+        assertThat(stateAfterSecondCopy.snackbar).isNotNull()
+        assertThat(stateAfterSecondCopy.data?.showDeviceInfoCopiedSnackbar).isTrue()
+
+        viewModel.onEvent(AboutEvents.DismissSnackbar)
+        dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
+        val finalState = viewModel.uiState.value
+        assertThat(finalState.snackbar).isNull()
+        assertThat(finalState.data?.showDeviceInfoCopiedSnackbar).isFalse()
+
+        // dismissing again should keep snackbar hidden
+        viewModel.onEvent(AboutEvents.DismissSnackbar)
+        dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
+        assertThat(viewModel.uiState.value.snackbar).isNull()
+        assertThat(viewModel.uiState.value.data?.showDeviceInfoCopiedSnackbar).isFalse()
     }
 }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/TestOnboardingViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/TestOnboardingViewModel.kt
@@ -33,4 +33,11 @@ class TestOnboardingViewModel {
         viewModel.currentTabIndex = 0
         assertThat(viewModel.currentTabIndex).isEqualTo(0)
     }
+
+    @Test
+    fun `setting extremely large tab index`() {
+        val viewModel = OnboardingViewModel()
+        viewModel.currentTabIndex = Int.MAX_VALUE
+        assertThat(viewModel.currentTabIndex).isEqualTo(Int.MAX_VALUE)
+    }
 }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/oboarding/utils/helpers/TestCrashlyticsOnboardingStateManager.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/oboarding/utils/helpers/TestCrashlyticsOnboardingStateManager.kt
@@ -13,4 +13,14 @@ class TestCrashlyticsOnboardingStateManager {
         CrashlyticsOnboardingStateManager.dismissDialog()
         assertFalse(CrashlyticsOnboardingStateManager.showCrashlyticsDialog)
     }
+
+    @Test
+    fun `repeated open and dismiss calls`() {
+        CrashlyticsOnboardingStateManager.openDialog()
+        CrashlyticsOnboardingStateManager.openDialog()
+        assertTrue(CrashlyticsOnboardingStateManager.showCrashlyticsDialog)
+        CrashlyticsOnboardingStateManager.dismissDialog()
+        CrashlyticsOnboardingStateManager.dismissDialog()
+        assertFalse(CrashlyticsOnboardingStateManager.showCrashlyticsDialog)
+    }
 }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestClipboardHelper.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestClipboardHelper.kt
@@ -13,6 +13,7 @@ import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
+import kotlin.test.assertFailsWith
 
 class TestClipboardHelper {
     @Test
@@ -33,6 +34,28 @@ class TestClipboardHelper {
             assertTrue(callbackExecuted)
         } else {
             assertFalse(callbackExecuted)
+        }
+    }
+
+    @Test
+    fun `copyTextToClipboard throws when manager missing`() {
+        val context = mockk<Context>()
+        every { context.getSystemService(Context.CLIPBOARD_SERVICE) } returns null
+
+        assertFailsWith<NullPointerException> {
+            ClipboardHelper.copyTextToClipboard(context, "l", "t")
+        }
+    }
+
+    @Test
+    fun `copyTextToClipboard handles manager exception`() {
+        val manager = mockk<ClipboardManager>()
+        val context = mockk<Context>()
+        every { context.getSystemService(Context.CLIPBOARD_SERVICE) } returns manager
+        every { manager.setPrimaryClip(any()) } throws RuntimeException("boom")
+
+        assertFailsWith<RuntimeException> {
+            ClipboardHelper.copyTextToClipboard(context, "l", "t")
         }
     }
 }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestConsentManagerHelper.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestConsentManagerHelper.kt
@@ -1,0 +1,35 @@
+import com.google.firebase.analytics.FirebaseAnalytics
+import com.google.firebase.analytics.ktx.analytics
+import com.google.firebase.ktx.Firebase
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.verify
+import kotlin.test.Test
+
+class TestConsentManagerHelper {
+    @Test
+    fun `updateConsent passes values to firebase`() {
+        val analytics = mockk<FirebaseAnalytics>(relaxed = true)
+        mockkObject(Firebase)
+        every { Firebase.analytics } returns analytics
+        justRun { analytics.setConsent(any()) }
+
+        com.d4rk.android.libs.apptoolkit.core.utils.helpers.ConsentManagerHelper.updateConsent(
+            analyticsGranted = true,
+            adStorageGranted = false,
+            adUserDataGranted = true,
+            adPersonalizationGranted = false
+        )
+
+        verify {
+            analytics.setConsent(match {
+                it[FirebaseAnalytics.ConsentType.ANALYTICS_STORAGE] == FirebaseAnalytics.ConsentStatus.GRANTED &&
+                it[FirebaseAnalytics.ConsentType.AD_STORAGE] == FirebaseAnalytics.ConsentStatus.DENIED &&
+                it[FirebaseAnalytics.ConsentType.AD_USER_DATA] == FirebaseAnalytics.ConsentStatus.GRANTED &&
+                it[FirebaseAnalytics.ConsentType.AD_PERSONALIZATION] == FirebaseAnalytics.ConsentStatus.DENIED
+            })
+        }
+    }
+}

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestIntentsHelper.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestIntentsHelper.kt
@@ -9,6 +9,7 @@ import io.mockk.slot
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
+import kotlin.test.assertFailsWith
 
 class TestIntentsHelper {
 
@@ -37,5 +38,25 @@ class TestIntentsHelper {
         val intent = intentSlot.captured
         assertEquals(String::class.java.name, intent.component?.className)
         assertTrue(intent.flags and Intent.FLAG_ACTIVITY_NEW_TASK != 0)
+    }
+
+    @Test
+    fun `openUrl propagates exception`() {
+        val context = mockk<Context>()
+        every { context.startActivity(any()) } throws RuntimeException("fail")
+
+        assertFailsWith<RuntimeException> {
+            IntentsHelper.openUrl(context, "https://example.com")
+        }
+    }
+
+    @Test
+    fun `openActivity propagates exception`() {
+        val context = mockk<Context>()
+        every { context.startActivity(any()) } throws RuntimeException("fail")
+
+        assertFailsWith<RuntimeException> {
+            IntentsHelper.openActivity(context, String::class.java)
+        }
     }
 }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestPermissionsHelper.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestPermissionsHelper.kt
@@ -47,4 +47,16 @@ class TestPermissionsHelper {
             verify(exactly = 0) { ActivityCompat.requestPermissions(any(), any(), any()) }
         }
     }
+
+    @Test
+    fun `hasNotificationPermission handles unexpected value`() {
+        val context = mockk<Context>()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            mockkStatic(ContextCompat::class)
+            every { ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) } returns 123
+            assertFalse(PermissionsHelper.hasNotificationPermission(context))
+        } else {
+            assertTrue(PermissionsHelper.hasNotificationPermission(context))
+        }
+    }
 }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/data/core/ads/TestAdsCoreManager.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/data/core/ads/TestAdsCoreManager.kt
@@ -1,0 +1,36 @@
+import android.app.Activity
+import android.content.Context
+import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoProvider
+import com.d4rk.android.libs.apptoolkit.data.core.ads.AdsCoreManager
+import com.google.android.gms.ads.MobileAds
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.verify
+import kotlin.test.Test
+
+class TestAdsCoreManager {
+    @Test
+    fun `initializeAds triggers MobileAds`() {
+        val context = mockk<Context>()
+        val provider = mockk<BuildInfoProvider>()
+        val manager = AdsCoreManager(context, provider)
+
+        mockkStatic(MobileAds::class)
+        justRun { MobileAds.initialize(context) }
+
+        manager.initializeAds("id")
+        verify { MobileAds.initialize(context) }
+    }
+
+    @Test
+    fun `showAdIfAvailable before init does nothing`() {
+        val context = mockk<Context>()
+        val provider = mockk<BuildInfoProvider>()
+        val manager = AdsCoreManager(context, provider)
+        val activity = mockk<Activity>()
+
+        manager.showAdIfAvailable(activity)
+    }
+}


### PR DESCRIPTION
## Summary
- update AboutViewModel to reset snackbar flag when dismissed
- expand AboutViewModel tests for snackbar dismissal and retrigger
- add boundary tests for onboarding view model and crashlytics manager
- extend helper tests for clipboard, intents and permissions
- add tests for consent manager and basic ads manager

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6868de7df820832db5a5cf4155e53fc4