### PR TITLE
Reuse AdView instances via pooling

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdViewPool.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdViewPool.kt
@@ -1,0 +1,18 @@
+package com.d4rk.android.libs.apptoolkit.core.ui.components.ads
+
+import android.content.Context
+import com.google.android.gms.ads.AdView
+
+object AdViewPool {
+    private val pool = mutableMapOf<String, AdView>()
+
+    fun acquire(context: Context, adUnitId: String): AdView {
+        return pool.remove(adUnitId) ?: AdView(context).apply {
+            this.adUnitId = adUnitId
+        }
+    }
+
+    fun release(adUnitId: String, adView: AdView) {
+        pool[adUnitId] = adView
+    }
+}


### PR DESCRIPTION
## Summary
- add AdViewPool to retain AdView instances by ad unit ID
- reuse pooled AdView in AdBanner and only load when needed

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a02c5de070832da877abc0ad7469db