### PR TITLE
Wrap dependency injections with remember in BottomNavigationBar

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/main/ui/components/navigation/BottomNavigationBar.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/main/ui/components/navigation/BottomNavigationBar.kt
@@ -13,6 +13,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
@@ -40,10 +41,10 @@ fun BottomNavigationBar(
     val hapticFeedback: HapticFeedback = LocalHapticFeedback.current
     val view: View = LocalView.current
     val context = LocalContext.current
-    val dataStore: CommonDataStore = CommonDataStore.getInstance(context = context)
+    val dataStore: CommonDataStore = remember { CommonDataStore.getInstance(context = context) }
     val backStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = backStackEntry?.destination?.route ?: navController.currentDestination?.route
-    val adsConfig: AdsConfig = koinInject(qualifier = named("full_banner"))
+    val adsConfig: AdsConfig = remember { koinInject(qualifier = named("full_banner")) }
 
     val showLabels: Boolean =
         dataStore.getShowBottomBarLabels().collectAsState(initial = true).value


### PR DESCRIPTION
## Summary
- wrap CommonDataStore and koinInject lookups with `remember`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a19b434268832d8a6d6e3d9cc02ee3