### PR TITLE
Use custom buttons across UI

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/ui/components/ConsentToggleCard.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/ui/components/ConsentToggleCard.kt
@@ -84,7 +84,6 @@ fun ConsentToggleCard(
                 CustomSwitch(
                     checked = switchState,
                     onCheckedChange = onCheckedChange,
-                    modifier = Modifier,
                 )
             }
         }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/ui/components/ExpandableConsentSectionHeader.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/ui/components/ExpandableConsentSectionHeader.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
-import androidx.compose.material3.Icon
 import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -26,7 +25,9 @@ import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 
 @Composable
 fun ExpandableConsentSectionHeader(
-    title: String, expanded: Boolean, onToggle: () -> Unit
+    title: String,
+    expanded: Boolean,
+    onToggle: () -> Unit
 ) {
     val view: View = LocalView.current
     Row(
@@ -50,14 +51,12 @@ fun ExpandableConsentSectionHeader(
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.primary
         )
-        IconButton(onClick = onToggle) {
-            Icon(
-                imageVector = if (expanded) Icons.Filled.ExpandLess else Icons.Filled.ExpandMore,
-                contentDescription = if (expanded) stringResource(id = R.string.icon_desc_expand_less) else stringResource(
-                    id = R.string.icon_desc_expand_more
-                ),
-                tint = MaterialTheme.colorScheme.primary
-            )
-        }
+        IconButton(
+            onClick = onToggle,
+            icon = if (expanded) Icons.Filled.ExpandLess else Icons.Filled.ExpandMore,
+            iconContentDescription = if (expanded) stringResource(id = R.string.icon_desc_expand_less) else stringResource(
+                id = R.string.icon_desc_expand_more
+            ),
+        )
     }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/ui/components/ExpandableConsentSectionHeader.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/ui/components/ExpandableConsentSectionHeader.kt
@@ -11,7 +11,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ExpandLess
 import androidx.compose.material.icons.filled.ExpandMore
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
+import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -50,10 +50,7 @@ fun ExpandableConsentSectionHeader(
             fontWeight = FontWeight.Bold,
             color = MaterialTheme.colorScheme.primary
         )
-        IconButton(modifier = Modifier.bounceClick(), onClick = {
-            view.playSoundEffect(SoundEffectConstants.CLICK)
-            onToggle()
-        }) {
+        IconButton(onClick = onToggle) {
             Icon(
                 imageVector = if (expanded) Icons.Filled.ExpandLess else Icons.Filled.ExpandMore,
                 contentDescription = if (expanded) stringResource(id = R.string.icon_desc_expand_less) else stringResource(

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/components/OnboardingBottomNavigation.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/components/OnboardingBottomNavigation.kt
@@ -1,7 +1,5 @@
 package com.d4rk.android.libs.apptoolkit.app.oboarding.ui.components
 
-import android.view.SoundEffectConstants
-import android.view.View
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.Spring
@@ -14,29 +12,22 @@ import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowLeft
 import androidx.compose.material.icons.automirrored.filled.KeyboardArrowRight
 import androidx.compose.material.icons.filled.Check
 import androidx.compose.material3.BottomAppBar
-import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
-import androidx.compose.material3.Icon
-import androidx.compose.material3.OutlinedButton
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import com.d4rk.android.libs.apptoolkit.R
-import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
+import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.IconButtonWithText
+import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.OutlinedIconButtonWithText
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 
 @OptIn(ExperimentalFoundationApi::class)
@@ -44,7 +35,6 @@ import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 fun OnboardingBottomNavigation(
     pagerState : PagerState , pageCount : Int , onNextClicked : () -> Unit , onBackClicked : () -> Unit
 ) {
-    val view : View = LocalView.current
 
     BottomAppBar {
         Row(
@@ -60,18 +50,13 @@ fun OnboardingBottomNavigation(
                 )) + fadeOut(animationSpec = spring(stiffness = Spring.StiffnessLow))) {
 
                     Box(contentAlignment = Alignment.CenterStart) {
-                        OutlinedButton(
-                            onClick = {
-                                view.playSoundEffect(SoundEffectConstants.CLICK)
-                                onBackClicked()
-                                      } , modifier = Modifier.bounceClick()
-                        ) {
-                            Icon(
-                                imageVector = Icons.AutoMirrored.Filled.KeyboardArrowLeft , contentDescription = stringResource(id = R.string.back_button_content_description) , modifier = Modifier.size(SizeConstants.ButtonIconSize)
-                            )
-                            Spacer(Modifier.size(ButtonDefaults.IconSpacing))
-                            Text(text = stringResource(id = R.string.back_button_text), maxLines = 1, overflow = TextOverflow.Ellipsis)
-                        }
+                        OutlinedIconButtonWithText(
+                            onClick = onBackClicked,
+                            modifier = Modifier,
+                            icon = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
+                            iconContentDescription = stringResource(id = R.string.back_button_content_description),
+                            label = stringResource(id = R.string.back_button_text)
+                        )
                     }
                 }
             }
@@ -84,29 +69,13 @@ fun OnboardingBottomNavigation(
                     .animateContentSize() , contentAlignment = Alignment.CenterEnd
             ) {
                 val isLastPage = pagerState.currentPage == pageCount - 1
-                Button(
-                    onClick = {
-                        view.playSoundEffect(SoundEffectConstants.CLICK)
-                        onNextClicked()
-                              } , modifier = Modifier
-                        .animateContentSize()
-                        .bounceClick()
-                ) {
-                    if (isLastPage) {
-                        Icon(
-                            imageVector = Icons.Filled.Check , contentDescription = stringResource(id = R.string.done_button_content_description) , modifier = Modifier.size(SizeConstants.ButtonIconSize)
-                        )
-                        Spacer(Modifier.size(ButtonDefaults.IconSpacing))
-                        Text(text = stringResource(id = R.string.done_button_text), maxLines = 1, overflow = TextOverflow.Ellipsis)
-                    }
-                    else {
-                        Text(text = stringResource(id = R.string.next_button_text), maxLines = 1, overflow = TextOverflow.Ellipsis)
-                        Spacer(Modifier.size(ButtonDefaults.IconSpacing))
-                        Icon(
-                            imageVector = Icons.AutoMirrored.Filled.KeyboardArrowRight , contentDescription = stringResource(id = R.string.next_button_content_description) , modifier = Modifier.size(SizeConstants.ButtonIconSize)
-                        )
-                    }
-                }
+                IconButtonWithText(
+                    onClick = onNextClicked,
+                    modifier = Modifier.animateContentSize(),
+                    icon = if (isLastPage) Icons.Filled.Check else Icons.AutoMirrored.Filled.KeyboardArrowRight,
+                    iconContentDescription = if (isLastPage) stringResource(id = R.string.done_button_content_description) else stringResource(id = R.string.next_button_content_description),
+                    label = if (isLastPage) stringResource(id = R.string.done_button_text) else stringResource(id = R.string.next_button_text)
+                )
             }
         }
     }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/components/OnboardingBottomNavigation.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/components/OnboardingBottomNavigation.kt
@@ -52,7 +52,6 @@ fun OnboardingBottomNavigation(
                     Box(contentAlignment = Alignment.CenterStart) {
                         OutlinedIconButtonWithText(
                             onClick = onBackClicked,
-                            modifier = Modifier,
                             icon = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
                             iconContentDescription = stringResource(id = R.string.back_button_content_description),
                             label = stringResource(id = R.string.back_button_text)

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/components/pages/CrashlyticsOnboardingPageTab.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/components/pages/CrashlyticsOnboardingPageTab.kt
@@ -40,7 +40,6 @@ import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
@@ -66,6 +65,7 @@ import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.oboarding.utils.helpers.CrashlyticsOnboardingStateManager
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoProvider
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
+import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.OutlinedIconButtonWithText
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.ButtonIconSpacer
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.ExtraLargeIncreasedVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.ExtraLargeVerticalSpacer
@@ -143,21 +143,13 @@ fun CrashlyticsOnboardingPageTab(configProvider: BuildInfoProvider = koinInject(
 
             LargeVerticalSpacer()
 
-            OutlinedButton(onClick = {
-                view.playSoundEffect(SoundEffectConstants.CLICK)
-                CrashlyticsOnboardingStateManager.openDialog()
-                                     },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .bounceClick()) {
-                Icon(
-                    Icons.Outlined.PrivacyTip,
-                    contentDescription = stringResource(id = R.string.onboarding_crashlytics_show_details_button_cd),
-                    modifier = Modifier.size(SizeConstants.ButtonIconSize)
-                )
-                ButtonIconSpacer()
-                Text(text = stringResource(id = R.string.onboarding_crashlytics_show_details_button))
-            }
+            OutlinedIconButtonWithText(
+                onClick = { CrashlyticsOnboardingStateManager.openDialog() },
+                modifier = Modifier.fillMaxWidth(),
+                icon = Icons.Outlined.PrivacyTip,
+                iconContentDescription = stringResource(id = R.string.onboarding_crashlytics_show_details_button_cd),
+                label = stringResource(id = R.string.onboarding_crashlytics_show_details_button)
+            )
 
             LargeVerticalSpacer()
 

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -55,7 +54,7 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.LoadingScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.NoDataScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.ScreenStateHandler
-import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
+import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.OutlinedIconButtonWithText
 import com.d4rk.android.libs.apptoolkit.core.ui.components.navigation.LargeTopAppBarWithScaffold
 import com.d4rk.android.libs.apptoolkit.core.ui.components.preferences.SettingsPreferenceItem
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.ExtraTinyVerticalSpacer
@@ -138,14 +137,14 @@ fun SettingsDetailPlaceholder(paddingValues : PaddingValues) {
                     SmallVerticalSpacer()
                     Text(text = stringResource(id = R.string.settings_placeholder_description) , style = MaterialTheme.typography.bodyMedium , textAlign = TextAlign.Center)
                 }
-                OutlinedButton(modifier = Modifier
+                OutlinedIconButtonWithText(
+                    modifier = Modifier
                         .padding(all = SizeConstants.MediumSize * 2)
-                        .align(alignment = Alignment.Start)
-                        .bounceClick() , onClick = { IntentsHelper.openActivity(context = context , activityClass = HelpActivity::class.java) }) {
-                    Icon(imageVector = Icons.AutoMirrored.Outlined.ContactSupport , contentDescription = null)
-                    ExtraTinyVerticalSpacer()
-                    Text(text = stringResource(id = R.string.get_help))
-                }
+                        .align(alignment = Alignment.Start),
+                    onClick = { IntentsHelper.openActivity(context = context , activityClass = HelpActivity::class.java) },
+                    icon = Icons.AutoMirrored.Outlined.ContactSupport,
+                    label = stringResource(id = R.string.get_help)
+                )
             }
         }
     }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportScreen.kt
@@ -2,8 +2,6 @@ package com.d4rk.android.libs.apptoolkit.app.support.ui
 
 import android.app.Activity
 import android.content.Context
-import android.view.SoundEffectConstants
-import android.view.View
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
@@ -16,7 +14,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.MoneyOff
 import androidx.compose.material.icons.outlined.Paid
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
@@ -28,7 +25,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.support.billing.SupportScreenUiState
@@ -40,7 +36,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.AdBanner
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.LoadingScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.NoDataScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.ScreenStateHandler
-import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
+import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.TonalIconButtonWithText
 import com.d4rk.android.libs.apptoolkit.core.ui.components.navigation.LargeTopAppBarWithScaffold
 import com.d4rk.android.libs.apptoolkit.core.ui.components.snackbar.DefaultSnackbarHandler
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.ButtonIconSpacer
@@ -99,7 +95,6 @@ fun SupportScreenContent(
     data: SupportScreenUiState,
     adsConfig: AdsConfig = koinInject(qualifier = named(name = "banner_medium_rectangle"))
 ) {
-    val view: View = LocalView.current
     val context: Context = LocalContext.current
 
     val productDetailsMap = data.products.associateBy { it.productId }
@@ -131,42 +126,24 @@ fun SupportScreenContent(
                         horizontalArrangement = Arrangement.SpaceEvenly
                     ) {
                         item {
-                            FilledTonalButton(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .bounceClick(),
+                            TonalIconButtonWithText(
+                                modifier = Modifier.fillMaxWidth(),
                                 onClick = {
-                                    view.playSoundEffect(SoundEffectConstants.CLICK)
                                     productDetailsMap[DonationProductIds.LOW_DONATION]?.let { viewModel.onDonateClicked(activity, it) }
-                                }
-                            ) {
-                                Icon(
-                                    imageVector = Icons.Outlined.Paid,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(SizeConstants.ButtonIconSize)
-                                )
-                                ButtonIconSpacer()
-                                Text(text = productDetailsMap[DonationProductIds.LOW_DONATION]?.oneTimePurchaseOfferDetails?.formattedPrice ?: "")
-                            }
+                                },
+                                icon = Icons.Outlined.Paid,
+                                label = productDetailsMap[DonationProductIds.LOW_DONATION]?.oneTimePurchaseOfferDetails?.formattedPrice ?: ""
+                            )
                         }
                         item {
-                            FilledTonalButton(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .bounceClick(),
+                            TonalIconButtonWithText(
+                                modifier = Modifier.fillMaxWidth(),
                                 onClick = {
-                                    view.playSoundEffect(SoundEffectConstants.CLICK)
                                     productDetailsMap[DonationProductIds.NORMAL_DONATION]?.let { viewModel.onDonateClicked(activity, it) }
-                                }
-                            ) {
-                                Icon(
-                                    Icons.Outlined.Paid,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(SizeConstants.ButtonIconSize)
-                                )
-                                ButtonIconSpacer()
-                                Text(text = productDetailsMap[DonationProductIds.NORMAL_DONATION]?.oneTimePurchaseOfferDetails?.formattedPrice ?: "")
-                            }
+                                },
+                                icon = Icons.Outlined.Paid,
+                                label = productDetailsMap[DonationProductIds.NORMAL_DONATION]?.oneTimePurchaseOfferDetails?.formattedPrice ?: ""
+                            )
                         }
                     }
                     LazyRow(
@@ -176,42 +153,24 @@ fun SupportScreenContent(
                         horizontalArrangement = Arrangement.SpaceEvenly
                     ) {
                         item {
-                            FilledTonalButton(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .bounceClick(),
+                            TonalIconButtonWithText(
+                                modifier = Modifier.fillMaxWidth(),
                                 onClick = {
-                                    view.playSoundEffect(SoundEffectConstants.CLICK)
                                     productDetailsMap[DonationProductIds.HIGH_DONATION]?.let { viewModel.onDonateClicked(activity, it) }
-                                }
-                            ) {
-                                Icon(
-                                    Icons.Outlined.Paid,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(SizeConstants.ButtonIconSize)
-                                )
-                                ButtonIconSpacer()
-                                Text(text = productDetailsMap[DonationProductIds.HIGH_DONATION]?.oneTimePurchaseOfferDetails?.formattedPrice ?: "")
-                            }
+                                },
+                                icon = Icons.Outlined.Paid,
+                                label = productDetailsMap[DonationProductIds.HIGH_DONATION]?.oneTimePurchaseOfferDetails?.formattedPrice ?: ""
+                            )
                         }
                         item {
-                            FilledTonalButton(
-                                modifier = Modifier
-                                    .fillMaxWidth()
-                                    .bounceClick(),
+                            TonalIconButtonWithText(
+                                modifier = Modifier.fillMaxWidth(),
                                 onClick = {
-                                    view.playSoundEffect(SoundEffectConstants.CLICK)
                                     productDetailsMap[DonationProductIds.EXTREME_DONATION]?.let { viewModel.onDonateClicked(activity, it) }
-                                }
-                            ) {
-                                Icon(
-                                    Icons.Outlined.Paid,
-                                    contentDescription = null,
-                                    modifier = Modifier.size(SizeConstants.ButtonIconSize)
-                                )
-                                ButtonIconSpacer()
-                                Text(text = productDetailsMap[DonationProductIds.EXTREME_DONATION]?.oneTimePurchaseOfferDetails?.formattedPrice ?: "")
-                            }
+                                },
+                                icon = Icons.Outlined.Paid,
+                                label = productDetailsMap[DonationProductIds.EXTREME_DONATION]?.oneTimePurchaseOfferDetails?.formattedPrice ?: ""
+                            )
                         }
                     }
                 }
@@ -225,27 +184,19 @@ fun SupportScreenContent(
             )
         }
         item {
-            FilledTonalButton(
+            TonalIconButtonWithText(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(all = SizeConstants.LargeSize),
                 onClick = {
-                    view.playSoundEffect(SoundEffectConstants.CLICK)
                     IntentsHelper.openUrl(
                         context = context,
                         url = "https://direct-link.net/548212/agOqI7123501341"
                     )
                 },
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .bounceClick()
-                    .padding(all = SizeConstants.LargeSize)
-            ) {
-                Icon(
-                    imageVector = Icons.Outlined.Paid,
-                    contentDescription = null,
-                    modifier = Modifier.size(SizeConstants.ButtonIconSize)
-                )
-                ButtonIconSpacer()
-                Text(text = stringResource(id = R.string.web_ad))
-            }
+                icon = Icons.Outlined.Paid,
+                label = stringResource(id = R.string.web_ad)
+            )
         }
         item {
             AdBanner(

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/dialogs/BasicFullScreenDialog.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/dialogs/BasicFullScreenDialog.kt
@@ -15,7 +15,7 @@ import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
+import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -37,7 +37,7 @@ fun BasicFullScreenDialog(title : String , onDismiss : () -> Unit , onConfirm : 
         Scaffold(
             modifier = Modifier.fillMaxSize() , topBar = {
                 CenterAlignedTopAppBar(navigationIcon = {
-                    IconButton(modifier = Modifier.bounceClick() , onClick = onDismiss) {
+                    IconButton(onClick = onDismiss) {
                         Icon(imageVector = Icons.Filled.Close , contentDescription = null)
                     }
                 } , title = { Text(text = title) } , actions = {

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/dialogs/BasicFullScreenDialog.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/dialogs/BasicFullScreenDialog.kt
@@ -14,7 +14,6 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
-import androidx.compose.material3.Icon
 import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
@@ -37,9 +36,11 @@ fun BasicFullScreenDialog(title : String , onDismiss : () -> Unit , onConfirm : 
         Scaffold(
             modifier = Modifier.fillMaxSize() , topBar = {
                 CenterAlignedTopAppBar(navigationIcon = {
-                    IconButton(onClick = onDismiss) {
-                        Icon(imageVector = Icons.Filled.Close , contentDescription = null)
-                    }
+                    IconButton(
+                        onClick = onDismiss,
+                        icon = Icons.Filled.Close,
+                        iconContentDescription = null
+                    )
                 } , title = { Text(text = title) } , actions = {
                     TextButton(modifier = Modifier.bounceClick() , onClick = {
                         view.playSoundEffect(SoundEffectConstants.CLICK)

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/layouts/NoDataScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/layouts/NoDataScreen.kt
@@ -1,7 +1,5 @@
 package com.d4rk.android.libs.apptoolkit.core.ui.components.layouts
 
-import android.view.SoundEffectConstants
-import android.view.View
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -13,7 +11,6 @@ import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Info
 import androidx.compose.material.icons.filled.Refresh
-import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -21,13 +18,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
 import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.AdBanner
-import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
+import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.IconButtonWithText
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.ButtonIconSpacer
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
@@ -57,7 +53,6 @@ fun NoDataScreen(
     isError : Boolean = false,
     adsConfig: AdsConfig = koinInject(qualifier = named(name = "banner_medium_rectangle"))
 ) {
-    val view: View = LocalView.current
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -82,18 +77,12 @@ fun NoDataScreen(
             )
             if (showRetry) {
                 LargeVerticalSpacer()
-                Button(onClick = {
-                    view.playSoundEffect(SoundEffectConstants.CLICK)
-                    onRetry()
-                }, modifier = Modifier.bounceClick()) {
-                    Icon(
-                        imageVector = Icons.Filled.Refresh,
-                        contentDescription = null,
-                        modifier = Modifier.size(size = SizeConstants.ButtonIconSize)
-                    )
-                    ButtonIconSpacer()
-                    Text(text = stringResource(id = text))
-                }
+                IconButtonWithText(
+                    onClick = onRetry,
+                    modifier = Modifier,
+                    icon = Icons.Filled.Refresh,
+                    label = stringResource(id = text)
+                )
             }
 
             LargeVerticalSpacer()

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/layouts/NoDataScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/layouts/NoDataScreen.kt
@@ -79,7 +79,6 @@ fun NoDataScreen(
                 LargeVerticalSpacer()
                 IconButtonWithText(
                     onClick = onRetry,
-                    modifier = Modifier,
                     icon = Icons.Filled.Refresh,
                     label = stringResource(id = text)
                 )

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/snackbar/DefaultSnackbarHost.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/snackbar/DefaultSnackbarHost.kt
@@ -3,7 +3,6 @@ package com.d4rk.android.libs.apptoolkit.core.ui.components.snackbar
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Close
-import androidx.compose.material3.Icon
 import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Snackbar
@@ -28,9 +27,11 @@ fun DefaultSnackbarHost(snackbarState : SnackbarHostState , modifier : Modifier 
                 containerColor = if (isError) MaterialTheme.colorScheme.errorContainer else MaterialTheme.colorScheme.inverseSurface ,
                 contentColor = if (isError) MaterialTheme.colorScheme.error else SnackbarDefaults.contentColor ,
                 action = {
-                    IconButton(onClick = { snackbarData.dismiss() }) {
-                        Icon(imageVector = Icons.Outlined.Close , contentDescription = "Close Snackbar" , tint = if (isError) MaterialTheme.colorScheme.error else SnackbarDefaults.contentColor)
-                    }
+                    IconButton(
+                        onClick = { snackbarData.dismiss() },
+                        icon = Icons.Outlined.Close,
+                        iconContentDescription = "Close Snackbar"
+                    )
                 }) {
                 Text(text = visuals.message)
             }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/snackbar/DefaultSnackbarHost.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/snackbar/DefaultSnackbarHost.kt
@@ -1,12 +1,10 @@
 package com.d4rk.android.libs.apptoolkit.core.ui.components.snackbar
 
-import android.view.SoundEffectConstants
-import android.view.View
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
+import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarData
@@ -16,14 +14,11 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalView
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.CustomSnackbarVisuals
-import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 
 @Composable
 fun DefaultSnackbarHost(snackbarState : SnackbarHostState , modifier : Modifier = Modifier) {
-    val view : View = LocalView.current
     SnackbarHost(hostState = snackbarState , modifier = modifier) { snackbarData : SnackbarData ->
         (snackbarData.visuals as? CustomSnackbarVisuals)?.let { visuals : CustomSnackbarVisuals ->
             val isError : Boolean = visuals.isError
@@ -33,10 +28,7 @@ fun DefaultSnackbarHost(snackbarState : SnackbarHostState , modifier : Modifier 
                 containerColor = if (isError) MaterialTheme.colorScheme.errorContainer else MaterialTheme.colorScheme.inverseSurface ,
                 contentColor = if (isError) MaterialTheme.colorScheme.error else SnackbarDefaults.contentColor ,
                 action = {
-                    IconButton(modifier = Modifier.bounceClick() , onClick = {
-                        view.playSoundEffect(SoundEffectConstants.CLICK)
-                        snackbarData.dismiss()
-                    }) {
+                    IconButton(onClick = { snackbarData.dismiss() }) {
                         Icon(imageVector = Icons.Outlined.Close , contentDescription = "Close Snackbar" , tint = if (isError) MaterialTheme.colorScheme.error else SnackbarDefaults.contentColor)
                     }
                 }) {


### PR DESCRIPTION
## Summary
- replace usages of FilledTonalButton with TonalIconButtonWithText in Support screen
- use OutlinedIconButtonWithText for settings help button
- switch onboarding navigation buttons to new button components
- apply custom icon buttons to snackbar, dialogs and other screens
- replace retry button in NoDataScreen with IconButtonWithText

## Testing
- `./gradlew test --quiet` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687029145cb0832da4e4a073a78a4e4c