### PR TITLE
Use custom button components

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/AppCard.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/AppCard.kt
@@ -106,14 +106,10 @@ fun AppCard(
             }
             IconButton(
                 onClick = onFavoriteToggle,
-                modifier = Modifier
-                    .align(Alignment.TopEnd)
-            ) {
-                Icon(
-                    imageVector = if (isFavorite) Icons.Filled.Star else Icons.Outlined.StarOutline,
-                    contentDescription = null
-                )
-            }
+                modifier = Modifier.align(Alignment.TopEnd),
+                icon = if (isFavorite) Icons.Filled.Star else Icons.Outlined.StarOutline,
+                iconContentDescription = null
+            )
         }
     }
 }

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/AppCard.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/AppCard.kt
@@ -19,7 +19,7 @@ import androidx.compose.material.icons.filled.Star
 import androidx.compose.material.icons.outlined.StarOutline
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
-import androidx.compose.material3.IconButton
+import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.IconButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -108,7 +108,6 @@ fun AppCard(
                 onClick = onFavoriteToggle,
                 modifier = Modifier
                     .align(Alignment.TopEnd)
-                    .bounceClick()
             ) {
                 Icon(
                     imageVector = if (isFavorite) Icons.Filled.Star else Icons.Outlined.StarOutline,

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/IssueReporterScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/IssueReporterScreen.kt
@@ -35,7 +35,7 @@ import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.RadioButton
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
+import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.OutlinedIconButtonWithText
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
@@ -188,19 +188,12 @@ fun IssueReporterScreenContent(
                         ) {
                             val uriHandler = LocalUriHandler.current
 
-                            TextButton(
+                            OutlinedIconButtonWithText(
                                 onClick = { uriHandler.openUri(data.issueUrl) },
-
-                                modifier = Modifier.bounceClick()
-                            ) {
-                                Icon(
-                                    imageVector = Icons.AutoMirrored.Outlined.OpenInNew,
-                                    contentDescription = stringResource(R.string.open_issue_in_browser),
-                                    modifier = Modifier.size(SizeConstants.ButtonIconSize)
-                                )
-                                ButtonIconSpacer()
-                                Text(stringResource(R.string.open_button_label))
-                            }
+                                icon = Icons.AutoMirrored.Outlined.OpenInNew,
+                                iconContentDescription = stringResource(R.string.open_issue_in_browser),
+                                label = stringResource(R.string.open_button_label)
+                            )
                         }
                     }
                 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/OnboardingScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/OnboardingScreen.kt
@@ -21,7 +21,7 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
+import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.OutlinedIconButtonWithText
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -36,7 +36,6 @@ import com.d4rk.android.libs.apptoolkit.app.oboarding.domain.data.model.ui.Onboa
 import com.d4rk.android.libs.apptoolkit.app.oboarding.ui.components.OnboardingBottomNavigation
 import com.d4rk.android.libs.apptoolkit.app.oboarding.ui.components.pages.OnboardingDefaultPageLayout
 import com.d4rk.android.libs.apptoolkit.app.oboarding.utils.interfaces.providers.OnboardingProvider
-import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.hapticPagerSwipe
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.ButtonIconSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
@@ -76,21 +75,15 @@ fun OnboardingScreen(activity : Activity) {
                     enter = slideInHorizontally(initialOffsetX = { fullWidth -> fullWidth }) + fadeIn(),
                     exit = slideOutHorizontally(targetOffsetX = { fullWidth -> fullWidth }) + fadeOut()
                 ) {
-                    TextButton(
+                    OutlinedIconButtonWithText(
                         onClick = {
                             view.playSoundEffect(SoundEffectConstants.CLICK)
                             onSkipRequested()
                         },
-                        modifier = Modifier.bounceClick()
-                    ) {
-                        Icon(
-                            imageVector = Icons.Filled.SkipNext,
-                            contentDescription = stringResource(id = R.string.skip_button_content_description),
-                            modifier = Modifier.size(SizeConstants.ButtonIconSize)
-                        )
-                        ButtonIconSpacer()
-                        Text(text = stringResource(id = R.string.skip_button_text))
-                    }
+                        icon = Icons.Filled.SkipNext,
+                        iconContentDescription = stringResource(id = R.string.skip_button_content_description),
+                        label = stringResource(id = R.string.skip_button_text)
+                    )
                 }
             })
         }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/components/pages/CrashlyticsOnboardingPageTab.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/components/pages/CrashlyticsOnboardingPageTab.kt
@@ -34,7 +34,6 @@ import androidx.compose.material.icons.outlined.Campaign
 import androidx.compose.material.icons.outlined.PrivacyTip
 import androidx.compose.material.icons.outlined.Storage
 import androidx.compose.material3.AlertDialog
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.HorizontalDivider
@@ -43,7 +42,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Switch
 import androidx.compose.material3.SwitchDefaults
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
 import androidx.compose.runtime.collectAsState
@@ -57,7 +55,6 @@ import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.window.DialogProperties
 import androidx.core.net.toUri
@@ -259,26 +256,16 @@ fun LearnMoreSection(context: Context) {
         )
 
         MediumVerticalSpacer()
-        TextButton(
+        OutlinedIconButtonWithText(
             onClick = {
                 view.playSoundEffect(SoundEffectConstants.CLICK)
                 val intent = Intent(Intent.ACTION_VIEW, AppLinks.PRIVACY_POLICY.toUri())
                 context.startActivity(intent)
             },
-            modifier = Modifier.bounceClick(),
-            colors = ButtonDefaults.textButtonColors(contentColor = MaterialTheme.colorScheme.primary)
-        ) {
-            Icon(
-                imageVector = Icons.AutoMirrored.Filled.Launch,
-                contentDescription = null,
-                modifier = Modifier.size(SizeConstants.ButtonIconSize)
-            )
-            ButtonIconSpacer()
-            Text(
-                text = stringResource(id = R.string.learn_more_privacy_policy),
-                textDecoration = TextDecoration.Underline
-            )
-        }
+            icon = Icons.AutoMirrored.Filled.Launch,
+            iconContentDescription = null,
+            label = stringResource(id = R.string.learn_more_privacy_policy)
+        )
     }
 }
 

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/components/pages/CrashlyticsOnboardingPageTab.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/oboarding/ui/components/pages/CrashlyticsOnboardingPageTab.kt
@@ -404,8 +404,8 @@ fun CrashlyticsConsentDialog(
             }
         },
         confirmButton = {
-            TextButton(
-                modifier = Modifier.bounceClick(), onClick = {
+            OutlinedIconButtonWithText(
+                onClick = {
                     view.playSoundEffect(SoundEffectConstants.CLICK)
                     coroutineScope.launch {
                         val overallConsent: Boolean =
@@ -420,9 +420,9 @@ fun CrashlyticsConsentDialog(
                         )
                     }
                     onAcknowledge()
-                }) {
-                Text(text = stringResource(id = R.string.button_acknowledge_consents))
-            }
+                },
+                label = stringResource(id = R.string.button_acknowledge_consents)
+            )
         },
         containerColor = MaterialTheme.colorScheme.surface,
     )


### PR DESCRIPTION
## Summary
- replace material icon button with custom bounce-enabled button in the sample `AppCard`
- switch onboarding skip action to custom button
- use custom buttons for privacy policy link and issue screen browser open action
- remove redundant import

## Testing
- `./gradlew test --no-daemon` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6870b90097f4832db631ceb5f2196b2e