### PR TITLE
Refactor Support screen ViewModel

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/billing/BillingRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/billing/BillingRepository.kt
@@ -12,6 +12,7 @@ import com.android.billingclient.api.ProductDetails
 import com.android.billingclient.api.Purchase
 import com.android.billingclient.api.PurchasesUpdatedListener
 import com.android.billingclient.api.QueryProductDetailsParams
+import com.android.billingclient.api.PendingPurchasesParams
 import com.android.billingclient.api.QueryPurchasesParams
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -50,7 +51,7 @@ class BillingRepository private constructor(private val context: Context) : Purc
     init {
         billingClient = BillingClient.newBuilder(context)
             .setListener(this)
-            .enablePendingPurchases()
+            .enablePendingPurchases(PendingPurchasesParams.newBuilder().build())
             .enableAutoServiceReconnection()
             .build()
 
@@ -117,7 +118,7 @@ class BillingRepository private constructor(private val context: Context) : Purc
         }
     }
 
-    suspend fun queryProductDetails(productIds: List<String>) {
+    fun queryProductDetails(productIds: List<String>) {
         val products = productIds.map {
             QueryProductDetailsParams.Product.newBuilder()
                 .setProductId(it)

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/billing/SupportScreenUiState.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/billing/SupportScreenUiState.kt
@@ -3,7 +3,6 @@ package com.d4rk.android.libs.apptoolkit.app.support.billing
 import com.android.billingclient.api.ProductDetails
 
 data class SupportScreenUiState(
-    val isLoading: Boolean = false,
     val error: String? = null,
     val products: List<ProductDetails> = emptyList()
 )

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/domain/actions/SupportEvent.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/domain/actions/SupportEvent.kt
@@ -5,4 +5,5 @@ import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.UiEvent
 
 sealed interface SupportEvent : UiEvent {
     data class QueryProductDetails(val billingClient : BillingClient) : SupportEvent
+    data object DismissSnackbar : SupportEvent
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportScreen.kt
@@ -23,10 +23,10 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberSnackbarHostState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
@@ -55,7 +55,7 @@ fun SupportComposable(
     adsConfig: AdsConfig = koinInject(qualifier = named(name = "banner_medium_rectangle"))
 ) {
     val screenState: UiStateScreen<SupportScreenUiState> by viewModel.uiState.collectAsState()
-    val snackbarHostState: SnackbarHostState = rememberSnackbarHostState()
+    val snackbarHostState: SnackbarHostState = remember { SnackbarHostState() }
 
     LargeTopAppBarWithScaffold(
         title = stringResource(id = R.string.support_us),
@@ -261,5 +261,7 @@ fun SupportScreenContent(
                             )
                         }
                     }
+            }
+        }
     }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportScreen.kt
@@ -21,12 +21,10 @@ import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
-import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberSnackbarHostState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
@@ -34,15 +32,18 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import com.d4rk.android.libs.apptoolkit.R
-import com.d4rk.android.libs.apptoolkit.app.support.billing.PurchaseResult
 import com.d4rk.android.libs.apptoolkit.app.support.billing.SupportScreenUiState
+import com.d4rk.android.libs.apptoolkit.app.support.domain.actions.SupportEvent
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
 import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.AdBanner
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
 import com.d4rk.android.libs.apptoolkit.core.ui.components.navigation.LargeTopAppBarWithScaffold
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.ButtonIconSpacer
+import com.d4rk.android.libs.apptoolkit.core.ui.components.snackbar.DefaultSnackbarHandler
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.IntentsHelper
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import org.koin.compose.koinInject
 import org.koin.core.qualifier.named
 
@@ -53,25 +54,8 @@ fun SupportComposable(
     activity: Activity,
     adsConfig: AdsConfig = koinInject(qualifier = named(name = "banner_medium_rectangle"))
 ) {
-    val state: SupportScreenUiState by viewModel.uiState.collectAsState()
+    val screenState: UiStateScreen<SupportScreenUiState> by viewModel.uiState.collectAsState()
     val snackbarHostState: SnackbarHostState = rememberSnackbarHostState()
-
-    LaunchedEffect(Unit) {
-        viewModel.purchaseResult.collect { result ->
-            when (result) {
-                PurchaseResult.Pending -> snackbarHostState.showSnackbar(
-                    message = stringResource(id = R.string.purchase_pending)
-                )
-                PurchaseResult.Success -> snackbarHostState.showSnackbar(
-                    message = stringResource(id = R.string.purchase_thank_you)
-                )
-                is PurchaseResult.Failed -> snackbarHostState.showSnackbar(result.error)
-                PurchaseResult.UserCancelled -> snackbarHostState.showSnackbar(
-                    message = stringResource(id = R.string.purchase_cancelled)
-                )
-            }
-        }
-    }
 
     LargeTopAppBarWithScaffold(
         title = stringResource(id = R.string.support_us),
@@ -81,9 +65,15 @@ fun SupportComposable(
         SupportScreenContent(
             paddingValues = paddingValues,
             activity = activity,
-            state = state,
+            screenState = screenState,
             adsConfig = adsConfig,
             viewModel = viewModel
+        )
+        DefaultSnackbarHandler(
+            screenState = screenState,
+            snackbarHostState = snackbarHostState,
+            getDismissEvent = { SupportEvent.DismissSnackbar },
+            onEvent = { viewModel.onEvent(it) }
         )
     }
 }
@@ -92,12 +82,13 @@ fun SupportComposable(
 fun SupportScreenContent(
     paddingValues: PaddingValues,
     activity: Activity,
-    state: SupportScreenUiState,
+    screenState: UiStateScreen<SupportScreenUiState>,
     adsConfig: AdsConfig,
     viewModel: SupportViewModel
 ) {
     val view: View = LocalView.current
     val context: Context = LocalContext.current
+    val state = screenState.data ?: SupportScreenUiState()
     val productDetailsMap = state.products.associateBy { it.productId }
 
     Box(
@@ -106,12 +97,12 @@ fun SupportScreenContent(
             .fillMaxHeight()
     ) {
         when {
-            state.isLoading -> {
+            screenState.screenState is ScreenState.IsLoading -> {
                 androidx.compose.material3.CircularProgressIndicator(
                     modifier = Modifier.align(Alignment.Center)
                 )
             }
-            state.error != null -> {
+            screenState.screenState is ScreenState.Error && state.error != null -> {
                 Text(
                     text = state.error,
                     modifier = Modifier

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportViewModel.kt
@@ -31,8 +31,6 @@ class SupportViewModel(
     )
 ) {
 
-    val purchaseResult = billingRepository.purchaseResult
-
     init {
         launch(dispatcherProvider.io) {
             billingRepository.productDetails.collectLatest { map ->

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportViewModel.kt
@@ -1,48 +1,95 @@
 package com.d4rk.android.libs.apptoolkit.app.support.ui
 
 import android.app.Activity
-import androidx.lifecycle.ViewModel
-import androidx.lifecycle.viewModelScope
 import com.android.billingclient.api.ProductDetails
 import com.d4rk.android.libs.apptoolkit.app.support.billing.BillingRepository
 import com.d4rk.android.libs.apptoolkit.app.support.billing.PurchaseResult
 import com.d4rk.android.libs.apptoolkit.app.support.billing.SupportScreenUiState
+import com.d4rk.android.libs.apptoolkit.app.support.domain.actions.SupportAction
+import com.d4rk.android.libs.apptoolkit.app.support.domain.actions.SupportEvent
 import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiSnackbar
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.dismissSnackbar
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.showSnackbar
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.updateData
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.updateState
+import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.ScreenMessageType
+import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.flow.update
 
 class SupportViewModel(
     private val billingRepository: BillingRepository,
     private val dispatcherProvider: DispatcherProvider
-) : ViewModel() {
+) : ScreenViewModel<SupportScreenUiState, SupportEvent, SupportAction>(
+    initialState = UiStateScreen(
+        screenState = ScreenState.IsLoading(),
+        data = SupportScreenUiState()
+    )
+) {
 
     val purchaseResult = billingRepository.purchaseResult
 
-    private val _uiState = MutableStateFlow(SupportScreenUiState(isLoading = true))
-    val uiState: StateFlow<SupportScreenUiState> = _uiState.asStateFlow()
-
     init {
-        viewModelScope.launch(dispatcherProvider.io) {
+        launch(dispatcherProvider.io) {
             billingRepository.productDetails.collectLatest { map ->
-                _uiState.update { current ->
-                    current.copy(isLoading = false, error = null, products = map.values.toList())
+                screenState.updateData(newState = ScreenState.Success()) { current ->
+                    current.copy(error = null, products = map.values.toList())
                 }
             }
         }
 
-        viewModelScope.launch {
+        launch {
             billingRepository.purchaseResult.collectLatest { result ->
-                if (result is PurchaseResult.Failed) {
-                    _uiState.update { it.copy(isLoading = false, error = result.error) }
+                when (result) {
+                    PurchaseResult.Pending -> screenState.showSnackbar(
+                        UiSnackbar(
+                            message = UiTextHelper.StringResource(R.string.purchase_pending),
+                            isError = false,
+                            timeStamp = System.currentTimeMillis(),
+                            type = ScreenMessageType.SNACKBAR
+                        )
+                    )
+
+                    PurchaseResult.Success -> screenState.showSnackbar(
+                        UiSnackbar(
+                            message = UiTextHelper.StringResource(R.string.purchase_thank_you),
+                            isError = false,
+                            timeStamp = System.currentTimeMillis(),
+                            type = ScreenMessageType.SNACKBAR
+                        )
+                    )
+
+                    is PurchaseResult.Failed -> {
+                        screenState.updateData(newState = ScreenState.Error()) { current ->
+                            current.copy(error = result.error)
+                        }
+                        screenState.showSnackbar(
+                            UiSnackbar(
+                                message = UiTextHelper.DynamicString(result.error),
+                                isError = true,
+                                timeStamp = System.currentTimeMillis(),
+                                type = ScreenMessageType.SNACKBAR
+                            )
+                        )
+                    }
+
+                    PurchaseResult.UserCancelled -> screenState.showSnackbar(
+                        UiSnackbar(
+                            message = UiTextHelper.StringResource(R.string.purchase_cancelled),
+                            isError = false,
+                            timeStamp = System.currentTimeMillis(),
+                            type = ScreenMessageType.SNACKBAR
+                        )
+                    )
                 }
             }
         }
 
-        viewModelScope.launch(dispatcherProvider.io) {
+        launch(dispatcherProvider.io) {
             billingRepository.queryProductDetails(
                 listOf(
                     "low_donation",
@@ -51,6 +98,23 @@ class SupportViewModel(
                     "extreme_donation"
                 )
             )
+        }
+    }
+
+    override fun onEvent(event: SupportEvent) {
+        when (event) {
+            is SupportEvent.QueryProductDetails -> launch(dispatcherProvider.io) {
+                billingRepository.queryProductDetails(
+                    listOf(
+                        "low_donation",
+                        "normal_donation",
+                        "high_donation",
+                        "extreme_donation"
+                    )
+                )
+            }
+
+            SupportEvent.DismissSnackbar -> screenState.dismissSnackbar()
         }
     }
 


### PR DESCRIPTION
## Summary
- adopt `ScreenViewModel` for `SupportViewModel`
- add snackbar dismissal event and hook `SupportScreen` into `DefaultSnackbarHandler`
- move loading/error flags into `ScreenState`

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*
- `./gradlew assembleDebug --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6869aaa56c0c832d906441eb83e94c94