### PR TITLE
Add purchase message translations

### DIFF
--- a/apptoolkit/src/main/res/values-ar-rEG/strings.xml
+++ b/apptoolkit/src/main/res/values-ar-rEG/strings.xml
@@ -279,4 +279,7 @@
     <string name="non_paid_support">دعم غير مدفوع</string>
     <string name="web_ad">إعلان ويب</string>
     <string name="error_failed_to_load_sku_details">فشل تحميل تفاصيل SKU</string>
+    <string name="purchase_pending">تتم معالجة تبرعك بواسطة Google. سوف نعلمك عند اكتماله. شكرًا لك!</string>
+    <string name="purchase_thank_you">شكرا لك على تبرعك!</string>
+    <string name="purchase_cancelled">الشراء تم إلغاؤه</string>
 </resources>

--- a/apptoolkit/src/main/res/values-bg-rBG/strings.xml
+++ b/apptoolkit/src/main/res/values-bg-rBG/strings.xml
@@ -279,4 +279,7 @@
     <string name="non_paid_support">Безплатна подкрепа</string>
     <string name="web_ad">Уеб реклама</string>
     <string name="error_failed_to_load_sku_details">Неуспешно зареждане на SKU детайли</string>
+    <string name="purchase_pending">Вашето дарение се обработва от Google. Ще ви уведомим, когато приключи. Благодаря ти!</string>
+    <string name="purchase_thank_you">Благодаря ви за дарението!</string>
+    <string name="purchase_cancelled">Покупка отменена</string>
 </resources>

--- a/apptoolkit/src/main/res/values-bn-rBD/strings.xml
+++ b/apptoolkit/src/main/res/values-bn-rBD/strings.xml
@@ -279,4 +279,7 @@
     <string name="non_paid_support">নন-পেইড সাপোর্ট</string>
     <string name="web_ad">ওয়েব বিজ্ঞাপন</string>
     <string name="error_failed_to_load_sku_details">SKU বিবরণ লোড করতে ব্যর্থ</string>
+    <string name="purchase_pending">আপনার অনুদান গুগল দ্বারা প্রক্রিয়া করা হচ্ছে। এটি সম্পূর্ণ হলে আমরা আপনাকে অবহিত করব। আপনাকে ধন্যবাদ!</string>
+    <string name="purchase_thank_you">আপনার অনুদানের জন্য আপনাকে ধন্যবাদ!</string>
+    <string name="purchase_cancelled">ক্রয় বাতিল</string>
 </resources>

--- a/apptoolkit/src/main/res/values-de-rDE/strings.xml
+++ b/apptoolkit/src/main/res/values-de-rDE/strings.xml
@@ -279,4 +279,7 @@
     <string name="non_paid_support">Unbezahlte Unterstützung</string>
     <string name="web_ad">Webanzeige</string>
     <string name="error_failed_to_load_sku_details">Fehler beim Laden der SKU-Details</string>
+    <string name="purchase_pending">Ihre Spende wird von Google verarbeitet. Wir werden Sie benachrichtigen, wenn es abgeschlossen ist. Danke schön!</string>
+    <string name="purchase_thank_you">Vielen Dank für Ihre Spende!</string>
+    <string name="purchase_cancelled">Kauf storniert</string>
 </resources>

--- a/apptoolkit/src/main/res/values-es-rGQ/strings.xml
+++ b/apptoolkit/src/main/res/values-es-rGQ/strings.xml
@@ -279,4 +279,7 @@
     <string name="non_paid_support">Soporte sin pago</string>
     <string name="web_ad">Anuncio web</string>
     <string name="error_failed_to_load_sku_details">Error al cargar los detalles del SKU</string>
+    <string name="purchase_pending">Google procesa su donación. Te notificaremos cuando esté completo. ¡Gracias!</string>
+    <string name="purchase_thank_you">¡Gracias por tu donación!</string>
+    <string name="purchase_cancelled">Compra cancelada</string>
 </resources>

--- a/apptoolkit/src/main/res/values-es-rMX/strings.xml
+++ b/apptoolkit/src/main/res/values-es-rMX/strings.xml
@@ -279,4 +279,7 @@
     <string name="non_paid_support">Soporte gratuito</string>
     <string name="web_ad">Anuncio web</string>
     <string name="error_failed_to_load_sku_details">Error al cargar los detalles del SKU</string>
+    <string name="purchase_pending">Google procesa su donación. Te notificaremos cuando esté completo. ¡Gracias!</string>
+    <string name="purchase_thank_you">¡Gracias por tu donación!</string>
+    <string name="purchase_cancelled">Compra cancelada</string>
 </resources>

