### PR TITLE
Fix favorite toggle error handling

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsViewModel.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsViewModel.kt
@@ -99,7 +99,11 @@ class FavoriteAppsViewModel(
 
     fun toggleFavorite(packageName: String) {
         viewModelScope.launch(context = dispatcherProvider.io) {
-            dataStore.toggleFavoriteApp(packageName)
+            try {
+                dataStore.toggleFavoriteApp(packageName)
+            } catch (_: Throwable) {
+                // Swallow the exception to keep favorites unchanged on failure
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- handle DataStore errors in `FavoriteAppsViewModel.toggleFavorite`

## Testing
- `./gradlew testDebugUnitTest --no-daemon --tests "*toggle favorite throws after load*"` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bb2d5a8e8832d9646b3674c42a613