### PR TITLE
Handle UMP consent form loading errors

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/ConsentFormHelper.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/ConsentFormHelper.kt
@@ -1,6 +1,7 @@
 package com.d4rk.android.libs.apptoolkit.core.utils.helpers
 
 import android.app.Activity
+import android.util.Log
 import com.google.android.ump.ConsentForm
 import com.google.android.ump.ConsentInformation
 import com.google.android.ump.ConsentRequestParameters
@@ -17,11 +18,24 @@ object ConsentFormHelper {
             ConsentRequestParameters.Builder().setTagForUnderAgeOfConsent(false).build()
 
         consentInfo.requestConsentInfoUpdate(activity , params , {
-            UserMessagingPlatform.loadConsentForm(activity , { consentForm : ConsentForm ->
-                if (consentInfo.consentStatus == ConsentInformation.ConsentStatus.REQUIRED || consentInfo.consentStatus == ConsentInformation.ConsentStatus.UNKNOWN) {
-                    consentForm.show(activity) { onFormShown() }
-                }
-            } , {})
+            runCatching {
+                UserMessagingPlatform.loadConsentForm(activity , { consentForm : ConsentForm ->
+                    if (consentInfo.consentStatus == ConsentInformation.ConsentStatus.REQUIRED || consentInfo.consentStatus == ConsentInformation.ConsentStatus.UNKNOWN) {
+                        runCatching {
+                            consentForm.show(activity) { onFormShown() }
+                        }.onFailure {
+                            Log.e("ConsentFormHelper", "Failed to load consent form", it)
+                            onFormShown()
+                        }
+                    }
+                } , { t ->
+                    Log.e("ConsentFormHelper", "Failed to load consent form", t)
+                    onFormShown()
+                })
+            }.onFailure {
+                Log.e("ConsentFormHelper", "Failed to load consent form", it)
+                onFormShown()
+            }
         } , {})
     }
 
@@ -34,9 +48,22 @@ object ConsentFormHelper {
             ConsentRequestParameters.Builder().setTagForUnderAgeOfConsent(false).build()
 
         consentInfo.requestConsentInfoUpdate(activity , params , {
-            UserMessagingPlatform.loadConsentForm(activity , { consentForm : ConsentForm ->
-                consentForm.show(activity) { onFormShown() }
-            } , {})
+            runCatching {
+                UserMessagingPlatform.loadConsentForm(activity , { consentForm : ConsentForm ->
+                    runCatching {
+                        consentForm.show(activity) { onFormShown() }
+                    }.onFailure {
+                        Log.e("ConsentFormHelper", "Failed to load consent form", it)
+                        onFormShown()
+                    }
+                } , { t ->
+                    Log.e("ConsentFormHelper", "Failed to load consent form", t)
+                    onFormShown()
+                })
+            }.onFailure {
+                Log.e("ConsentFormHelper", "Failed to load consent form", it)
+                onFormShown()
+            }
         } , {})
     }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/ConsentFormHelper.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/ConsentFormHelper.kt
@@ -29,7 +29,7 @@ object ConsentFormHelper {
                         }
                     }
                 } , { t ->
-                    Log.e("ConsentFormHelper", "Failed to load consent form", t)
+                    Log.e("ConsentFormHelper", "Failed to load consent form: ${t.message}")
                     onFormShown()
                 })
             }.onFailure {
@@ -57,7 +57,7 @@ object ConsentFormHelper {
                         onFormShown()
                     }
                 } , { t ->
-                    Log.e("ConsentFormHelper", "Failed to load consent form", t)
+                    Log.e("ConsentFormHelper", "Failed to load consent form: ${t.message}")
                     onFormShown()
                 })
             }.onFailure {

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestConsentFormHelper.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestConsentFormHelper.kt
@@ -1,0 +1,31 @@
+package com.d4rk.android.libs.apptoolkit.core.utils.helpers
+
+import android.app.Activity
+import com.google.android.ump.ConsentInformation
+import com.google.android.ump.UserMessagingPlatform
+import io.mockk.*
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class TestConsentFormHelper {
+    @Test
+    fun `showConsentForm handles OutOfMemoryError from loadConsentForm`() {
+        println("🚀 [TEST] showConsentForm handles OutOfMemoryError from loadConsentForm")
+        val activity = mockk<Activity>()
+        val consentInfo = mockk<ConsentInformation>()
+
+        every { consentInfo.requestConsentInfoUpdate(activity, any(), any(), any()) } answers {
+            val onSuccess = arg<() -> Unit>(2)
+            onSuccess()
+        }
+
+        mockkStatic(UserMessagingPlatform::class)
+        every { UserMessagingPlatform.loadConsentForm(any(), any(), any()) } throws OutOfMemoryError("oom")
+
+        var called = false
+        ConsentFormHelper.showConsentForm(activity, consentInfo) { called = true }
+
+        assertTrue(called)
+        println("🏁 [TEST DONE] showConsentForm handles OutOfMemoryError from loadConsentForm")
+    }
+}


### PR DESCRIPTION
## Summary
- handle OutOfMemoryError and Exception when loading and showing consent form using `runCatching`
- add unit test for consent form error resilience

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f55fab8e4832db16eb7508e63c92a