### PR TITLE
Define constants for donation product IDs

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportScreen.kt
@@ -33,6 +33,7 @@ import androidx.compose.ui.res.stringResource
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.support.billing.SupportScreenUiState
 import com.d4rk.android.libs.apptoolkit.app.support.domain.actions.SupportEvent
+import com.d4rk.android.libs.apptoolkit.app.support.utils.constants.DonationProductIds
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.AdBanner
@@ -136,7 +137,7 @@ fun SupportScreenContent(
                                     .bounceClick(),
                                 onClick = {
                                     view.playSoundEffect(SoundEffectConstants.CLICK)
-                                    productDetailsMap["low_donation"]?.let { viewModel.onDonateClicked(activity, it) }
+                                    productDetailsMap[DonationProductIds.LOW_DONATION]?.let { viewModel.onDonateClicked(activity, it) }
                                 }
                             ) {
                                 Icon(
@@ -145,7 +146,7 @@ fun SupportScreenContent(
                                     modifier = Modifier.size(SizeConstants.ButtonIconSize)
                                 )
                                 ButtonIconSpacer()
-                                Text(text = productDetailsMap["low_donation"]?.oneTimePurchaseOfferDetails?.formattedPrice ?: "")
+                                Text(text = productDetailsMap[DonationProductIds.LOW_DONATION]?.oneTimePurchaseOfferDetails?.formattedPrice ?: "")
                             }
                         }
                         item {
@@ -155,7 +156,7 @@ fun SupportScreenContent(
                                     .bounceClick(),
                                 onClick = {
                                     view.playSoundEffect(SoundEffectConstants.CLICK)
-                                    productDetailsMap["normal_donation"]?.let { viewModel.onDonateClicked(activity, it) }
+                                    productDetailsMap[DonationProductIds.NORMAL_DONATION]?.let { viewModel.onDonateClicked(activity, it) }
                                 }
                             ) {
                                 Icon(
@@ -164,7 +165,7 @@ fun SupportScreenContent(
                                     modifier = Modifier.size(SizeConstants.ButtonIconSize)
                                 )
                                 ButtonIconSpacer()
-                                Text(text = productDetailsMap["normal_donation"]?.oneTimePurchaseOfferDetails?.formattedPrice ?: "")
+                                Text(text = productDetailsMap[DonationProductIds.NORMAL_DONATION]?.oneTimePurchaseOfferDetails?.formattedPrice ?: "")
                             }
                         }
                     }
@@ -181,7 +182,7 @@ fun SupportScreenContent(
                                     .bounceClick(),
                                 onClick = {
                                     view.playSoundEffect(SoundEffectConstants.CLICK)
-                                    productDetailsMap["high_donation"]?.let { viewModel.onDonateClicked(activity, it) }
+                                    productDetailsMap[DonationProductIds.HIGH_DONATION]?.let { viewModel.onDonateClicked(activity, it) }
                                 }
                             ) {
                                 Icon(
@@ -190,7 +191,7 @@ fun SupportScreenContent(
                                     modifier = Modifier.size(SizeConstants.ButtonIconSize)
                                 )
                                 ButtonIconSpacer()
-                                Text(text = productDetailsMap["high_donation"]?.oneTimePurchaseOfferDetails?.formattedPrice ?: "")
+                                Text(text = productDetailsMap[DonationProductIds.HIGH_DONATION]?.oneTimePurchaseOfferDetails?.formattedPrice ?: "")
                             }
                         }
                         item {
@@ -200,7 +201,7 @@ fun SupportScreenContent(
                                     .bounceClick(),
                                 onClick = {
                                     view.playSoundEffect(SoundEffectConstants.CLICK)
-                                    productDetailsMap["extreme_donation"]?.let { viewModel.onDonateClicked(activity, it) }
+                                    productDetailsMap[DonationProductIds.EXTREME_DONATION]?.let { viewModel.onDonateClicked(activity, it) }
                                 }
                             ) {
                                 Icon(
@@ -209,7 +210,7 @@ fun SupportScreenContent(
                                     modifier = Modifier.size(SizeConstants.ButtonIconSize)
                                 )
                                 ButtonIconSpacer()
-                                Text(text = productDetailsMap["extreme_donation"]?.oneTimePurchaseOfferDetails?.formattedPrice ?: "")
+                                Text(text = productDetailsMap[DonationProductIds.EXTREME_DONATION]?.oneTimePurchaseOfferDetails?.formattedPrice ?: "")
                             }
                         }
                     }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportViewModel.kt
@@ -17,6 +17,7 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.showSnackbar
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.updateData
 import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.ScreenMessageType
+import com.d4rk.android.libs.apptoolkit.app.support.utils.constants.DonationProductIds
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
 import kotlinx.coroutines.flow.collectLatest
 
@@ -89,10 +90,10 @@ class SupportViewModel(
         launch(dispatcherProvider.io) {
             billingRepository.queryProductDetails(
                 listOf(
-                    "low_donation",
-                    "normal_donation",
-                    "high_donation",
-                    "extreme_donation"
+                    DonationProductIds.LOW_DONATION,
+                    DonationProductIds.NORMAL_DONATION,
+                    DonationProductIds.HIGH_DONATION,
+                    DonationProductIds.EXTREME_DONATION
                 )
             )
         }
@@ -103,10 +104,10 @@ class SupportViewModel(
             is SupportEvent.QueryProductDetails -> launch(dispatcherProvider.io) {
                 billingRepository.queryProductDetails(
                     listOf(
-                        "low_donation",
-                        "normal_donation",
-                        "high_donation",
-                        "extreme_donation"
+                        DonationProductIds.LOW_DONATION,
+                        DonationProductIds.NORMAL_DONATION,
+                        DonationProductIds.HIGH_DONATION,
+                        DonationProductIds.EXTREME_DONATION
                     )
                 )
             }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/utils/constants/DonationProductIds.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/utils/constants/DonationProductIds.kt
@@ -1,0 +1,11 @@
+package com.d4rk.android.libs.apptoolkit.app.support.utils.constants
+
+/**
+ * Constant values for donation in-app product IDs.
+ */
+object DonationProductIds {
+    const val LOW_DONATION = "low_donation"
+    const val NORMAL_DONATION = "normal_donation"
+    const val HIGH_DONATION = "high_donation"
+    const val EXTREME_DONATION = "extreme_donation"
+}


### PR DESCRIPTION
## Summary
- centralize donation product IDs in `DonationProductIds`
- use constants in `SupportViewModel` and `SupportScreen`

## Testing
- `./gradlew test --no-daemon` *(fails: Android publication misconfigured)*

------
https://chatgpt.com/codex/tasks/task_e_686b3662f010832da525058cd077a9c8