### PR TITLE
Initialize ads only when enabled

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/AppToolkit.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/AppToolkit.kt
@@ -32,7 +32,7 @@ class AppToolkit : BaseCoreManager(), DefaultLifecycleObserver {
         listOf(async { initializeAds() }).awaitAll()
     }
 
-    private fun initializeAds() {
+    private suspend fun initializeAds() {
         adsCoreManager.initializeAds(AdsConstants.APP_OPEN_UNIT_ID)
     }
 

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/core/ads/AdsCoreManager.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/core/ads/AdsCoreManager.kt
@@ -22,9 +22,14 @@ open class AdsCoreManager(protected val context : Context , val buildInfoProvide
     private var dataStore : CommonDataStore = CommonDataStore.getInstance(context = context)
     private var appOpenAdManager : AppOpenAdManager? = null
 
-    fun initializeAds(appOpenUnitId : String) {
-        MobileAds.initialize(context)
-        appOpenAdManager = AppOpenAdManager(appOpenUnitId)
+    suspend fun initializeAds(appOpenUnitId : String) {
+        val isAdsChecked : Boolean = withContext(Dispatchers.IO) {
+            dataStore.ads(default = !buildInfoProvider.isDebugBuild).first()
+        }
+        if (isAdsChecked) {
+            MobileAds.initialize(context)
+            appOpenAdManager = AppOpenAdManager(appOpenUnitId)
+        }
     }
 
     fun showAdIfAvailable(activity : Activity , scope : CoroutineScope) {

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/data/core/ads/TestAdsCoreManager.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/data/core/ads/TestAdsCoreManager.kt
@@ -17,6 +17,7 @@ import io.mockk.verify
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
 import kotlin.coroutines.Continuation
 import kotlin.coroutines.EmptyCoroutineContext
 import org.junit.Assert.assertFalse
@@ -40,10 +41,16 @@ class TestAdsCoreManager {
         val provider = mockk<BuildInfoProvider>()
         val manager = AdsCoreManager(context, provider)
 
+        val dataStore = mockk<CommonDataStore>()
+        every { dataStore.ads(any()) } returns flowOf(true)
+        val storeField = AdsCoreManager::class.java.getDeclaredField("dataStore")
+        storeField.isAccessible = true
+        storeField.set(manager, dataStore)
+
         mockkStatic(MobileAds::class)
         justRun { MobileAds.initialize(context) }
 
-        manager.initializeAds("id")
+        runBlocking { manager.initializeAds("id") }
         verify { MobileAds.initialize(context) }
         println("🏁 [TEST DONE] initializeAds triggers MobileAds")
     }
@@ -68,7 +75,12 @@ class TestAdsCoreManager {
         every { context.applicationContext } returns context
         val provider = mockk<BuildInfoProvider>()
         val manager = AdsCoreManager(context, provider)
-        manager.initializeAds("unit")
+        val dataStore = mockk<CommonDataStore>()
+        every { dataStore.ads(any()) } returns flowOf(true)
+        val storeField = AdsCoreManager::class.java.getDeclaredField("dataStore")
+        storeField.isAccessible = true
+        storeField.set(manager, dataStore)
+        runBlocking { manager.initializeAds("unit") }
 
         val mgrField = AdsCoreManager::class.java.getDeclaredField("appOpenAdManager")
         mgrField.isAccessible = true
@@ -108,13 +120,12 @@ class TestAdsCoreManager {
         every { context.applicationContext } returns context
         val provider = mockk<BuildInfoProvider>()
         val manager = AdsCoreManager(context, provider)
-        manager.initializeAds("unit")
-
         val dataStore = mockk<CommonDataStore>()
         every { dataStore.ads(any()) } returns flowOf(true)
         val storeField = AdsCoreManager::class.java.getDeclaredField("dataStore")
         storeField.isAccessible = true
         storeField.set(manager, dataStore)
+        runBlocking { manager.initializeAds("unit") }
 
         mockkStatic(AppOpenAd::class)
         justRun { AppOpenAd.load(any(), any(), any(), any()) }
@@ -145,13 +156,12 @@ class TestAdsCoreManager {
         every { context.applicationContext } returns context
         val provider = mockk<BuildInfoProvider>()
         val manager = AdsCoreManager(context, provider)
-        manager.initializeAds("unit")
-
         val dataStore = mockk<CommonDataStore>()
         every { dataStore.ads(any()) } returns flowOf(true)
         val storeField = AdsCoreManager::class.java.getDeclaredField("dataStore")
         storeField.isAccessible = true
         storeField.set(manager, dataStore)
+        runBlocking { manager.initializeAds("unit") }
 
         val ad = mockk<AppOpenAd>(relaxed = true)
         val mgrField3 = AdsCoreManager::class.java.getDeclaredField("appOpenAdManager")
@@ -194,13 +204,12 @@ class TestAdsCoreManager {
         every { context.applicationContext } returns context
         val provider = mockk<BuildInfoProvider>()
         val manager = AdsCoreManager(context, provider)
-        manager.initializeAds("unit")
-
         val dataStore = mockk<CommonDataStore>()
         every { dataStore.ads(any()) } returns flowOf(false)
         val storeField = AdsCoreManager::class.java.getDeclaredField("dataStore")
         storeField.isAccessible = true
         storeField.set(manager, dataStore)
+        runBlocking { manager.initializeAds("unit") }
 
         mockkStatic(AppOpenAd::class)
         justRun { AppOpenAd.load(any(), any(), any(), any()) }
@@ -219,13 +228,12 @@ class TestAdsCoreManager {
         every { context.applicationContext } returns context
         val provider = mockk<BuildInfoProvider>()
         val manager = AdsCoreManager(context, provider)
-        manager.initializeAds("unit")
-
         val dataStore = mockk<CommonDataStore>()
         every { dataStore.ads(any()) } returns flowOf(true)
         val storeField = AdsCoreManager::class.java.getDeclaredField("dataStore")
         storeField.isAccessible = true
         storeField.set(manager, dataStore)
+        runBlocking { manager.initializeAds("unit") }
 
         val mgrField = AdsCoreManager::class.java.getDeclaredField("appOpenAdManager")
         mgrField.isAccessible = true
@@ -257,13 +265,12 @@ class TestAdsCoreManager {
         every { context.applicationContext } returns context
         val provider = mockk<BuildInfoProvider>()
         val manager = AdsCoreManager(context, provider)
-        manager.initializeAds("unit")
-
         val dataStore = mockk<CommonDataStore>()
         every { dataStore.ads(any()) } returns flowOf(true)
         val storeField = AdsCoreManager::class.java.getDeclaredField("dataStore")
         storeField.isAccessible = true
         storeField.set(manager, dataStore)
+        runBlocking { manager.initializeAds("unit") }
 
         val mgrField = AdsCoreManager::class.java.getDeclaredField("appOpenAdManager")
         mgrField.isAccessible = true
@@ -295,13 +302,12 @@ class TestAdsCoreManager {
         every { context.applicationContext } returns context
         val provider = mockk<BuildInfoProvider>()
         val manager = AdsCoreManager(context, provider)
-        manager.initializeAds("unit")
-
         val dataStore = mockk<CommonDataStore>()
         every { dataStore.ads(any()) } returns flowOf(true)
         val storeField = AdsCoreManager::class.java.getDeclaredField("dataStore")
         storeField.isAccessible = true
         storeField.set(manager, dataStore)
+        runBlocking { manager.initializeAds("unit") }
 
         val mgrField = AdsCoreManager::class.java.getDeclaredField("appOpenAdManager")
         mgrField.isAccessible = true
@@ -340,13 +346,12 @@ class TestAdsCoreManager {
         every { context.applicationContext } returns context
         val provider = mockk<BuildInfoProvider>()
         val manager = AdsCoreManager(context, provider)
-        manager.initializeAds("unit")
-
         val dataStore = mockk<CommonDataStore>()
         every { dataStore.ads(any()) } returns flowOf(true)
         val storeField = AdsCoreManager::class.java.getDeclaredField("dataStore")
         storeField.isAccessible = true
         storeField.set(manager, dataStore)
+        runBlocking { manager.initializeAds("unit") }
 
         val mgrField = AdsCoreManager::class.java.getDeclaredField("appOpenAdManager")
         mgrField.isAccessible = true
@@ -374,14 +379,13 @@ class TestAdsCoreManager {
         val provider = mockk<BuildInfoProvider>()
         every { provider.isDebugBuild } returns true
         val manager = AdsCoreManager(context, provider)
-        manager.initializeAds("unit")
-
         val dataStore = mockk<CommonDataStore>()
         val slot = slot<Boolean>()
         every { dataStore.ads(capture(slot)) } returns flowOf(false)
         val storeField = AdsCoreManager::class.java.getDeclaredField("dataStore")
         storeField.isAccessible = true
         storeField.set(manager, dataStore)
+        runBlocking { manager.initializeAds("unit") }
 
         mockkStatic(AppOpenAd::class)
         justRun { AppOpenAd.load(any(), any(), any(), any()) }
@@ -401,14 +405,13 @@ class TestAdsCoreManager {
         val provider = mockk<BuildInfoProvider>()
         every { provider.isDebugBuild } returns false
         val manager = AdsCoreManager(context, provider)
-        manager.initializeAds("unit")
-
         val dataStore = mockk<CommonDataStore>()
         val slot = slot<Boolean>()
         every { dataStore.ads(capture(slot)) } returns flowOf(true)
         val storeField = AdsCoreManager::class.java.getDeclaredField("dataStore")
         storeField.isAccessible = true
         storeField.set(manager, dataStore)
+        runBlocking { manager.initializeAds("unit") }
 
         mockkStatic(AppOpenAd::class)
         justRun { AppOpenAd.load(any(), any(), any(), any()) }


### PR DESCRIPTION
## Summary
- read ad preference from DataStore on `Dispatchers.IO`
- only initialize MobileAds and AppOpenAdManager when ads are enabled
- update tests for new suspend initialization

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a18711a98c832da7a94fca5b3f8a59