### PR TITLE
Handle billing flow errors

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/billing/BillingRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/billing/BillingRepository.kt
@@ -149,7 +149,15 @@ class BillingRepository private constructor(context: Context) : PurchasesUpdated
                         .build()
                 )
             ).build()
-        billingClient.launchBillingFlow(activity, params)
+        val billingResult = billingClient.launchBillingFlow(activity, params)
+        if (billingResult.responseCode != BillingClient.BillingResponseCode.OK) {
+            val result = if (billingResult.responseCode == BillingClient.BillingResponseCode.USER_CANCELED) {
+                PurchaseResult.UserCancelled
+            } else {
+                PurchaseResult.Failed(billingResult.debugMessage)
+            }
+            scope.launch { _purchaseResult.emit(result) }
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- store `BillingResult` from billing flow launch
- emit failure when launchBillingFlow returns non-OK result

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f5deb6838832da0ae61b1cf065a54