### PR TITLE
Use coroutines for cache clearing

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/advanced/ui/AdvancedSettingsList.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/advanced/ui/AdvancedSettingsList.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
@@ -21,10 +22,12 @@ import com.d4rk.android.libs.apptoolkit.core.ui.components.preferences.SettingsP
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.SmallVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.IntentsHelper
+import kotlinx.coroutines.launch
 
 @Composable
 fun AdvancedSettingsList(paddingValues : PaddingValues = PaddingValues() , provider : AdvancedSettingsProvider) {
     val context : Context = LocalContext.current
+    val coroutineScope = rememberCoroutineScope()
 
     LazyColumn(contentPadding = paddingValues , modifier = Modifier.fillMaxHeight()) {
         item {
@@ -46,7 +49,7 @@ fun AdvancedSettingsList(paddingValues : PaddingValues = PaddingValues() , provi
                         .padding(horizontal = SizeConstants.LargeSize)
                         .clip(shape = RoundedCornerShape(size = SizeConstants.LargeSize))
             ) {
-                SettingsPreferenceItem(title = stringResource(id = R.string.clear_cache) , summary = stringResource(id = R.string.summary_preference_settings_clear_cache) , onClick = { CleanHelper.clearApplicationCache(context = context) })
+                SettingsPreferenceItem(title = stringResource(id = R.string.clear_cache) , summary = stringResource(id = R.string.summary_preference_settings_clear_cache) , onClick = { coroutineScope.launch { CleanHelper.clearApplicationCache(context = context) } })
             }
         }
     }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/advanced/utils/CleanHelper.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/advanced/utils/CleanHelper.kt
@@ -4,21 +4,28 @@ import android.content.Context
 import android.widget.Toast
 import com.d4rk.android.libs.apptoolkit.R
 import java.io.File
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 object CleanHelper {
 
-    fun clearApplicationCache(context : Context) {
+    suspend fun clearApplicationCache(context : Context) {
         val cacheDirectories : List<File> = listOf(context.cacheDir , context.codeCacheDir , context.filesDir)
 
-        var allDeleted = true
-        for (directory in cacheDirectories) {
-            if (! directory.deleteRecursively()) {
-                allDeleted = false
+        val allDeleted : Boolean = withContext(context = Dispatchers.IO) {
+            var allDeleted = true
+            for (directory in cacheDirectories) {
+                if (! directory.deleteRecursively()) {
+                    allDeleted = false
+                }
             }
+            allDeleted
         }
 
         val messageResId : Int = if (allDeleted) R.string.cache_cleared_success else R.string.cache_cleared_error
 
-        Toast.makeText(context , context.getString(messageResId) , Toast.LENGTH_SHORT).show()
+        withContext(context = Dispatchers.Main) {
+            Toast.makeText(context , context.getString(messageResId) , Toast.LENGTH_SHORT).show()
+        }
     }
 }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/advanced/utils/TestCleanHelper.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/advanced/utils/TestCleanHelper.kt
@@ -11,11 +11,12 @@ import org.junit.Test
 import kotlin.io.path.createTempDirectory
 import kotlin.test.assertFalse
 import kotlin.test.assertFailsWith
+import kotlinx.coroutines.test.runTest
 
 class TestCleanHelper {
 
     @Test
-    fun `clearApplicationCache deletes cache directories`() {
+    fun `clearApplicationCache deletes cache directories`() = runTest {
         println("🚀 [TEST] clearApplicationCache deletes cache directories")
         val dir1 = createTempDirectory().toFile()
         val dir2 = createTempDirectory().toFile()
@@ -42,7 +43,7 @@ class TestCleanHelper {
     }
 
     @Test
-    fun `clearApplicationCache shows error toast when deletion fails`() {
+    fun `clearApplicationCache shows error toast when deletion fails`() = runTest {
         println("🚀 [TEST] clearApplicationCache shows error toast when deletion fails")
         val dir1 = createTempDirectory().toFile()
         val failing = mockk<java.io.File>()
@@ -71,7 +72,7 @@ class TestCleanHelper {
     }
 
     @Test
-    fun `clearApplicationCache throws when directory inaccessible`() {
+    fun `clearApplicationCache throws when directory inaccessible`() = runTest {
         println("🚀 [TEST] clearApplicationCache throws when directory inaccessible")
         val context = mockk<Context>()
         every { context.cacheDir } throws SecurityException("denied")
@@ -83,7 +84,7 @@ class TestCleanHelper {
     }
 
     @Test
-    fun `clearApplicationCache handles missing directories`() {
+    fun `clearApplicationCache handles missing directories`() = runTest {
         println("🚀 [TEST] clearApplicationCache handles missing directories")
         val dir1 = createTempDirectory().toFile().also { it.deleteRecursively() }
         val dir2 = createTempDirectory().toFile().also { it.deleteRecursively() }
@@ -107,7 +108,7 @@ class TestCleanHelper {
     }
 
     @Test
-    fun `clearApplicationCache propagates io exception`() {
+    fun `clearApplicationCache propagates io exception`() = runTest {
         println("🚀 [TEST] clearApplicationCache propagates io exception")
         val dir1 = createTempDirectory().toFile()
         val failing = mockk<java.io.File>()
@@ -127,7 +128,7 @@ class TestCleanHelper {
     }
 
     @Test
-    fun `clearApplicationCache propagates toast exception`() {
+    fun `clearApplicationCache propagates toast exception`() = runTest {
         println("🚀 [TEST] clearApplicationCache propagates toast exception")
         val dir1 = createTempDirectory().toFile()
         val dir2 = createTempDirectory().toFile()
@@ -149,7 +150,7 @@ class TestCleanHelper {
     }
 
     @Test
-    fun `clearApplicationCache handles partial deletion`() {
+    fun `clearApplicationCache handles partial deletion`() = runTest {
         println("🚀 [TEST] clearApplicationCache handles partial deletion")
         val dir1 = createTempDirectory().toFile()
         val failing2 = mockk<java.io.File>()


### PR DESCRIPTION
## Summary
- Convert `clearApplicationCache` to a suspend function that deletes files on `Dispatchers.IO` and posts toast on `Dispatchers.Main`
- Launch cache clearing from settings UI in a coroutine
- Update tests to use `runTest` with the suspend API

## Testing
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1b9622508832d9496ab95e603a2fa