### PR TITLE
Refactor ad loading to use caller coroutine scope

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/AppToolkit.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/AppToolkit.kt
@@ -7,6 +7,7 @@ import android.os.Bundle
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
+import androidx.lifecycle.lifecycleScope
 import com.d4rk.android.apps.apptoolkit.core.di.initializeKoin
 import com.d4rk.android.apps.apptoolkit.core.utils.constants.ads.AdsConstants
 import com.d4rk.android.libs.apptoolkit.data.core.BaseCoreManager
@@ -36,7 +37,7 @@ class AppToolkit : BaseCoreManager(), DefaultLifecycleObserver {
     }
 
     override fun onStart(owner: LifecycleOwner) {
-        currentActivity?.let { adsCoreManager.showAdIfAvailable(it) }
+        currentActivity?.let { adsCoreManager.showAdIfAvailable(it, owner.lifecycleScope) }
     }
 
     override fun onResume(owner: LifecycleOwner) {


### PR DESCRIPTION
## Summary
- launch ad display from caller scope
- await DataStore preference in a suspend function instead of blocking

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689f6cf7a884832d9ec7cdd3f934f79a