--- a/apptoolkit/src/main/res/values-fil-rPH/strings.xml
+++ b/apptoolkit/src/main/res/values-fil-rPH/strings.xml
@@ -279,4 +279,7 @@
     <string name="non_paid_support">Hindi Bayad na Suporta</string>
     <string name="web_ad">Web Ad</string>
     <string name="error_failed_to_load_sku_details">Nabigong i-load ang mga detalye ng SKU</string>
+    <string name="purchase_pending">Ang iyong donasyon ay pinoproseso ng Google. Sasabihan ka namin kapag kumpleto na ito. Salamat!</string>
+    <string name="purchase_thank_you">Salamat sa iyong donasyon!</string>
+    <string name="purchase_cancelled">Bumili ng kanselahin</string>
 </resources>

--- a/apptoolkit/src/main/res/values-fr-rFR/strings.xml
+++ b/apptoolkit/src/main/res/values-fr-rFR/strings.xml
@@ -279,4 +279,7 @@
     <string name="non_paid_support">Support non payant</string>
     <string name="web_ad">Publicité Web</string>
     <string name="error_failed_to_load_sku_details">Échec du chargement des détails du SKU</string>
+    <string name="purchase_pending">Votre don est traité par Google. Nous vous informerons quand il sera terminé. Merci!</string>
+    <string name="purchase_thank_you">Merci pour votre don!</string>
+    <string name="purchase_cancelled">Acheter annulé</string>
 </resources>

--- a/apptoolkit/src/main/res/values-hi-rIN/strings.xml
+++ b/apptoolkit/src/main/res/values-hi-rIN/strings.xml
@@ -279,4 +279,7 @@
     <string name="non_paid_support">गैर-भुगतान समर्थन</string>
     <string name="web_ad">वेब विज्ञापन</string>
     <string name="error_failed_to_load_sku_details">SKU विवरण लोड करने में विफल</string>
+    <string name="purchase_pending">आपका दान Google द्वारा संसाधित किया जा रहा है। जब यह पूरा हो जाएगा तो हम आपको सूचित करेंगे। धन्यवाद!</string>
+    <string name="purchase_thank_you">आपके दान के लिए शुक्रिया!</string>
+    <string name="purchase_cancelled">रद्द कर दिया गया</string>
 </resources>

--- a/apptoolkit/src/main/res/values-hu-rHU/strings.xml
+++ b/apptoolkit/src/main/res/values-hu-rHU/strings.xml
@@ -279,4 +279,7 @@
     <string name="non_paid_support">Nem fizetett támogatás</string>
     <string name="web_ad">Webes hirdetés</string>
     <string name="error_failed_to_load_sku_details">Nem sikerült betölteni az SKU részleteit</string>
+    <string name="purchase_pending">Adományát a Google dolgozza fel. Értesítjük, ha teljes. Köszönöm!</string>
+    <string name="purchase_thank_you">Köszönöm az adományt!</string>
+    <string name="purchase_cancelled">Vásárlás lemondva</string>
 </resources>

--- a/apptoolkit/src/main/res/values-in-rID/strings.xml
+++ b/apptoolkit/src/main/res/values-in-rID/strings.xml
@@ -279,4 +279,7 @@
     <string name="non_paid_support">Dukungan tidak berbayar</string>
     <string name="web_ad">Iklan web</string>
     <string name="error_failed_to_load_sku_details">Gagal memuat detail SKU</string>
+    <string name="purchase_pending">Donasi Anda sedang diproses oleh Google. Kami akan memberi tahu Anda saat selesai. Terima kasih!</string>
+    <string name="purchase_thank_you">Terima kasih atas donasi Anda!</string>
+    <string name="purchase_cancelled">Pembelian dibatalkan</string>
 </resources>

--- a/apptoolkit/src/main/res/values-it-rIT/strings.xml
+++ b/apptoolkit/src/main/res/values-it-rIT/strings.xml
@@ -279,4 +279,7 @@
     <string name="non_paid_support">Supporto non a pagamento</string>
     <string name="web_ad">Annuncio web</string>
     <string name="error_failed_to_load_sku_details">Impossibile caricare i dettagli dello SKU</string>
+    <string name="purchase_pending">La tua donazione viene elaborata da Google. Ti avviseremo quando sarà completo. Grazie!</string>
+    <string name="purchase_thank_you">Grazie per la tua donazione!</string>
+    <string name="purchase_cancelled">Acquista annullato</string>
 </resources>

--- a/apptoolkit/src/main/res/values-ja-rJP/strings.xml
+++ b/apptoolkit/src/main/res/values-ja-rJP/strings.xml
@@ -279,4 +279,7 @@
     <string name="non_paid_support">無償サポート</string>
     <string name="web_ad">ウェブ広告</string>
     <string name="error_failed_to_load_sku_details">SKU の詳細を読み込めませんでした</string>
