### PR TITLE
Avoid redundant notification permission requests

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/PermissionsHelper.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/PermissionsHelper.kt
@@ -37,9 +37,12 @@ object PermissionsHelper {
      * @param activity The Activity instance required to request the permission.
      */
     fun requestNotificationPermission(activity : Activity) {
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU &&
+            !hasNotificationPermission(activity)) {
             ActivityCompat.requestPermissions(
-                activity , arrayOf(Manifest.permission.POST_NOTIFICATIONS) , PermissionsConstants.REQUEST_CODE_NOTIFICATION_PERMISSION
+                activity,
+                arrayOf(Manifest.permission.POST_NOTIFICATIONS),
+                PermissionsConstants.REQUEST_CODE_NOTIFICATION_PERMISSION
             )
         }
     }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestPermissionsHelper.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestPermissionsHelper.kt
@@ -41,6 +41,8 @@ class TestPermissionsHelper {
         println("🚀 [TEST] requestNotificationPermission delegates to ActivityCompat when needed")
         val activity = mockk<Activity>()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            mockkStatic(ContextCompat::class)
+            every { ContextCompat.checkSelfPermission(activity, Manifest.permission.POST_NOTIFICATIONS) } returns PackageManager.PERMISSION_DENIED
             mockkStatic(ActivityCompat::class)
             justRun { ActivityCompat.requestPermissions(activity, arrayOf(Manifest.permission.POST_NOTIFICATIONS), PermissionsConstants.REQUEST_CODE_NOTIFICATION_PERMISSION) }
             PermissionsHelper.requestNotificationPermission(activity)
@@ -86,6 +88,8 @@ class TestPermissionsHelper {
         println("🚀 [TEST] requestNotificationPermission propagates exception")
         val activity = mockk<Activity>()
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            mockkStatic(ContextCompat::class)
+            every { ContextCompat.checkSelfPermission(activity, Manifest.permission.POST_NOTIFICATIONS) } returns PackageManager.PERMISSION_DENIED
             mockkStatic(ActivityCompat::class)
             every { ActivityCompat.requestPermissions(activity, arrayOf(Manifest.permission.POST_NOTIFICATIONS), PermissionsConstants.REQUEST_CODE_NOTIFICATION_PERMISSION) } throws RuntimeException("boom")
             assertFailsWith<RuntimeException> { PermissionsHelper.requestNotificationPermission(activity) }
@@ -110,6 +114,24 @@ class TestPermissionsHelper {
             assertTrue(PermissionsHelper.hasNotificationPermission(context))
         }
         println("🏁 [TEST DONE] hasNotificationPermission handles other unknown values")
+    }
+
+    @Test
+    fun `requestNotificationPermission skips when already granted`() {
+        println("🚀 [TEST] requestNotificationPermission skips when already granted")
+        val activity = mockk<Activity>()
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            mockkStatic(ContextCompat::class)
+            every { ContextCompat.checkSelfPermission(activity, Manifest.permission.POST_NOTIFICATIONS) } returns PackageManager.PERMISSION_GRANTED
+            mockkStatic(ActivityCompat::class)
+            PermissionsHelper.requestNotificationPermission(activity)
+            verify(exactly = 0) { ActivityCompat.requestPermissions(any(), any(), any()) }
+        } else {
+            mockkStatic(ActivityCompat::class)
+            PermissionsHelper.requestNotificationPermission(activity)
+            verify(exactly = 0) { ActivityCompat.requestPermissions(any(), any(), any()) }
+        }
+        println("🏁 [TEST DONE] requestNotificationPermission skips when already granted")
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Check notification permission before invoking `ActivityCompat.requestPermissions`
- Extend unit tests to cover granted and denied notification permission scenarios

## Testing
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fa97a1620832d9528e2d6654e9c91