### PR TITLE
Enable debug logging for Ktor client

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppModule.kt
@@ -13,6 +13,7 @@ import com.d4rk.android.apps.apptoolkit.core.data.datastore.DataStore
 import com.d4rk.android.libs.apptoolkit.app.main.domain.usecases.PerformInAppUpdateUseCase
 import com.d4rk.android.libs.apptoolkit.app.oboarding.utils.interfaces.providers.OnboardingProvider
 import com.d4rk.android.libs.apptoolkit.data.client.KtorClient
+import com.d4rk.android.apps.apptoolkit.BuildConfig
 import com.d4rk.android.libs.apptoolkit.data.core.ads.AdsCoreManager
 import com.google.android.play.core.appupdate.AppUpdateManager
 import com.google.android.play.core.appupdate.AppUpdateManagerFactory
@@ -25,7 +26,7 @@ import org.koin.dsl.module
 val appModule : Module = module {
     single<DataStore> { DataStore.getInstance(context = get()) }
     single<AdsCoreManager> { AdsCoreManager(context = get() , get()) }
-    single { KtorClient().createClient() }
+    single { KtorClient().createClient(isDebug = BuildConfig.DEBUG) }
 
     single<List<String>>(qualifier = named(name = "startup_entries")) {
         get<Context>().resources.getStringArray(R.array.preference_startup_entries).toList()

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/client/KtorClient.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/client/KtorClient.kt
@@ -1,10 +1,15 @@
 package com.d4rk.android.libs.apptoolkit.data.client
 
+import android.util.Log
+import com.d4rk.android.libs.apptoolkit.BuildConfig
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.android.Android
 import io.ktor.client.plugins.DefaultRequest
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
+import io.ktor.client.plugins.logging.LogLevel
+import io.ktor.client.plugins.logging.Logger
+import io.ktor.client.plugins.logging.Logging
 import io.ktor.client.request.accept
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
@@ -22,6 +27,19 @@ class KtorClient {
     private val requestTimeout : Long = 10_000L
 
     /**
+     * Logs a network message when debugging is enabled.
+     */
+    private fun log(message: String, throwable: Throwable? = null) {
+        if (BuildConfig.DEBUG) {
+            if (throwable != null) {
+                Log.d("KtorClient", message, throwable)
+            } else {
+                Log.d("KtorClient", message)
+            }
+        }
+    }
+
+    /**
      * Creates and configures an [HttpClient] for making network requests.
      *
      * This function sets up the client with the following:
@@ -32,8 +50,18 @@ class KtorClient {
      *
      * @return An [HttpClient] instance ready for use.
      */
-    fun createClient() : HttpClient {
+    fun createClient(isDebug: Boolean = false) : HttpClient {
         return HttpClient(engineFactory = Android) {
+            if (isDebug) {
+                install(plugin = Logging) {
+                    logger = object : Logger {
+                        override fun log(message: String) {
+                            log(message)
+                        }
+                    }
+                    level = LogLevel.ALL
+                }
+            }
             install(plugin = ContentNegotiation) {
                 json(json = Json {
                     prettyPrint = true

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/core/BaseCoreManager.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/core/BaseCoreManager.kt
@@ -5,6 +5,7 @@ import android.app.Application
 import android.os.Bundle
 import androidx.lifecycle.LifecycleObserver
 import androidx.multidex.MultiDexApplication
+import com.d4rk.android.libs.apptoolkit.BuildConfig
 import com.d4rk.android.libs.apptoolkit.data.client.KtorClient
 import io.ktor.client.HttpClient
 import kotlinx.coroutines.CoroutineScope
@@ -44,7 +45,7 @@ open class BaseCoreManager : MultiDexApplication() , Application.ActivityLifecyc
 
     private fun initializeKtorClient() {
         runCatching {
-            ktorClient = KtorClient().createClient()
+            ktorClient = KtorClient().createClient(isDebug = BuildConfig.DEBUG)
         }
     }
 


### PR DESCRIPTION
## Summary
- wire up `KtorClient` with optional debug logging
- feed the debug flag from `AppModule` and `BaseCoreManager`

## Testing
- `./gradlew assembleDebug` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869340b7dc0832da7f7def01eca79db