### PR TITLE
Use activity context for UiTextHelper

### DIFF
--- a/apptoolkit/src/androidTest/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/UiTextHelperInstrumentationTest.kt
+++ b/apptoolkit/src/androidTest/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/UiTextHelperInstrumentationTest.kt
@@ -1,0 +1,43 @@
+package com.d4rk.android.libs.apptoolkit.core.utils.helpers
+
+import android.content.res.Configuration
+import androidx.activity.ComponentActivity
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.d4rk.android.libs.apptoolkit.R
+import com.google.common.truth.Truth.assertThat
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import java.util.Locale
+
+@RunWith(AndroidJUnit4::class)
+class UiTextHelperInstrumentationTest {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun asString_uses_updated_configuration() {
+        val baseContext = InstrumentationRegistry.getInstrumentation().targetContext
+        val config = Configuration(baseContext.resources.configuration)
+        config.setLocale(Locale("fr", "FR"))
+        val localizedContext = baseContext.createConfigurationContext(config)
+
+        val expected = localizedContext.getString(R.string.welcome)
+        var actual: String? = null
+
+        composeRule.setContent {
+            CompositionLocalProvider(LocalContext provides localizedContext) {
+                actual = UiTextHelper.StringResource(R.string.welcome).asString()
+            }
+        }
+
+        composeRule.runOnIdle {
+            assertThat(actual).isEqualTo(expected)
+        }
+    }
+}

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/UiTextHelper.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/UiTextHelper.kt
@@ -58,10 +58,10 @@ sealed class UiTextHelper {
      *
      * @see DynamicString
      * @see StringResource
-     */
+    */
     @Composable
     fun asString() : String {
-        val context : Context = LocalContext.current.applicationContext
+        val context : Context = LocalContext.current
         return when (this) {
             is DynamicString -> content
             is StringResource -> context.getString(resourceId , *arguments.toTypedArray())


### PR DESCRIPTION
## Summary
- Use `LocalContext.current` in `UiTextHelper.asString` instead of the application context
- Add instrumentation test confirming string retrieval respects configuration changes

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fa954e36c832da3d75f5676726ba3