### PR TITLE
Use lifecycle-aware state in AdBanner

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/ui/AdsSettingsScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/ui/AdsSettingsScreen.kt
@@ -10,10 +10,11 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
@@ -37,8 +38,9 @@ import kotlinx.coroutines.launch
 fun AdsSettingsScreen(activity : Activity , buildInfoProvider : BuildInfoProvider) {
     val context : Context = LocalContext.current
     val coroutineScope : CoroutineScope = rememberCoroutineScope()
-    val dataStore: CommonDataStore = CommonDataStore.getInstance(context = context)
-    val adsEnabled : Boolean by dataStore.ads(default = ! buildInfoProvider.isDebugBuild).collectAsState(initial = ! buildInfoProvider.isDebugBuild)
+    val dataStore: CommonDataStore = remember { CommonDataStore.getInstance(context = context) }
+    val adsEnabled : Boolean by dataStore.ads(default = ! buildInfoProvider.isDebugBuild)
+        .collectAsStateWithLifecycle(initialValue = ! buildInfoProvider.isDebugBuild)
 
     LargeTopAppBarWithScaffold(
         title = stringResource(id = R.string.ads) , onBackClicked = { (context as? Activity)?.finish() }) { paddingValues : PaddingValues ->

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/main/ui/components/navigation/BottomNavigationBar.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/main/ui/components/navigation/BottomNavigationBar.kt
@@ -12,6 +12,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.key
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
@@ -48,7 +49,9 @@ fun BottomNavigationBar(
         dataStore.getShowBottomBarLabels().collectAsState(initial = true).value
 
     Column(modifier = modifier) {
-        AdBanner(modifier = Modifier.fillMaxWidth(), adsConfig = adsConfig)
+        key("bottom_ad") {
+            AdBanner(modifier = Modifier.fillMaxWidth(), adsConfig = adsConfig)
+        }
 
         NavigationBar {
             items.forEach { item ->

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdBanner.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdBanner.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -22,8 +22,8 @@ import org.koin.compose.koinInject
 @Composable
 fun AdBanner(modifier : Modifier = Modifier , adsConfig : AdsConfig , buildInfoProvider : BuildInfoProvider = koinInject()) {
     val context: Context = LocalContext.current
-    val dataStore: CommonDataStore = CommonDataStore.getInstance(context = context)
-    val showAds : Boolean by dataStore.ads(default = ! buildInfoProvider.isDebugBuild).collectAsState(initial = true)
+    val dataStore: CommonDataStore = remember { CommonDataStore.getInstance(context = context) }
+    val showAds : Boolean by dataStore.ads(default = ! buildInfoProvider.isDebugBuild).collectAsStateWithLifecycle(initialValue = true)
 
     if (showAds) {
         val adView = remember { AdView(context) }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdBanner.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdBanner.kt
@@ -28,7 +28,7 @@ fun AdBanner(modifier : Modifier = Modifier , adsConfig : AdsConfig , buildInfoP
     val context: Context = LocalContext.current
     val dataStore: CommonDataStore = remember { CommonDataStore.getInstance(context = context) }
     val showAds: Boolean? by dataStore.ads(default = !buildInfoProvider.isDebugBuild)
-        .map<Boolean?> { it }
+        .map { it as Boolean? }
         .collectAsStateWithLifecycle(initialValue = null)
 
     if (showAds == true) {

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdBanner.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdBanner.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
@@ -28,6 +29,10 @@ fun AdBanner(modifier : Modifier = Modifier , adsConfig : AdsConfig , buildInfoP
     if (showAds) {
         val adView = remember { AdView(context) }
 
+        LaunchedEffect(adView) {
+            adView.loadAd(AdRequest.Builder().build())
+        }
+
         DisposableEffect(Unit) {
             onDispose { adView.destroy() }
         }
@@ -41,9 +46,6 @@ fun AdBanner(modifier : Modifier = Modifier , adsConfig : AdsConfig , buildInfoP
                     setAdSize(adsConfig.adSize)
                     adUnitId = adsConfig.bannerAdUnitId
                 }
-            },
-            update = {
-                it.loadAd(AdRequest.Builder().build())
             }
         )
     }


### PR DESCRIPTION
## Summary
- use `remember` for `CommonDataStore.getInstance` in `AdBanner`
- collect ad display state with `collectAsStateWithLifecycle`

## Testing
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_689fab348fec832dbc01178f3fc1ac19