### PR TITLE
Fix flaky FavoriteAppsViewModel test

### DIFF
--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModel.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModel.kt
@@ -141,6 +141,9 @@ class TestFavoriteAppsViewModel : TestFavoriteAppsViewModelBase() {
         val favorites = MutableSharedFlow<Set<String>>(replay = 1).apply { tryEmit(setOf("pkg")) }
         setup(fetchFlow = shared, testDispatcher = dispatcherExtension.testDispatcher, favoritesFlow = favorites)
 
+        // allow view model initialization to complete before emitting values
+        dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
+
         // initial list contains the app
         shared.emit(DataState.Success(listOf(AppInfo("App", "pkg", "url"))))
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()


### PR DESCRIPTION
## Summary
- wait for initial coroutine setup in `toggle favorite after removal`

## Testing
- `./gradlew :app:testDebugUnitTest --tests "com.d4rk.android.apps.apptoolkit.app.apps.favorites.TestFavoriteAppsViewModel.toggle favorite after removal" --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686949bac9f0832d9048d9bfc8a6d1d5