### PR TITLE
Run ad and consent initialization concurrently

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainActivity.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainActivity.kt
@@ -26,9 +26,11 @@ import com.google.android.play.core.appupdate.AppUpdateManagerFactory
 import com.google.android.ump.ConsentInformation
 import com.google.android.ump.UserMessagingPlatform
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.async
+import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 import org.koin.android.ext.android.inject
 
 class MainActivity : AppCompatActivity() {
@@ -56,9 +58,12 @@ class MainActivity : AppCompatActivity() {
 
     private fun initializeDependencies() {
         lifecycleScope.launch {
-            MobileAds.initialize(this@MainActivity) {}
-            withContext(Dispatchers.IO) {
-                ConsentManagerHelper.applyInitialConsent(dataStore)
+            coroutineScope {
+                val adsInitialization = async { MobileAds.initialize(this@MainActivity) {} }
+                val consentInitialization = async(Dispatchers.IO) {
+                    ConsentManagerHelper.applyInitialConsent(dataStore)
+                }
+                awaitAll(adsInitialization, consentInitialization)
             }
         }
     }


### PR DESCRIPTION
## Summary
- initialize MobileAds and consent handling in parallel using coroutineScope

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a19acf3b5c832d8dad9758f6c63fe2