### PR TITLE
Fix flaky SupportViewModel unit tests

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportViewModel.kt
@@ -10,13 +10,26 @@ import com.d4rk.android.libs.apptoolkit.app.support.domain.usecases.QueryProduct
 import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Errors
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiSnackbar
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.applyResult
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.setErrors
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.updateState
 import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.yield
 
-class SupportViewModel(private val queryProductDetailsUseCase : QueryProductDetailsUseCase , private val dispatcherProvider : DispatcherProvider) : ScreenViewModel<UiSupportScreen , SupportEvent , SupportAction>(initialState = UiStateScreen(data = UiSupportScreen())) {
+class SupportViewModel(
+    private val queryProductDetailsUseCase : QueryProductDetailsUseCase,
+    private val dispatcherProvider : DispatcherProvider
+) : ScreenViewModel<UiSupportScreen , SupportEvent , SupportAction>(
+    initialState = UiStateScreen(data = UiSupportScreen())
+) {
+
+    private var queryJob: Job? = null
 
     override fun onEvent(event : SupportEvent) {
         when (event) {
@@ -25,11 +38,26 @@ class SupportViewModel(private val queryProductDetailsUseCase : QueryProductDeta
     }
 
     private fun queryProductDetails(billingClient : BillingClient) {
-        launch(context = dispatcherProvider.io) {
-            queryProductDetailsUseCase(billingClient).flowOn(dispatcherProvider.default).collect { result : DataState<Map<String , ProductDetails> , Errors> ->
-                screenState.applyResult(result = result , errorMessage = UiTextHelper.StringResource(R.string.error_failed_to_load_sku_details)) { productMap , current ->
-                    current.copy(productDetails = productMap)
-                }
+        queryJob?.cancel()
+        queryJob = launch(context = dispatcherProvider.io) {
+            screenState.updateState(ScreenState.IsLoading())
+            // ensure observers see the loading state before work continues
+            yield()
+
+            try {
+                queryProductDetailsUseCase(billingClient)
+                    .flowOn(dispatcherProvider.default)
+                    .collect { result : DataState<Map<String , ProductDetails> , Errors> ->
+                        screenState.applyResult(
+                            result = result,
+                            errorMessage = UiTextHelper.StringResource(R.string.error_failed_to_load_sku_details)
+                        ) { productMap , current ->
+                            current.copy(productDetails = productMap)
+                        }
+                    }
+            } catch (throwable: Throwable) {
+                screenState.setErrors(listOf(UiSnackbar(message = UiTextHelper.StringResource(R.string.error_failed_to_load_sku_details))))
+                screenState.updateState(ScreenState.Error())
             }
         }
     }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/support/ui/TestSupportViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/support/ui/TestSupportViewModel.kt
@@ -104,6 +104,7 @@ class TestSupportViewModel : TestSupportViewModelBase() {
             awaitItem()
 
             viewModel.onEvent(SupportEvent.QueryProductDetails(billingClient))
+            dispatcherExtension.testDispatcher.scheduler.runCurrent()
             // second loading
             assertTrue(awaitItem().screenState is ScreenState.IsLoading)
             dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
@@ -138,6 +139,7 @@ class TestSupportViewModel : TestSupportViewModelBase() {
             assertTrue(awaitItem().screenState is ScreenState.Error)
 
             viewModel.onEvent(SupportEvent.QueryProductDetails(billingClient))
+            dispatcherExtension.testDispatcher.scheduler.runCurrent()
             assertTrue(awaitItem().screenState is ScreenState.IsLoading)
             dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
             assertTrue(awaitItem().screenState is ScreenState.Success)
@@ -191,9 +193,14 @@ class TestSupportViewModel : TestSupportViewModelBase() {
         setup(flow = emptyFlow, testDispatcher = dispatcherExtension.testDispatcher)
         coEvery { useCase.invoke(any()) } throws IllegalStateException("bad client")
 
-        assertFailsWith<IllegalStateException> {
+        viewModel.uiState.test {
             viewModel.onEvent(SupportEvent.QueryProductDetails(billingClient))
+            awaitItem() // initial
+            dispatcherExtension.testDispatcher.scheduler.runCurrent()
+            assertTrue(awaitItem().screenState is ScreenState.IsLoading)
             dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
+            assertTrue(awaitItem().screenState is ScreenState.Error)
+            cancelAndIgnoreRemainingEvents()
         }
     }
 }


### PR DESCRIPTION
## Summary
- stabilize query product details retry scenarios
- catch exceptions in SupportViewModel and emit error state
- verify billing client exception path via screen state flow

## Testing
- `./gradlew :apptoolkit:testDebugUnitTest --tests com.d4rk.android.libs.apptoolkit.app.support.ui.TestSupportViewModel` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68697624c420832d8a9970d0647cc657