### PR TITLE
Remember AdsConfig injection in SupportScreen

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportScreen.kt
@@ -93,7 +93,9 @@ fun SupportScreenContent(
     data: SupportScreenUiState,
 ) {
     val context: Context = LocalContext.current
-    val adsConfig: AdsConfig = koinInject(qualifier = named(name = "banner_medium_rectangle"))
+    val adsConfig: AdsConfig = remember {
+        koinInject(qualifier = named(name = "banner_medium_rectangle"))
+    }
 
     val productDetailsMap = data.products.associateBy { it.productId }
     LazyColumn(


### PR DESCRIPTION
## Summary
- remember AdsConfig injection in SupportScreen to avoid recomposition lookups
- pass the remembered AdsConfig to AdBanner

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a18d056ea4832d8096681493c6b40b