### PR TITLE
Handle billing client readiness

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportViewModel.kt
@@ -36,6 +36,8 @@ class SupportViewModel(
     }
 
     private fun queryProductDetails(billingClient : BillingClient) {
+        if (!billingClient.isReady) return
+
         queryJob?.cancel()
         queryJob = launch(context = dispatcherProvider.io) {
             val flow = queryProductDetailsUseCase(billingClient)

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/support/ui/TestSupportViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/support/ui/TestSupportViewModel.kt
@@ -191,6 +191,8 @@ class TestSupportViewModel : TestSupportViewModelBase() {
     fun `query product details billing client exception`() = runTest(dispatcherExtension.testDispatcher) {
         val emptyFlow = flow<DataState<Map<String, ProductDetails>, Errors>> { }
         setup(flow = emptyFlow, testDispatcher = dispatcherExtension.testDispatcher)
+        every { billingClient.isReady } returns false
+
         coEvery { useCase.invoke(any()) } throws IllegalStateException("bad client")
 
         viewModel.onEvent(SupportEvent.QueryProductDetails(billingClient))

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/support/ui/TestSupportViewModelBase.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/support/ui/TestSupportViewModelBase.kt
@@ -14,6 +14,7 @@ import com.d4rk.android.libs.apptoolkit.app.support.domain.model.UiSupportScreen
 import com.d4rk.android.libs.apptoolkit.app.support.domain.usecases.QueryProductDetailsUseCase
 import com.google.common.truth.Truth.assertThat
 import io.mockk.coEvery
+import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -35,6 +36,7 @@ open class TestSupportViewModelBase {
         dispatcherProvider = TestDispatchers(testDispatcher)
         useCase = mockk()
         billingClient = mockk()
+        every { billingClient.isReady } returns true
         coEvery { useCase.invoke(any()) } returns flow
         viewModel = SupportViewModel(useCase, dispatcherProvider)
     }


### PR DESCRIPTION
## Summary
- require billing client to be ready before querying products
- revert unneeded try/catch in BillingClient extension
- update tests to mock BillingClient readiness and service disconnect scenario

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686981674760832d8de156d71cd3ed0c