### PR TITLE
Enhance onboarding view model

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/OnboardingViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/OnboardingViewModel.kt
@@ -3,8 +3,34 @@ package com.d4rk.android.libs.apptoolkit.app.oboarding.ui
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.setValue
+import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.ViewModel
 
-class OnboardingViewModel : ViewModel() {
-    var currentTabIndex by mutableStateOf(0)
+class OnboardingViewModel(private val savedStateHandle: SavedStateHandle) : ViewModel() {
+
+    companion object {
+        private const val KEY_INDEX = "currentTabIndex"
+    }
+
+    var currentTabIndex by mutableStateOf(savedStateHandle.get<Int>(KEY_INDEX) ?: 0)
+        private set
+
+    fun onEvent(event: OnboardingEvent) {
+        when (event) {
+            is OnboardingEvent.SetIndex -> currentTabIndex = event.index
+            OnboardingEvent.Next -> currentTabIndex++
+            OnboardingEvent.Previous -> currentTabIndex--
+            OnboardingEvent.Unknown -> Unit
+        }
+        savedStateHandle[KEY_INDEX] = currentTabIndex
+    }
+
+    constructor() : this(SavedStateHandle())
+}
+
+sealed interface OnboardingEvent {
+    data object Next : OnboardingEvent
+    data object Previous : OnboardingEvent
+    data class SetIndex(val index: Int) : OnboardingEvent
+    data object Unknown : OnboardingEvent
 }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/TestOnboardingViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/TestOnboardingViewModel.kt
@@ -1,5 +1,6 @@
 package com.d4rk.android.libs.apptoolkit.app.oboarding.ui
 
+import androidx.lifecycle.SavedStateHandle
 import com.google.common.truth.Truth.assertThat
 import org.junit.jupiter.api.Test
 
@@ -14,29 +15,29 @@ class TestOnboardingViewModel {
     @Test
     fun `tab index can be changed`() {
         val viewModel = OnboardingViewModel()
-        viewModel.currentTabIndex = 1
+        viewModel.onEvent(OnboardingEvent.SetIndex(1))
         assertThat(viewModel.currentTabIndex).isEqualTo(1)
     }
 
     @Test
     fun `setting negative tab index`() {
         val viewModel = OnboardingViewModel()
-        viewModel.currentTabIndex = -1
+        viewModel.onEvent(OnboardingEvent.SetIndex(-1))
         assertThat(viewModel.currentTabIndex).isEqualTo(-1)
     }
 
     @Test
     fun `resetting tab index to default`() {
         val viewModel = OnboardingViewModel()
-        viewModel.currentTabIndex = 2
-        viewModel.currentTabIndex = 0
+        viewModel.onEvent(OnboardingEvent.SetIndex(2))
+        viewModel.onEvent(OnboardingEvent.SetIndex(0))
         assertThat(viewModel.currentTabIndex).isEqualTo(0)
     }
 
     @Test
     fun `setting extremely large tab index`() {
         val viewModel = OnboardingViewModel()
-        viewModel.currentTabIndex = Int.MAX_VALUE
+        viewModel.onEvent(OnboardingEvent.SetIndex(Int.MAX_VALUE))
         assertThat(viewModel.currentTabIndex).isEqualTo(Int.MAX_VALUE)
     }
 
@@ -51,9 +52,26 @@ class TestOnboardingViewModel {
     fun `repeated open dismiss remains stable`() {
         val viewModel = OnboardingViewModel()
         repeat(5) { index ->
-            viewModel.currentTabIndex = index
-            viewModel.currentTabIndex = 0
+            viewModel.onEvent(OnboardingEvent.SetIndex(index))
+            viewModel.onEvent(OnboardingEvent.SetIndex(0))
         }
         assertThat(viewModel.currentTabIndex).isEqualTo(0)
+    }
+
+    @Test
+    fun `unknown event does nothing`() {
+        val viewModel = OnboardingViewModel()
+        viewModel.onEvent(OnboardingEvent.SetIndex(3))
+        viewModel.onEvent(OnboardingEvent.Unknown)
+        assertThat(viewModel.currentTabIndex).isEqualTo(3)
+    }
+
+    @Test
+    fun `state persists through saved state handle`() {
+        val handle = SavedStateHandle(mapOf("currentTabIndex" to 5))
+        val viewModel = OnboardingViewModel(handle)
+        assertThat(viewModel.currentTabIndex).isEqualTo(5)
+        viewModel.onEvent(OnboardingEvent.Next)
+        assertThat(handle.get<Int>("currentTabIndex")).isEqualTo(6)
     }
 }


### PR DESCRIPTION
## Summary
- add event model and saved-state support to `OnboardingViewModel`
- update onboarding view model unit tests for event handling and persistence

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bf0fbd0d8832db67a8c83a4a40e10