### PR TITLE
Add cleanup hook for BillingRepository

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/billing/BillingRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/billing/BillingRepository.kt
@@ -16,6 +16,7 @@ import com.android.billingclient.api.QueryPurchasesParams
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -175,6 +176,11 @@ class BillingRepository private constructor(context: Context) : PurchasesUpdated
             }
             scope.launch { _purchaseResult.emit(result) }
         }
+    }
+
+    fun close() {
+        scope.cancel()
+        billingClient.endConnection()
     }
 }
 

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/core/BaseCoreManager.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/core/BaseCoreManager.kt
@@ -60,4 +60,9 @@ open class BaseCoreManager : MultiDexApplication(), Application.ActivityLifecycl
     override fun onActivityStopped(activity : Activity) {}
     override fun onActivitySaveInstanceState(activity : Activity , outState : Bundle) {}
     override fun onActivityDestroyed(activity : Activity) {}
+
+    override fun onTerminate() {
+        super.onTerminate()
+        billingRepository.close()
+    }
 }


### PR DESCRIPTION
## Summary
- add public `close()` to `BillingRepository` to cancel scope and end the billing connection
- invoke repository cleanup from `BaseCoreManager.onTerminate`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fa4e61690832d9fe79a2b9dcf5caa