### PR TITLE
Integrate Firebase App Check

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 AppToolkit is a versatile Android library designed to streamline development by providing pre-built components and utilities that adhere to modern design principles.
 
+The library initializes Firebase App Check with Play Integrity by default to help protect your Firebase resources from unauthorized access.
+
 ## Installation
 
 To integrate AppToolkit into your project, add the following dependency to your `build.gradle` file:

--- a/apptoolkit/build.gradle.kts
+++ b/apptoolkit/build.gradle.kts
@@ -82,6 +82,7 @@ dependencies {
     api(dependencyNotation = libs.firebase.analytics)
     api(dependencyNotation = libs.firebase.crashlytics)
     api(dependencyNotation = libs.firebase.perf)
+    api(dependencyNotation = libs.firebase.appcheck.playintegrity)
 
     // Google
     api(dependencyNotation = libs.play.services.ads)

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/core/BaseCoreManager.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/core/BaseCoreManager.kt
@@ -6,6 +6,8 @@ import android.os.Bundle
 import androidx.lifecycle.LifecycleObserver
 import androidx.multidex.MultiDexApplication
 import com.d4rk.android.libs.apptoolkit.app.support.billing.BillingRepository
+import com.google.firebase.Firebase
+import com.google.firebase.appcheck.playintegrity.PlayIntegrityAppCheckProviderFactory
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
 import kotlinx.coroutines.Dispatchers
@@ -25,6 +27,10 @@ open class BaseCoreManager : MultiDexApplication(), Application.ActivityLifecycl
 
     override fun onCreate() {
         super.onCreate()
+        Firebase.initialize(context = this)
+        Firebase.appCheck.installAppCheckProviderFactory(
+            PlayIntegrityAppCheckProviderFactory.getInstance(),
+        )
         registerActivityLifecycleCallbacks(this)
         CoroutineScope(Dispatchers.IO).launch {
             initializeApp()

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -85,6 +85,7 @@ firebase-bom = { module = "com.google.firebase:firebase-bom", version.ref = "fir
 firebase-analytics = { module = "com.google.firebase:firebase-analytics" }
 firebase-crashlytics = { module = "com.google.firebase:firebase-crashlytics" }
 firebase-perf = { module = "com.google.firebase:firebase-perf" }
+firebase-appcheck-playintegrity = { module = "com.google.firebase:firebase-appcheck-playintegrity" }
 integrity = { module = "com.google.android.play:integrity", version.ref = "integrity" }
 app-update-ktx = { module = "com.google.android.play:app-update-ktx", version.ref = "appUpdateKtx" }
 review-ktx = { module = "com.google.android.play:review-ktx", version.ref = "reviewKtx" }


### PR DESCRIPTION
## Summary
- initialize Firebase App Check using Play Integrity
- include Play Integrity App Check dependency in the library
- document that AppToolkit secures Firebase resources with App Check

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_688101c56f84832daecc47ebd59e4b10