### PR TITLE
Use remember for ad configuration

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/layouts/NoDataScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/layouts/NoDataScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -52,7 +53,7 @@ fun NoDataScreen(
     isError : Boolean = false,
     adsConfig: AdsConfig? = null,
 ) {
-    val adsConfigRemember: AdsConfig = adsConfig ?: koinInject(qualifier = named(name = "banner_medium_rectangle"))
+    val adsConfigRemember = remember { adsConfig ?: koinInject(qualifier = named("banner_medium_rectangle")) }
 
     Box(
         modifier = Modifier


### PR DESCRIPTION
## Summary
- memoize ad configuration with `remember` to avoid recomposition costs

## Testing
- `./gradlew test --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a19b3b441c832dbcb46a0ce78c18e7