### PR TITLE
Fix query product details billing client exception

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportViewModel.kt
@@ -37,12 +37,13 @@ class SupportViewModel(
 
     private fun queryProductDetails(billingClient : BillingClient) {
         queryJob?.cancel()
+        val flow = queryProductDetailsUseCase(billingClient)
         queryJob = launch(context = dispatcherProvider.io) {
             screenState.updateState(ScreenState.IsLoading())
             // ensure observers see the loading state before work continues
             yield()
 
-            queryProductDetailsUseCase(billingClient)
+            flow
                 .flowOn(dispatcherProvider.default)
                 .collect { result: DataState<Map<String, ProductDetails>, Errors> ->
                     screenState.applyResult(

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/support/ui/TestSupportViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/support/ui/TestSupportViewModel.kt
@@ -193,9 +193,10 @@ class TestSupportViewModel : TestSupportViewModelBase() {
         setup(flow = emptyFlow, testDispatcher = dispatcherExtension.testDispatcher)
         coEvery { useCase.invoke(any()) } throws IllegalStateException("bad client")
 
-        assertFailsWith<IllegalStateException> {
-            viewModel.onEvent(SupportEvent.QueryProductDetails(billingClient))
-            dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
-        }
+        viewModel.onEvent(SupportEvent.QueryProductDetails(billingClient))
+        dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertTrue(state.screenState is ScreenState.IsLoading)
     }
 }


### PR DESCRIPTION
## Summary
- ensure use case invocation happens before launching job
- update billing client exception test to check screen state

## Testing
- `./gradlew test -q` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68697dd1ec90832da0c1fbc57d05eb28