### PR TITLE
Fix dispatcher in tests

### DIFF
--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/MainDispatcherExtension.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/MainDispatcherExtension.kt
@@ -3,7 +3,7 @@ package com.d4rk.android.libs.apptoolkit.core
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.TestDispatcher
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.setMain
 import org.junit.jupiter.api.extension.AfterEachCallback
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.extension.ExtensionContext
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class MainDispatcherExtension : BeforeEachCallback, AfterEachCallback {
-    val testDispatcher: TestDispatcher = UnconfinedTestDispatcher()
+    val testDispatcher: TestDispatcher = StandardTestDispatcher()
 
     override fun beforeEach(context: ExtensionContext?) {
         Dispatchers.setMain(testDispatcher)


### PR DESCRIPTION
## Summary
- use `StandardTestDispatcher` in library tests so loading state is observable

## Testing
- `./gradlew test --no-build-cache` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869714e3bc0832da6015ef97f89c5eb