### PR TITLE
Inject changelog URL via Koin

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainScreen.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainScreen.kt
@@ -48,6 +48,8 @@ import com.d4rk.android.libs.apptoolkit.core.utils.helpers.ScreenHelper
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.koin.compose.viewmodel.koinViewModel
+import org.koin.compose.koinInject
+import org.koin.core.qualifier.named
 
 @Composable
 fun MainScreen() {
@@ -119,6 +121,7 @@ fun MainScaffoldTabletContent() {
     val coroutineScope: CoroutineScope = rememberCoroutineScope()
     val context: Context = LocalContext.current
     val snackBarHostState: SnackbarHostState = remember { SnackbarHostState() }
+    val changelogUrl: String = koinInject(qualifier = named("github_changelog"))
 
     val viewModel: MainViewModel = koinViewModel()
     val screenState: UiStateScreen<UiMainScreen> by viewModel.uiState.collectAsState()
@@ -165,7 +168,8 @@ fun MainScaffoldTabletContent() {
             onDrawerItemClick = { item: NavigationDrawerItem ->
                 handleNavigationItemClick(
                     context = context,
-                    item = item
+                    item = item,
+                    changelogUrl = changelogUrl,
                 )
             },
             content = {

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/components/navigation/AppNavigationHost.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/components/navigation/AppNavigationHost.kt
@@ -17,8 +17,9 @@ import com.d4rk.android.libs.apptoolkit.app.help.ui.HelpActivity
 import com.d4rk.android.libs.apptoolkit.app.main.ui.components.navigation.NavigationHost
 import com.d4rk.android.libs.apptoolkit.app.settings.settings.ui.SettingsActivity
 import com.d4rk.android.libs.apptoolkit.core.domain.model.navigation.NavigationDrawerItem
-import com.d4rk.android.libs.apptoolkit.core.utils.constants.links.AppLinks
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.IntentsHelper
+import org.koin.core.context.GlobalContext
+import org.koin.core.qualifier.named
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
@@ -46,7 +47,11 @@ fun handleNavigationItemClick(context : Context , item : NavigationDrawerItem , 
     when (item.title) {
         com.d4rk.android.libs.apptoolkit.R.string.settings -> IntentsHelper.openActivity(context = context , activityClass = SettingsActivity::class.java)
         com.d4rk.android.libs.apptoolkit.R.string.help_and_feedback -> IntentsHelper.openActivity(context = context , activityClass = HelpActivity::class.java)
-        com.d4rk.android.libs.apptoolkit.R.string.updates -> IntentsHelper.openUrl(context = context , url = AppLinks.githubChangelog(context.packageName))
+        com.d4rk.android.libs.apptoolkit.R.string.updates -> {
+            val koin = GlobalContext.get().koin
+            val changelogUrl: String = koin.get(qualifier = named("github_changelog"))
+            IntentsHelper.openUrl(context = context , url = changelogUrl)
+        }
         com.d4rk.android.libs.apptoolkit.R.string.share -> IntentsHelper.shareApp(context = context , shareMessageFormat = com.d4rk.android.libs.apptoolkit.R.string.summary_share_message)
     }
     if (drawerState != null && coroutineScope != null) {

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/components/navigation/AppNavigationHost.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/components/navigation/AppNavigationHost.kt
@@ -18,11 +18,11 @@ import com.d4rk.android.libs.apptoolkit.app.main.ui.components.navigation.Naviga
 import com.d4rk.android.libs.apptoolkit.app.settings.settings.ui.SettingsActivity
 import com.d4rk.android.libs.apptoolkit.core.domain.model.navigation.NavigationDrawerItem
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.IntentsHelper
-import org.koin.core.context.GlobalContext
-import org.koin.core.qualifier.named
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
+import org.koin.core.context.GlobalContext
+import org.koin.core.qualifier.named
 
 @Composable
 fun AppNavigationHost(
@@ -48,8 +48,8 @@ fun handleNavigationItemClick(context : Context , item : NavigationDrawerItem , 
         com.d4rk.android.libs.apptoolkit.R.string.settings -> IntentsHelper.openActivity(context = context , activityClass = SettingsActivity::class.java)
         com.d4rk.android.libs.apptoolkit.R.string.help_and_feedback -> IntentsHelper.openActivity(context = context , activityClass = HelpActivity::class.java)
         com.d4rk.android.libs.apptoolkit.R.string.updates -> {
-            val koin = GlobalContext.get().koin
-            val changelogUrl: String = koin.get(qualifier = named("github_changelog"))
+            val koin = GlobalContext.get()
+            val changelogUrl: String = koin.get<String>(qualifier = named("github_changelog"))
             IntentsHelper.openUrl(context = context , url = changelogUrl)
         }
         com.d4rk.android.libs.apptoolkit.R.string.share -> IntentsHelper.shareApp(context = context , shareMessageFormat = com.d4rk.android.libs.apptoolkit.R.string.summary_share_message)

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/components/navigation/AppNavigationHost.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/components/navigation/AppNavigationHost.kt
@@ -21,8 +21,6 @@ import com.d4rk.android.libs.apptoolkit.core.utils.helpers.IntentsHelper
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
-import org.koin.core.context.GlobalContext
-import org.koin.core.qualifier.named
 
 @Composable
 fun AppNavigationHost(
@@ -43,15 +41,20 @@ fun AppNavigationHost(
     }
 }
 
-fun handleNavigationItemClick(context : Context , item : NavigationDrawerItem , drawerState : DrawerState? = null , coroutineScope : CoroutineScope? = null) {
+fun handleNavigationItemClick(
+    context: Context,
+    item: NavigationDrawerItem,
+    drawerState: DrawerState? = null,
+    coroutineScope: CoroutineScope? = null,
+    changelogUrl: String,
+) {
     when (item.title) {
         com.d4rk.android.libs.apptoolkit.R.string.settings -> IntentsHelper.openActivity(context = context , activityClass = SettingsActivity::class.java)
         com.d4rk.android.libs.apptoolkit.R.string.help_and_feedback -> IntentsHelper.openActivity(context = context , activityClass = HelpActivity::class.java)
-        com.d4rk.android.libs.apptoolkit.R.string.updates -> {
-            val koin = GlobalContext.get()
-            val changelogUrl: String = koin.get<String>(qualifier = named("github_changelog"))
-            IntentsHelper.openUrl(context = context , url = changelogUrl)
-        }
+        com.d4rk.android.libs.apptoolkit.R.string.updates -> IntentsHelper.openUrl(
+            context = context,
+            url = changelogUrl,
+        )
         com.d4rk.android.libs.apptoolkit.R.string.share -> IntentsHelper.shareApp(context = context , shareMessageFormat = com.d4rk.android.libs.apptoolkit.R.string.summary_share_message)
     }
     if (drawerState != null && coroutineScope != null) {

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/components/navigation/NavigationDrawer.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/components/navigation/NavigationDrawer.kt
@@ -18,12 +18,15 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.hapticDrawerSwipe
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeVerticalSpacer
 import kotlinx.coroutines.CoroutineScope
+import org.koin.compose.koinInject
+import org.koin.core.qualifier.named
 
 @Composable
 fun NavigationDrawer(screenState : UiStateScreen<UiMainScreen>) {
     val drawerState : DrawerState = rememberDrawerState(initialValue = DrawerValue.Closed)
     val coroutineScope : CoroutineScope = rememberCoroutineScope()
     val context : Context = LocalContext.current
+    val changelogUrl: String = koinInject(qualifier = named("github_changelog"))
     val uiState : UiMainScreen = screenState.data ?: UiMainScreen()
 
     ModalNavigationDrawer(
@@ -32,7 +35,13 @@ fun NavigationDrawer(screenState : UiStateScreen<UiMainScreen>) {
                 LargeVerticalSpacer()
                 uiState.navigationDrawerItems.forEach { item : NavigationDrawerItem ->
                     NavigationDrawerItemContent(item = item , handleNavigationItemClick = {
-                        handleNavigationItemClick(context = context , item = item , drawerState = drawerState , coroutineScope = coroutineScope)
+                        handleNavigationItemClick(
+                            context = context,
+                            item = item,
+                            drawerState = drawerState,
+                            coroutineScope = coroutineScope,
+                            changelogUrl = changelogUrl,
+                        )
                     })
                 }
             }

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppToolkitModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppToolkitModule.kt
@@ -31,12 +31,17 @@ val appToolkitModule : Module = module {
         )
     }
 
+    single(named("github_repository")) { "AppToolkit" }
+
     single<GithubTarget> {
-        GithubTarget(username = "D4rK7355608", repository = "AppToolkit")
+        GithubTarget(
+            username = "D4rK7355608",
+            repository = get(named("github_repository")),
+        )
     }
 
     single(named("github_changelog")) {
-        AppLinks.githubChangelog(get<GithubTarget>().repository)
+        AppLinks.githubChangelog(get<String>(named("github_repository")))
     }
 
     single(named("github_token")) { BuildConfig.GITHUB_TOKEN }

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppToolkitModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppToolkitModule.kt
@@ -8,6 +8,7 @@ import com.d4rk.android.libs.apptoolkit.app.issuereporter.ui.IssueReporterViewMo
 import com.d4rk.android.libs.apptoolkit.app.startup.utils.interfaces.providers.StartupProvider
 import com.d4rk.android.libs.apptoolkit.app.support.billing.BillingRepository
 import com.d4rk.android.libs.apptoolkit.app.support.ui.SupportViewModel
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.links.AppLinks
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.viewModel
 import org.koin.core.qualifier.named
@@ -32,6 +33,10 @@ val appToolkitModule : Module = module {
 
     single<GithubTarget> {
         GithubTarget(username = "D4rK7355608", repository = "AppToolkit")
+    }
+
+    single(named("github_changelog")) {
+        AppLinks.githubChangelog(get<GithubTarget>().repository)
     }
 
     single(named("github_token")) { BuildConfig.GITHUB_TOKEN }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/constants/links/AppLinks.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/constants/links/AppLinks.kt
@@ -23,5 +23,5 @@ object AppLinks {
     const val GITHUB_BASE : String = "https://github.com/$GITHUB_USER/"
     const val GITHUB_ISSUES_SUFFIX : String = "/issues/new"
     const val GITHUB_RAW : String = "https://raw.githubusercontent.com/$GITHUB_USER"
-    fun githubChangelog(packageName : String) : String = "$GITHUB_BASE$packageName/blob/master/CHANGELOG.md"
+    fun githubChangelog(repository: String) : String = "$GITHUB_BASE$repository/blob/master/CHANGELOG.md"
 }


### PR DESCRIPTION
## Summary
- change `githubChangelog` to accept repository name
- provide GitHub changelog URL via Koin
- look up injected changelog link when handling navigation drawer actions

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew assemble` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_687f57692a2c832d9d19712f46cabd5e