### PR TITLE
Refactor ads configuration handling

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportScreen.kt
@@ -65,7 +65,7 @@ fun SupportComposable(
                 NoDataScreen(
                     icon = Icons.Outlined.MoneyOff,
                     isError = true,
-                    textMessage = R.string.error_failed_to_load_sku_details
+                    textMessage = R.string.error_failed_to_load_sku_details,
                 )
             },
             onSuccess = { data: SupportScreenUiState ->
@@ -73,7 +73,7 @@ fun SupportComposable(
                     paddingValues = paddingValues,
                     activity = activity,
                     viewModel = viewModel,
-                    data = data
+                    data = data,
                 )
             })
         DefaultSnackbarHandler(
@@ -91,9 +91,9 @@ fun SupportScreenContent(
     activity: Activity,
     viewModel: SupportViewModel,
     data: SupportScreenUiState,
-    adsConfig: AdsConfig = koinInject(qualifier = named(name = "banner_medium_rectangle"))
 ) {
     val context: Context = LocalContext.current
+    val adsConfig: AdsConfig = remember { koinInject(qualifier = named(name = "banner_medium_rectangle")) }
 
     val productDetailsMap = data.products.associateBy { it.productId }
     LazyColumn(

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportScreen.kt
@@ -93,7 +93,7 @@ fun SupportScreenContent(
     data: SupportScreenUiState,
 ) {
     val context: Context = LocalContext.current
-    val adsConfig: AdsConfig = remember { koinInject(qualifier = named(name = "banner_medium_rectangle")) }
+    val adsConfig: AdsConfig = koinInject(qualifier = named(name = "banner_medium_rectangle"))
 
     val productDetailsMap = data.products.associateBy { it.productId }
     LazyColumn(

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdBanner.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdBanner.kt
@@ -11,27 +11,22 @@ import androidx.compose.runtime.remember
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import kotlinx.coroutines.flow.map
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
-import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoProvider
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
 import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
 import com.google.android.gms.ads.AdRequest
-import org.koin.compose.koinInject
 import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.AdViewPool
 
 @Composable
-fun AdBanner(modifier : Modifier = Modifier , adsConfig : AdsConfig , buildInfoProvider : BuildInfoProvider = koinInject()) {
+fun AdBanner(modifier : Modifier = Modifier , adsConfig : AdsConfig) {
     val context: Context = LocalContext.current
     val dataStore: CommonDataStore = remember { CommonDataStore.getInstance(context = context) }
-    val showAds: Boolean? by dataStore.ads(default = !buildInfoProvider.isDebugBuild)
-        .map { it as Boolean? }
-        .collectAsStateWithLifecycle(initialValue = null)
+    val showAds: Boolean by dataStore.adsEnabledFlow.collectAsStateWithLifecycle()
 
-    if (showAds == true) {
+    if (showAds) {
         val adView = remember(adsConfig.bannerAdUnitId) {
             AdViewPool.acquire(context, adsConfig.bannerAdUnitId)
         }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/layouts/NoDataScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/layouts/NoDataScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -51,9 +50,9 @@ fun NoDataScreen(
     onRetry: () -> Unit = {},
     showAd: Boolean = true,
     isError : Boolean = false,
-    adsConfig: AdsConfig = koinInject(qualifier = named(name = "banner_medium_rectangle")),
+    adsConfig: AdsConfig? = null,
 ) {
-    val adsConfigRemember: AdsConfig = remember { adsConfig }
+    val adsConfigRemember: AdsConfig = adsConfig ?: koinInject(qualifier = named(name = "banner_medium_rectangle"))
 
     Box(
         modifier = Modifier

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/layouts/NoDataScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/layouts/NoDataScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -50,8 +51,10 @@ fun NoDataScreen(
     onRetry: () -> Unit = {},
     showAd: Boolean = true,
     isError : Boolean = false,
-    adsConfig: AdsConfig = koinInject(qualifier = named(name = "banner_medium_rectangle"))
+    adsConfig: AdsConfig = koinInject(qualifier = named(name = "banner_medium_rectangle")),
 ) {
+    val adsConfigRemember: AdsConfig = remember { adsConfig }
+
     Box(
         modifier = Modifier
             .fillMaxSize()
@@ -85,11 +88,12 @@ fun NoDataScreen(
 
             LargeVerticalSpacer()
 
-            if(showAd) {
+            if (showAd) {
                 AdBanner(
                     modifier = Modifier
                         .fillMaxWidth()
-                        .padding(bottom = SizeConstants.MediumSize), adsConfig = adsConfig
+                        .padding(bottom = SizeConstants.MediumSize),
+                    adsConfig = adsConfigRemember
                 )
             }
         }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/core/ads/AdsCoreManager.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/core/ads/AdsCoreManager.kt
@@ -13,7 +13,9 @@ import com.google.android.gms.ads.MobileAds
 import com.google.android.gms.ads.appopen.AppOpenAd
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.util.Date
 
 open class AdsCoreManager(protected val context : Context , val buildInfoProvider : BuildInfoProvider) {
@@ -77,8 +79,9 @@ open class AdsCoreManager(protected val context : Context , val buildInfoProvide
         suspend fun showAdIfAvailable(
             activity : Activity , onShowAdCompleteListener : OnShowAdCompleteListener
         ) {
-            val isAdsChecked : Boolean =
-                dataStore.ads(default = ! buildInfoProvider.isDebugBuild).first()
+            val isAdsChecked : Boolean = withContext(Dispatchers.IO) {
+                dataStore.ads(default = !buildInfoProvider.isDebugBuild).first()
+            }
 
             if (isShowingAd || ! isAdsChecked) {
                 return

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/datastore/CommonDataStore.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/datastore/CommonDataStore.kt
@@ -12,8 +12,13 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.datastore.DataStoreNamesConstants
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 
 val Context.commonDataStore : DataStore<Preferences> by preferencesDataStore(name = DataStoreNamesConstants.DATA_STORE_SETTINGS)
 
@@ -29,6 +34,7 @@ val Context.commonDataStore : DataStore<Preferences> by preferencesDataStore(nam
  */
 open class CommonDataStore(context : Context) {
     val dataStore : DataStore<Preferences> = context.commonDataStore
+    private val scope = CoroutineScope(context = Dispatchers.IO)
 
     companion object {
         @Volatile
@@ -201,6 +207,12 @@ open class CommonDataStore(context : Context) {
     fun ads(default : Boolean) : Flow<Boolean> = dataStore.data.map { prefs : Preferences ->
         prefs[adsKey] ?: default
     }
+    val adsEnabledFlow: StateFlow<Boolean> =
+        ads(default = true).stateIn(
+            scope = scope,
+            started = SharingStarted.Eagerly,
+            initialValue = true
+        )
 
     suspend fun saveAds(isChecked : Boolean) {
         dataStore.edit { preferences : MutablePreferences ->


### PR DESCRIPTION
## Summary
- inject AdsConfig inline in NoDataScreen with default koin injection and remember it for banner rendering
- delegate AdsConfig injection to SupportScreenContent for banner usage
- wrap ads-enabled flag retrieval in AdsCoreManager with IO dispatcher and cache flag in CommonDataStore for AdBanner

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a0767947ac832da16c2021d373f2ad