### PR TITLE
Obtain AdsConfig inside BottomNavigationBar

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/main/ui/components/navigation/BottomNavigationBar.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/main/ui/components/navigation/BottomNavigationBar.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
@@ -44,7 +43,7 @@ fun BottomNavigationBar(
     val dataStore: CommonDataStore = CommonDataStore.getInstance(context = context)
     val backStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = backStackEntry?.destination?.route ?: navController.currentDestination?.route
-    val adsConfig: AdsConfig = remember { koinInject(named("full_banner")) }
+    val adsConfig: AdsConfig = koinInject(qualifier = named("full_banner"))
 
     val showLabels: Boolean =
         dataStore.getShowBottomBarLabels().collectAsState(initial = true).value

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/main/ui/components/navigation/BottomNavigationBar.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/main/ui/components/navigation/BottomNavigationBar.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
@@ -36,14 +37,14 @@ fun BottomNavigationBar(
     navController: NavController,
     items: List<BottomBarItem>,
     modifier: Modifier = Modifier,
-    adsConfig: AdsConfig = koinInject(qualifier = named(name = "full_banner")),
 ) {
-    val hapticFeedback : HapticFeedback = LocalHapticFeedback.current
-    val view : View = LocalView.current
+    val hapticFeedback: HapticFeedback = LocalHapticFeedback.current
+    val view: View = LocalView.current
     val context = LocalContext.current
     val dataStore: CommonDataStore = CommonDataStore.getInstance(context = context)
     val backStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = backStackEntry?.destination?.route ?: navController.currentDestination?.route
+    val adsConfig: AdsConfig = remember { koinInject(named("full_banner")) }
 
     val showLabels: Boolean =
         dataStore.getShowBottomBarLabels().collectAsState(initial = true).value


### PR DESCRIPTION
## Summary
- Remove `adsConfig` parameter from `BottomNavigationBar`
- Retrieve ads config via `remember { koinInject(named("full_banner")) }`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a186f90594832d87242e08a777031e