### PR TITLE
feat: add coroutine-based review helper

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainActivity.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainActivity.kt
@@ -107,9 +107,10 @@ class MainActivity : AppCompatActivity() {
             ReviewHelper.launchInAppReviewIfEligible(
                 activity = this@MainActivity,
                 sessionCount = sessionCount,
-                hasPromptedBefore = hasPrompted
+                hasPromptedBefore = hasPrompted,
+                scope = this
             ) {
-                lifecycleScope.launch { dataStore.setHasPromptedReview(value = true) }
+                launch { dataStore.setHasPromptedReview(value = true) }
             }
             dataStore.incrementSessionCount()
         }

--- a/apptoolkit/build.gradle.kts
+++ b/apptoolkit/build.gradle.kts
@@ -103,6 +103,7 @@ dependencies {
 
     // Kotlin
     api(dependencyNotation = libs.kotlinx.coroutines.android)
+    api(dependencyNotation = libs.kotlinx.coroutines.play.services)
     api(dependencyNotation = libs.kotlinx.serialization.json)
 
     // Ktor

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpActivity.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpActivity.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.lifecycleScope
 import com.d4rk.android.libs.apptoolkit.app.help.domain.data.model.HelpScreenConfig
 import com.d4rk.android.libs.apptoolkit.app.theme.style.AppTheme
 import org.koin.android.ext.android.inject
@@ -21,7 +22,7 @@ class HelpActivity : AppCompatActivity() {
         setContent {
             AppTheme {
                 Surface(modifier = Modifier.fillMaxSize() , color = MaterialTheme.colorScheme.background) {
-                    HelpScreen(activity = this@HelpActivity , config = config)
+                    HelpScreen(activity = this@HelpActivity , config = config, scope = lifecycleScope)
                 }
             }
         }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpScreen.kt
@@ -37,6 +37,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.MediumVertica
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.IntentsHelper
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.ReviewHelper
+import androidx.lifecycle.lifecycleScope
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -54,7 +55,7 @@ fun HelpScreen(activity : Activity , config : HelpScreenConfig) {
         HelpScreenMenuActions(context = context , activity = activity , showDialog = remember { mutableStateOf(value = false) } , config = config)
     } , scrollBehavior = scrollBehavior , floatingActionButton = {
         AnimatedExtendedFloatingActionButton(visible = true , expanded = isFabExtended.value , onClick = {
-            ReviewHelper.forceLaunchInAppReview(activity = activity)
+            ReviewHelper.forceLaunchInAppReview(activity = activity, scope = activity.lifecycleScope)
         } , text = { Text(text = stringResource(id = R.string.feedback)) } , icon = { Icon(Icons.Outlined.RateReview , contentDescription = null) })
     }) { paddingValues ->
         HelpScreenContent(questions = faqList , paddingValues = paddingValues , activity = activity)

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpScreen.kt
@@ -1,6 +1,6 @@
 package com.d4rk.android.libs.apptoolkit.app.help.ui
 
-import android.app.Activity
+import androidx.activity.ComponentActivity
 import android.content.Context
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Spacer
@@ -41,7 +41,7 @@ import androidx.lifecycle.lifecycleScope
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun HelpScreen(activity : Activity , config : HelpScreenConfig) {
+fun HelpScreen(activity : ComponentActivity , config : HelpScreenConfig) {
     val scrollBehavior : TopAppBarScrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(state = rememberTopAppBarState())
     val context : Context = LocalContext.current
     val isFabExtended : MutableState<Boolean> = remember { mutableStateOf(value = true) }
@@ -63,7 +63,7 @@ fun HelpScreen(activity : Activity , config : HelpScreenConfig) {
 }
 
 @Composable
-fun HelpScreenContent(questions : List<UiHelpQuestion> , paddingValues : PaddingValues , activity : Activity) {
+fun HelpScreenContent(questions : List<UiHelpQuestion> , paddingValues : PaddingValues , activity : ComponentActivity) {
     LazyColumn(
         modifier = Modifier.fillMaxSize() , contentPadding = PaddingValues(
             top = paddingValues.calculateTopPadding() , bottom = paddingValues.calculateBottomPadding() , start = SizeConstants.LargeSize , end = SizeConstants.LargeSize

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpScreen.kt
@@ -37,11 +37,11 @@ import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.MediumVertica
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.IntentsHelper
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.ReviewHelper
-import androidx.lifecycle.lifecycleScope
+import kotlinx.coroutines.CoroutineScope
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun HelpScreen(activity : ComponentActivity , config : HelpScreenConfig) {
+fun HelpScreen(activity: ComponentActivity, config: HelpScreenConfig, scope: CoroutineScope) {
     val scrollBehavior : TopAppBarScrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(state = rememberTopAppBarState())
     val context : Context = LocalContext.current
     val isFabExtended : MutableState<Boolean> = remember { mutableStateOf(value = true) }
@@ -51,14 +51,31 @@ fun HelpScreen(activity : ComponentActivity , config : HelpScreenConfig) {
         isFabExtended.value = scrollBehavior.state.contentOffset >= 0f
     }
 
-    LargeTopAppBarWithScaffold(title = stringResource(id = R.string.help) , onBackClicked = { activity.finish() } , actions = {
-        HelpScreenMenuActions(context = context , activity = activity , showDialog = remember { mutableStateOf(value = false) } , config = config)
-    } , scrollBehavior = scrollBehavior , floatingActionButton = {
-        AnimatedExtendedFloatingActionButton(visible = true , expanded = isFabExtended.value , onClick = {
-            ReviewHelper.forceLaunchInAppReview(activity = activity, scope = activity.lifecycleScope)
-        } , text = { Text(text = stringResource(id = R.string.feedback)) } , icon = { Icon(Icons.Outlined.RateReview , contentDescription = null) })
-    }) { paddingValues ->
-        HelpScreenContent(questions = faqList , paddingValues = paddingValues , activity = activity)
+    LargeTopAppBarWithScaffold(
+        title = stringResource(id = R.string.help),
+        onBackClicked = { activity.finish() },
+        actions = {
+            HelpScreenMenuActions(
+                context = context,
+                activity = activity,
+                showDialog = remember { mutableStateOf(value = false) },
+                config = config
+            )
+        },
+        scrollBehavior = scrollBehavior,
+        floatingActionButton = {
+            AnimatedExtendedFloatingActionButton(
+                visible = true,
+                expanded = isFabExtended.value,
+                onClick = {
+                    ReviewHelper.forceLaunchInAppReview(activity = activity, scope = scope)
+                },
+                text = { Text(text = stringResource(id = R.string.feedback)) },
+                icon = { Icon(Icons.Outlined.RateReview, contentDescription = null) }
+            )
+        }
+    ) { paddingValues ->
+        HelpScreenContent(questions = faqList, paddingValues = paddingValues, activity = activity)
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -116,6 +116,7 @@ aboutlibraries-compose-m3 = { module = "com.mikepenz:aboutlibraries-compose-m3",
 konfetti-compose = { module = "nl.dionsegijn:konfetti-compose", version.ref = "konfettiCompose" }
 kotlinx-serialization-json = { module = "org.jetbrains.kotlinx:kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 kotlinx-coroutines-android = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinxCoroutinesAndroid" }
+kotlinx-coroutines-play-services = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-play-services", version.ref = "kotlinxCoroutinesAndroid" }
 core = { module = "io.noties.markwon:core", version.ref = "core" }
 
 # --- TESTING ---


### PR DESCRIPTION
## Summary
- add suspend `launchReview` using Play review coroutines
- invoke review helper functions within caller scopes
- wire up app and help screen to new API and add play-services coroutine dependency

## Testing
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a187ba2710832dafb5ebf5339cda06