### PR TITLE
Add ViewModel edge case tests

### DIFF
--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/main/TestMainViewModel.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/main/TestMainViewModel.kt
@@ -156,4 +156,26 @@ class TestMainViewModel {
         assertThat(firstItems?.size).isEqualTo(4)
         assertThat(secondItems?.size).isEqualTo(4)
     }
+
+    @Test
+    fun `loading update emits nothing else`() = runTest(dispatcherExtension.testDispatcher) {
+        val flow = flow {
+            emit(DataState.Loading<Int, Errors>())
+        }
+        setup(flow, dispatcherExtension.testDispatcher)
+        viewModel.onEvent(MainEvent.CheckForUpdates)
+        dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
+        assertThat(viewModel.uiState.value.snackbar).isNull()
+    }
+
+    @Test
+    fun `unexpected update result is ignored`() = runTest(dispatcherExtension.testDispatcher) {
+        val flow = flow {
+            emit(DataState.Success<Int, Errors>(5))
+        }
+        setup(flow, dispatcherExtension.testDispatcher)
+        viewModel.onEvent(MainEvent.CheckForUpdates)
+        dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
+        assertThat(viewModel.uiState.value.snackbar).isNull()
+    }
 }


### PR DESCRIPTION
## Summary
- expand setup helpers to allow simulating DataStore failures
- exercise error handling and duplicate lists in `FavoriteAppsViewModel`
- add duplicate and DataStore failure tests for `AppsListViewModel`
- cover loading-only and unexpected result scenarios in `MainViewModel`

## Testing
- `./gradlew test --no-daemon` *(fails: could not download dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6868e89cfcc0832d8c526a8fa4cedf87