### PR TITLE
Add test for changelog parser

### DIFF
--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/main/ui/components/dialogs/TestChangelogParser.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/main/ui/components/dialogs/TestChangelogParser.kt
@@ -1,0 +1,18 @@
+package com.d4rk.android.libs.apptoolkit.app.main.ui.components.dialogs
+
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.File
+
+class TestChangelogParser {
+    @Test
+    fun `extractChangesForVersion returns section`() {
+        val markdown = File("CHANGELOG.md").readText()
+        val clazz = Class.forName("com.d4rk.android.libs.apptoolkit.app.main.ui.components.dialogs.ChangelogDialogKt")
+        val method = clazz.getDeclaredMethod("extractChangesForVersion", String::class.java, String::class.java)
+        method.isAccessible = true
+        val section = method.invoke(null, markdown, "1.0.9") as String
+        assertTrue(section.startsWith("# Version"))
+        assertTrue(section.contains("1.0.9"))
+    }
+}


### PR DESCRIPTION
## Summary
- add a unit test that invokes `extractChangesForVersion`
- ensure changelog parsing still works by reflecting the private function

## Testing
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_6880e948eb0c832db8ed7a821d32b883