### PR TITLE
Add test for runtime permission revocation

### DIFF
--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestPermissionsHelper.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestPermissionsHelper.kt
@@ -99,4 +99,21 @@ class TestPermissionsHelper {
             assertTrue(PermissionsHelper.hasNotificationPermission(context))
         }
     }
+
+    @Test
+    fun `hasNotificationPermission reflects runtime revocation`() {
+        val context = mockk<Context>()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            mockkStatic(ContextCompat::class)
+            every { ContextCompat.checkSelfPermission(context, Manifest.permission.POST_NOTIFICATIONS) } returnsMany listOf(
+                PackageManager.PERMISSION_GRANTED,
+                PackageManager.PERMISSION_DENIED
+            )
+            assertTrue(PermissionsHelper.hasNotificationPermission(context))
+            assertFalse(PermissionsHelper.hasNotificationPermission(context))
+        } else {
+            assertTrue(PermissionsHelper.hasNotificationPermission(context))
+            assertTrue(PermissionsHelper.hasNotificationPermission(context))
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- extend `TestPermissionsHelper` with a check for permission revocation at runtime

## Testing
- `./gradlew test --no-build-cache --continue` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_686bf1a318ac832d92aa7a6b3e69d222