### PR TITLE
Fix snackbar timestamp generation in AboutViewModel

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/ui/AboutViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/ui/AboutViewModel.kt
@@ -30,9 +30,14 @@ open class AboutViewModel(private val dispatcherProvider : DispatcherProvider) :
         updateUi {
             copy(showDeviceInfoCopiedSnackbar = true)
         }
-        screenState.showSnackbar<UiAboutScreen>(snackbar = UiSnackbar(message = UiTextHelper.StringResource(
-            resourceId = R.string.snack_device_info_copied
-        ) , isError = false , timeStamp = System.currentTimeMillis() , type = ScreenMessageType.SNACKBAR))
+        screenState.showSnackbar<UiAboutScreen>(
+            snackbar = UiSnackbar(
+                message = UiTextHelper.StringResource(resourceId = R.string.snack_device_info_copied),
+                isError = false,
+                timeStamp = System.nanoTime(),
+                type = ScreenMessageType.SNACKBAR
+            )
+        )
     }
 
     private inline fun updateUi(crossinline transform : UiAboutScreen.() -> UiAboutScreen) {


### PR DESCRIPTION
## Summary
- update timestamp used for copy device info snackbar to use `System.nanoTime`

## Testing
- `./gradlew :apptoolkit:testDebugUnitTest --tests "com.d4rk.android.libs.apptoolkit.app.about.ui.TestAboutViewModel.repeated copy events show snackbar each time" --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68696c277e10832d816898d78c71192c