+    <string name="purchase_pending">あなたの寄付はGoogleによって処理されています。完了したら通知します。ありがとう！</string>
+    <string name="purchase_thank_you">寄付ありがとうございます！</string>
+    <string name="purchase_cancelled">キャンセルされた購入</string>
 </resources>

--- a/apptoolkit/src/main/res/values-ko-rKR/strings.xml
+++ b/apptoolkit/src/main/res/values-ko-rKR/strings.xml
@@ -279,4 +279,7 @@
     <string name="non_paid_support">무료 지원</string>
     <string name="web_ad">웹 광고</string>
     <string name="error_failed_to_load_sku_details">SKU 세부 정보를 로드하지 못했습니다.</string>
+    <string name="purchase_pending">기부금은 Google에서 처리 중입니다. 완료되면 알려 드리겠습니다. 감사합니다!</string>
+    <string name="purchase_thank_you">기부해 주셔서 감사합니다!</string>
+    <string name="purchase_cancelled">구매 취소</string>
 </resources>

--- a/apptoolkit/src/main/res/values-pl-rPL/strings.xml
+++ b/apptoolkit/src/main/res/values-pl-rPL/strings.xml
@@ -279,4 +279,7 @@
     <string name="non_paid_support">Wsparcie bezpłatne</string>
     <string name="web_ad">Reklama internetowa</string>
     <string name="error_failed_to_load_sku_details">Nie udało się załadować szczegółów SKU</string>
+    <string name="purchase_pending">Twoja darowizna jest przetwarzana przez Google. Powiadomimy Cię, kiedy będzie to kompletne. Dziękuję!</string>
+    <string name="purchase_thank_you">Dziękuję za darowiznę!</string>
+    <string name="purchase_cancelled">Zakup anulowany</string>
 </resources>

--- a/apptoolkit/src/main/res/values-pt-rBR/strings.xml
+++ b/apptoolkit/src/main/res/values-pt-rBR/strings.xml
@@ -279,4 +279,7 @@
     <string name="non_paid_support">Suporte não pago</string>
     <string name="web_ad">Anúncio na web</string>
     <string name="error_failed_to_load_sku_details">Falha ao carregar os detalhes do SKU</string>
+    <string name="purchase_pending">Sua doação está sendo processada pelo Google. Nós o notificaremos quando estiver completo. Obrigado!</string>
+    <string name="purchase_thank_you">Obrigado por sua doação!</string>
+    <string name="purchase_cancelled">Compra cancelada</string>
 </resources>

--- a/apptoolkit/src/main/res/values-ro-rRO/strings.xml
+++ b/apptoolkit/src/main/res/values-ro-rRO/strings.xml
@@ -279,4 +279,7 @@
     <string name="non_paid_support">Suport neplătit</string>
     <string name="web_ad">Reclamă web</string>
     <string name="error_failed_to_load_sku_details">Nu s-au putut încărca detaliile SKU</string>
+    <string name="purchase_pending">Donația dvs. este procesată de Google. Vă vom anunța când va fi finalizat. Vă mulțumesc!</string>
+    <string name="purchase_thank_you">Vă mulțumim pentru donație!</string>
+    <string name="purchase_cancelled">Achiziția a fost anulată</string>
 </resources>

--- a/apptoolkit/src/main/res/values-ru-rRU/strings.xml
+++ b/apptoolkit/src/main/res/values-ru-rRU/strings.xml
@@ -279,4 +279,7 @@
     <string name="non_paid_support">Бесплатная поддержка</string>
     <string name="web_ad">Веб-реклама</string>
     <string name="error_failed_to_load_sku_details">Не удалось загрузить сведения о SKU</string>
+    <string name="purchase_pending">Ваше пожертвование обрабатывается Google. Мы уведомим вас, когда это будет завершено. Спасибо!</string>
+    <string name="purchase_thank_you">Спасибо за пожертвование!</string>
+    <string name="purchase_cancelled">Купить отменен</string>
 </resources>

--- a/apptoolkit/src/main/res/values-sv-rSE/strings.xml
+++ b/apptoolkit/src/main/res/values-sv-rSE/strings.xml
@@ -279,4 +279,7 @@
     <string name="non_paid_support">Obetalt stöd</string>
     <string name="web_ad">Webbannons</string>
     <string name="error_failed_to_load_sku_details">Det gick inte att läsa in SKU-detaljer</string>
+    <string name="purchase_pending">Din donation behandlas av Google. Vi kommer att meddela dig när den är klar. Tack!</string>
+    <string name="purchase_thank_you">Tack för din donation!</string>
+    <string name="purchase_cancelled">Köp avbruten</string>
 </resources>

