### PR TITLE
Fix loading state and clear errors in ViewModel

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/GeneralSettingsViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/GeneralSettingsViewModel.kt
@@ -13,6 +13,7 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.updateData
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.updateState
 import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
+import kotlinx.coroutines.yield
 
 class GeneralSettingsViewModel : ScreenViewModel<UiGeneralSettingsScreen , GeneralSettingsEvent , GeneralSettingsAction>(initialState = UiStateScreen(data = UiGeneralSettingsScreen())) {
 
@@ -25,7 +26,12 @@ class GeneralSettingsViewModel : ScreenViewModel<UiGeneralSettingsScreen , Gener
     private fun loadContent(contentKey : String?) {
         launch {
             screenState.setLoading()
+            // ensure a state observation of Loading before processing result
+            yield()
+
             if (! contentKey.isNullOrBlank()) {
+                // clear previous errors on successful load
+                screenState.setErrors(errors = emptyList())
                 screenState.updateData(newState = ScreenState.Success()) { current : UiGeneralSettingsScreen ->
                     current.copy(contentKey = contentKey)
                 }


### PR DESCRIPTION
## Summary
- ensure `GeneralSettingsViewModel` exposes a loading state before processing data
- clear any previous errors once content loads successfully

## Testing
- `./gradlew :apptoolkit:testDebugUnitTest --info` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68696fbae3ec832da349ded69dee71dd