### PR TITLE
Fix support screen BillingClient setup

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/billing/BillingRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/billing/BillingRepository.kt
@@ -35,7 +35,12 @@ class BillingRepository private constructor(context: Context) : PurchasesUpdated
 
     private val billingClient: BillingClient = BillingClient.newBuilder(context)
         .setListener(this)
-        .enablePendingPurchases(PendingPurchasesParams.newBuilder().build())
+        .enablePendingPurchases(
+            PendingPurchasesParams
+                .newBuilder()
+                .enableOneTimeProducts()
+                .build()
+        )
         .enableAutoServiceReconnection()
         .build()
 


### PR DESCRIPTION
## Summary
- enable one-time products when setting up BillingClient

## Testing
- `./gradlew :app:testDebugUnitTest --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a21153c20832d91b6d3de545f9f37