--- a/apptoolkit/src/main/res/values-th-rTH/strings.xml
+++ b/apptoolkit/src/main/res/values-th-rTH/strings.xml
@@ -279,4 +279,7 @@
     <string name="non_paid_support">การสนับสนุนแบบไม่ชำระเงิน</string>
     <string name="web_ad">โฆษณาเว็บ</string>
     <string name="error_failed_to_load_sku_details">ไม่สามารถโหลดรายละเอียด SKU ได้</string>
+    <string name="purchase_pending">การบริจาคของคุณกำลังดำเนินการโดย Google เราจะแจ้งให้คุณทราบเมื่อเสร็จสิ้น ขอบคุณ!</string>
+    <string name="purchase_thank_you">ขอบคุณสำหรับการบริจาค!</string>
+    <string name="purchase_cancelled">การซื้อที่ถูกยกเลิก</string>
 </resources>

--- a/apptoolkit/src/main/res/values-tr-rTR/strings.xml
+++ b/apptoolkit/src/main/res/values-tr-rTR/strings.xml
@@ -279,4 +279,7 @@
     <string name="non_paid_support">Ücretsiz destek</string>
     <string name="web_ad">Web Reklamı</string>
     <string name="error_failed_to_load_sku_details">SKU ayrıntıları yüklenemedi</string>
+    <string name="purchase_pending">Bağışınız Google tarafından işleniyor. Tamamlandığında sizi bilgilendireceğiz. Teşekkür ederim!</string>
+    <string name="purchase_thank_you">Bağışınız için teşekkür ederiz!</string>
+    <string name="purchase_cancelled">Satınalma İptal edildi</string>
 </resources>

--- a/apptoolkit/src/main/res/values-uk-rUA/strings.xml
+++ b/apptoolkit/src/main/res/values-uk-rUA/strings.xml
@@ -279,4 +279,7 @@
     <string name="non_paid_support">Безкоштовна підтримка</string>
     <string name="web_ad">Веб-реклама</string>
     <string name="error_failed_to_load_sku_details">Не вдалося завантажити деталі SKU</string>
+    <string name="purchase_pending">Ваша пожертва обробляється Google. Ми повідомимо вас, коли він завершиться. Дякую!</string>
+    <string name="purchase_thank_you">Дякую за пожертву!</string>
+    <string name="purchase_cancelled">Купівля скасована</string>
 </resources>

--- a/apptoolkit/src/main/res/values-ur-rPK/strings.xml
+++ b/apptoolkit/src/main/res/values-ur-rPK/strings.xml
@@ -279,4 +279,7 @@
     <string name="non_paid_support">بغیر معاوضہ سپورٹ</string>
     <string name="web_ad">ویب اشتہار</string>
     <string name="error_failed_to_load_sku_details">SKU تفصیلات لوڈ کرنے میں ناکام</string>
+    <string name="purchase_pending">آپ کے عطیہ پر گوگل کے ذریعہ کارروائی کی جارہی ہے۔ جب یہ مکمل ہوجائے گا تو ہم آپ کو مطلع کریں گے۔ آپ کا شکریہ!</string>
+    <string name="purchase_thank_you">آپ کے عطیہ کا شکریہ!</string>
+    <string name="purchase_cancelled">خریداری منسوخ</string>
 </resources>

--- a/apptoolkit/src/main/res/values-vi-rVN/strings.xml
+++ b/apptoolkit/src/main/res/values-vi-rVN/strings.xml
@@ -279,4 +279,7 @@
     <string name="non_paid_support">Hỗ trợ không trả phí</string>
     <string name="web_ad">Quảng cáo web</string>
     <string name="error_failed_to_load_sku_details">Không thể tải chi tiết SKU</string>
+    <string name="purchase_pending">Sự đóng góp của bạn đang được Google xử lý. Chúng tôi sẽ thông báo cho bạn khi nó hoàn thành. Cảm ơn!</string>
+    <string name="purchase_thank_you">Cảm ơn bạn đã đóng góp của bạn!</string>
+    <string name="purchase_cancelled">Mua hàng bị hủy bỏ</string>
 </resources>

--- a/apptoolkit/src/main/res/values-zh-rTW/strings.xml
+++ b/apptoolkit/src/main/res/values-zh-rTW/strings.xml
@@ -279,4 +279,7 @@
     <string name="non_paid_support">非付費支持</string>
     <string name="web_ad">網頁廣告</string>
     <string name="error_failed_to_load_sku_details">載入 SKU 詳細資料失敗</string>
+    <string name="purchase_pending">您的捐款正在Google处理。完成后，我们将通知您。谢谢你！</string>
+    <string name="purchase_thank_you">谢谢您的捐款！</string>
+    <string name="purchase_cancelled">购买取消</string>
 </resources>


### PR DESCRIPTION
## Summary
- translate donation purchase messages into all supported languages

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686b383e4438832dbf2159cbb18760c6