### PR TITLE
Remember Koin injections in AppsList

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/AppsList.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/AppsList.kt
@@ -27,7 +27,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.NonLazyGrid
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.animateVisibility
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.ScreenHelper
-import org.koin.compose.koinInject
+import org.koin.compose.getKoin
 import org.koin.core.qualifier.named
 
 @Composable
@@ -43,10 +43,11 @@ fun AppsList(
     val columnCount: Int = if (isTabletOrLandscape) 4 else 2
 
     val bannerType: String = if (isTabletOrLandscape) "full_banner" else "banner_medium_rectangle"
-    val adsConfig: AdsConfig = remember { koinInject(qualifier = named(bannerType)) }
+    val koin = getKoin()
+    val adsConfig: AdsConfig = remember { koin.get(qualifier = named(bannerType)) }
     val listState: LazyGridState = rememberLazyGridState()
     val adFrequency = 4
-    val dataStore: DataStore = remember { koinInject<DataStore>() }
+    val dataStore: DataStore = remember { koin.get() }
     val adsEnabled: Boolean by remember { dataStore.ads(default = true) }.collectAsState(initial = true)
     val items: List<AppListItem> = remember(key1 = apps, key2 = adsEnabled) {
         buildList {

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/AppsList.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/AppsList.kt
@@ -43,10 +43,10 @@ fun AppsList(
     val columnCount: Int = if (isTabletOrLandscape) 4 else 2
 
     val bannerType: String = if (isTabletOrLandscape) "full_banner" else "banner_medium_rectangle"
-    val adsConfig: AdsConfig = koinInject(qualifier = named(bannerType))
+    val adsConfig: AdsConfig = remember { koinInject(qualifier = named(bannerType)) }
     val listState: LazyGridState = rememberLazyGridState()
     val adFrequency = 4
-    val dataStore: DataStore = koinInject()
+    val dataStore: DataStore = remember { koinInject<DataStore>() }
     val adsEnabled: Boolean by remember { dataStore.ads(default = true) }.collectAsState(initial = true)
     val items: List<AppListItem> = remember(key1 = apps, key2 = adsEnabled) {
         buildList {


### PR DESCRIPTION
## Summary
- remember Koin-injected AdsConfig and DataStore instances in AppsList
- use remembered instances for ad configuration and DataStore flows

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a186e05f24832d9b5577ce017e1437