### PR TITLE
Fix exception propagation test in TestMainViewModel

### DIFF
--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/main/TestMainViewModel.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/main/TestMainViewModel.kt
@@ -184,14 +184,16 @@ class TestMainViewModel {
     }
 
     @Test
-    fun `use case throws propagates exception`() = runTest(dispatcherExtension.testDispatcher) {
-        val flow = flow<DataState<Int, Errors>> { }
-        setup(flow, dispatcherExtension.testDispatcher)
-        coEvery { updateUseCase.invoke(Unit) } throws RuntimeException("boom")
-
+    fun `use case throws propagates exception`() {
         assertFailsWith<RuntimeException> {
-            viewModel.onEvent(MainEvent.CheckForUpdates)
-            dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
+            runTest(dispatcherExtension.testDispatcher) {
+                val flow = flow<DataState<Int, Errors>> { }
+                setup(flow, dispatcherExtension.testDispatcher)
+                coEvery { updateUseCase.invoke(Unit) } throws RuntimeException("boom")
+
+                viewModel.onEvent(MainEvent.CheckForUpdates)
+                dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- adjust `use case throws propagates exception` test so `runTest` is inside `assertFailsWith`

## Testing
- `./gradlew test --continue` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bb32211ec832db7c12853ff2f3a09