### PR TITLE
Fix permissions provider exception handling

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/permissions/ui/PermissionsViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/permissions/ui/PermissionsViewModel.kt
@@ -27,16 +27,20 @@ class PermissionsViewModel(private val settingsProvider : PermissionsProvider , 
 
     private fun loadPermissions(context : Context) {
         launch(context = dispatcherProvider.io) {
-            flowOf(value = settingsProvider.providePermissionsConfig(context = context)).collect { result : SettingsConfig ->
-                if (result.categories.isNotEmpty()) {
-                    screenState.successData {
-                        copy(title = result.title , categories = result.categories)
+            try {
+                flowOf(value = settingsProvider.providePermissionsConfig(context = context)).collect { result : SettingsConfig ->
+                    if (result.categories.isNotEmpty()) {
+                        screenState.successData {
+                            copy(title = result.title , categories = result.categories)
+                        }
+                    }
+                    else {
+                        screenState.setErrors(listOf(UiSnackbar(message = UiTextHelper.DynamicString("No settings found"))))
+                        screenState.updateState(ScreenState.NoData())
                     }
                 }
-                else {
-                    screenState.setErrors(listOf(UiSnackbar(message = UiTextHelper.DynamicString("No settings found"))))
-                    screenState.updateState(ScreenState.NoData())
-                }
+            } catch (_ : Exception) {
+                // Keep current loading state when provider fails
             }
         }
     }


### PR DESCRIPTION
## Summary
- handle exceptions when loading permissions config so the ViewModel stays in a loading state

## Testing
- `./gradlew test --no-daemon --stacktrace` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bb376c024832d82b4f98e7a49a22e