### PR TITLE
Fix AppsListViewModel toggle error handling

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListViewModel.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListViewModel.kt
@@ -66,6 +66,12 @@ class AppsListViewModel(
     }
 
     fun toggleFavorite(packageName: String) {
-        launch(context = dispatcherProvider.io) { dataStore.toggleFavoriteApp(packageName) }
+        launch(context = dispatcherProvider.io) {
+            try {
+                dataStore.toggleFavoriteApp(packageName)
+            } catch (_: Throwable) {
+                // Swallow the exception to keep favorites unchanged on failure
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- ignore datastore toggle errors in AppsListViewModel

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68694b779c64832da5916d8d826bf7c8