### PR TITLE
Wrap issue reporter network call in IO dispatcher

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/IssueReporterViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/IssueReporterViewModel.kt
@@ -38,7 +38,7 @@ class IssueReporterViewModel(
     )
 ) {
 
-    private val repository = IssueReporterRepository(httpClient)
+    private val repository = IssueReporterRepository(httpClient, dispatcherProvider)
 
     override fun onEvent(event: IssueReporterEvent) {
         when (event) {

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/data/TestIssueReporterRepository.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/data/TestIssueReporterRepository.kt
@@ -17,6 +17,7 @@ import com.google.common.truth.Truth.assertThat
 import kotlin.test.assertFailsWith
 import org.junit.jupiter.api.Test
 import java.net.SocketTimeoutException
+import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.TestDispatchers
 
 class TestIssueReporterRepository {
 
@@ -32,7 +33,7 @@ class TestIssueReporterRepository {
         val client = HttpClient(engine) {
             install(ContentNegotiation) { json() }
         }
-        val repository = IssueReporterRepository(client)
+        val repository = IssueReporterRepository(client, TestDispatchers())
         val report = Report("title", "desc", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo(android.app.Application()), ExtraInfo(), "me@test.com")
         val target = GithubTarget("user", "repo")
         val result = repository.sendReport(report, target, token = "token123")
@@ -48,7 +49,7 @@ class TestIssueReporterRepository {
         println("\uD83D\uDE80 [TEST] repository error")
         val engine = MockEngine { respond("fail", HttpStatusCode.BadRequest) }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
-        val repository = IssueReporterRepository(client)
+        val repository = IssueReporterRepository(client, TestDispatchers())
         val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
         val result = repository.sendReport(report, target)
@@ -68,7 +69,7 @@ class TestIssueReporterRepository {
             respond("""{"html_url":"https://example.com/issue/2"}""", HttpStatusCode.Created)
         }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
-        val repository = IssueReporterRepository(client)
+        val repository = IssueReporterRepository(client, TestDispatchers())
         val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
 
@@ -82,7 +83,7 @@ class TestIssueReporterRepository {
     fun `sendReport network exception`() = runTest {
         val engine = MockEngine { throw SocketTimeoutException("timeout") }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
-        val repository = IssueReporterRepository(client)
+        val repository = IssueReporterRepository(client, TestDispatchers())
         val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
 
@@ -95,7 +96,7 @@ class TestIssueReporterRepository {
     fun `sendReport malformed json`() = runTest {
         val engine = MockEngine { respond("{", HttpStatusCode.Created) }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
-        val repository = IssueReporterRepository(client)
+        val repository = IssueReporterRepository(client, TestDispatchers())
         val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
 
@@ -108,7 +109,7 @@ class TestIssueReporterRepository {
     fun `sendReport unsupported status`() = runTest {
         val engine = MockEngine { respond("weird", HttpStatusCode.PaymentRequired) }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
-        val repository = IssueReporterRepository(client)
+        val repository = IssueReporterRepository(client, TestDispatchers())
         val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
 
@@ -127,7 +128,7 @@ class TestIssueReporterRepository {
             respond("""{"html_url":"https://ex.com/1"}""", HttpStatusCode.Created)
         }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
-        val repository = IssueReporterRepository(client)
+        val repository = IssueReporterRepository(client, TestDispatchers())
         val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
 
@@ -139,7 +140,7 @@ class TestIssueReporterRepository {
     fun `sendReport handles bad gateway`() = runTest {
         val engine = MockEngine { respond("broke", HttpStatusCode.BadGateway) }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
-        val repository = IssueReporterRepository(client)
+        val repository = IssueReporterRepository(client, TestDispatchers())
         val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
 
@@ -154,7 +155,7 @@ class TestIssueReporterRepository {
     fun `sendReport handles teapot`() = runTest {
         val engine = MockEngine { respond("hot", HttpStatusCode.fromValue(418)) }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
-        val repository = IssueReporterRepository(client)
+        val repository = IssueReporterRepository(client, TestDispatchers())
         val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
 
@@ -169,7 +170,7 @@ class TestIssueReporterRepository {
     fun `sendReport null pointer exception`() = runTest {
         val engine = MockEngine { throw NullPointerException("boom") }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
-        val repository = IssueReporterRepository(client)
+        val repository = IssueReporterRepository(client, TestDispatchers())
         val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
 
@@ -182,7 +183,7 @@ class TestIssueReporterRepository {
     fun `sendReport illegal state exception`() = runTest {
         val engine = MockEngine { throw IllegalStateException("illegal") }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
-        val repository = IssueReporterRepository(client)
+        val repository = IssueReporterRepository(client, TestDispatchers())
         val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
 
@@ -195,7 +196,7 @@ class TestIssueReporterRepository {
     fun `sendReport unauthorized`() = runTest {
         val engine = MockEngine { respond("unauth", HttpStatusCode.Unauthorized) }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
-        val repository = IssueReporterRepository(client)
+        val repository = IssueReporterRepository(client, TestDispatchers())
         val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
 
@@ -210,7 +211,7 @@ class TestIssueReporterRepository {
     fun `sendReport forbidden`() = runTest {
         val engine = MockEngine { respond("stop", HttpStatusCode.Forbidden) }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
-        val repository = IssueReporterRepository(client)
+        val repository = IssueReporterRepository(client, TestDispatchers())
         val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
 
@@ -225,7 +226,7 @@ class TestIssueReporterRepository {
     fun `sendReport created without url`() = runTest {
         val engine = MockEngine { respond("{}", HttpStatusCode.Created) }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
-        val repository = IssueReporterRepository(client)
+        val repository = IssueReporterRepository(client, TestDispatchers())
         val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
 


### PR DESCRIPTION
## Summary
- run issue reporter calls on the IO dispatcher
- pass DispatcherProvider through IssueReporterViewModel
- update repository tests to use TestDispatchers

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a18cf57fc0832dae30f63e8fbc878b