### PR TITLE
Use IO dispatcher for developer app flows

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsViewModel.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsViewModel.kt
@@ -75,7 +75,7 @@ class FavoriteAppsViewModel(
             start = CoroutineStart.UNDISPATCHED
         ) {
             combine(
-                flow = fetchDeveloperAppsUseCase().flowOn(dispatcherProvider.default),
+                flow = fetchDeveloperAppsUseCase().flowOn(dispatcherProvider.io),
                 flow2 = favorites
             ) { dataState, favorites ->
                 dataState to favorites

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListViewModel.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListViewModel.kt
@@ -67,7 +67,7 @@ class AppsListViewModel(
 
     private fun fetchDeveloperApps() {
         launch(context = dispatcherProvider.io) {
-            fetchDeveloperAppsUseCase().flowOn(context = dispatcherProvider.default).collect { result : DataState<List<AppInfo> , RootError> ->
+            fetchDeveloperAppsUseCase().flowOn(dispatcherProvider.io).collect { result : DataState<List<AppInfo> , RootError> ->
                 when (result) {
                     is DataState.Success -> {
                         val apps = result.data


### PR DESCRIPTION
## Summary
- run developer app fetch flow on IO dispatcher in AppsListViewModel
- run developer app fetch flow on IO dispatcher in FavoriteAppsViewModel

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b94a0aac832d8ec346082dd0df06