### PR TITLE
Defer app open ads until first frame with logging

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,6 +65,7 @@ android {
             ""
         }
         buildConfigField("String", "GITHUB_TOKEN", "\"$githubToken\"")
+        buildConfigField("Boolean", "DEFER_APP_OPEN", "true")
     }
 
     signingConfigs {

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/AppToolkit.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/AppToolkit.kt
@@ -4,10 +4,12 @@ package com.d4rk.android.apps.apptoolkit
 
 import android.app.Activity
 import android.os.Bundle
+import android.util.Log
 import androidx.lifecycle.DefaultLifecycleObserver
 import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.lifecycle.lifecycleScope
+import com.d4rk.android.apps.apptoolkit.BuildConfig
 import com.d4rk.android.apps.apptoolkit.core.di.initializeKoin
 import com.d4rk.android.apps.apptoolkit.core.utils.constants.ads.AdsConstants
 import com.d4rk.android.libs.apptoolkit.data.core.BaseCoreManager
@@ -37,7 +39,21 @@ class AppToolkit : BaseCoreManager(), DefaultLifecycleObserver {
     }
 
     override fun onStart(owner: LifecycleOwner) {
-        currentActivity?.let { adsCoreManager.showAdIfAvailable(it, owner.lifecycleScope) }
+        val startTime = System.currentTimeMillis()
+        Log.d("AppToolkit", "onStart at $startTime")
+        currentActivity?.let { activity ->
+            if (BuildConfig.DEFER_APP_OPEN) {
+                activity.window.decorView.post {
+                    val firstFrameTime = System.currentTimeMillis()
+                    Log.d("AppToolkit", "first frame at $firstFrameTime")
+                    adsCoreManager.showAdIfAvailable(activity, owner.lifecycleScope)
+                    Log.d("AppToolkit", "ad show at ${System.currentTimeMillis()}")
+                }
+            } else {
+                adsCoreManager.showAdIfAvailable(activity, owner.lifecycleScope)
+                Log.d("AppToolkit", "ad show at ${System.currentTimeMillis()}")
+            }
+        }
     }
 
     override fun onResume(owner: LifecycleOwner) {


### PR DESCRIPTION
## Summary
- Add BuildConfig flag `DEFER_APP_OPEN` to control ad deferral
- Postpone app open ad until the first frame and log timing data

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0128d9e14832d83d558b3b7fe0b22