### PR TITLE
Add deque-based AdView pooling with preload support

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdBanner.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdBanner.kt
@@ -28,6 +28,7 @@ fun AdBanner(modifier : Modifier = Modifier , adsConfig : AdsConfig) {
 
     if (showAds) {
         val adView = remember(adsConfig.bannerAdUnitId) {
+            AdViewPool.preload(context, adsConfig.bannerAdUnitId)
             AdViewPool.acquire(context, adsConfig.bannerAdUnitId)
         }
         val adRequest = remember { AdRequest.Builder().build() }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdViewPool.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdViewPool.kt
@@ -2,17 +2,29 @@ package com.d4rk.android.libs.apptoolkit.core.ui.components.ads
 
 import android.content.Context
 import com.google.android.gms.ads.AdView
+import kotlin.collections.ArrayDeque
 
 object AdViewPool {
-    private val pool = mutableMapOf<String, AdView>()
+    private val pool: MutableMap<String, ArrayDeque<AdView>> = mutableMapOf()
+
+    fun preload(context: Context, adUnitId: String, count: Int = 1) {
+        val deque = pool.getOrPut(adUnitId) { ArrayDeque() }
+        repeat(count) {
+            deque.add(AdView(context).apply { this.adUnitId = adUnitId })
+        }
+    }
 
     fun acquire(context: Context, adUnitId: String): AdView {
-        return pool.remove(adUnitId) ?: AdView(context).apply {
-            this.adUnitId = adUnitId
+        val deque = pool[adUnitId]
+        return if (deque != null && deque.isNotEmpty()) {
+            deque.removeFirst()
+        } else {
+            AdView(context).apply { this.adUnitId = adUnitId }
         }
     }
 
     fun release(adUnitId: String, adView: AdView) {
-        pool[adUnitId] = adView
+        val deque = pool.getOrPut(adUnitId) { ArrayDeque() }
+        deque.add(adView)
     }
 }


### PR DESCRIPTION
## Summary
- replace single AdView pool with deque-based pool
- add optional preload function for prepared AdViews
- update AdBanner to preload and use new pool implementation

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a19b52e5f0832d8778800cd67d15d8