### PR TITLE
feat: improve ad view pooling

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdViewPool.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdViewPool.kt
@@ -3,28 +3,76 @@ package com.d4rk.android.libs.apptoolkit.core.ui.components.ads
 import android.content.Context
 import com.google.android.gms.ads.AdView
 import kotlin.collections.ArrayDeque
+import kotlin.concurrent.fixedRateTimer
+
+private const val MAX_POOL_SIZE = 3
+private const val TIMEOUT_MS = 5 * 60 * 1000L
+
+private data class PooledAdView(val view: AdView, var lastUsed: Long)
 
 object AdViewPool {
-    private val pool: MutableMap<String, ArrayDeque<AdView>> = mutableMapOf()
+    private val pool: MutableMap<String, ArrayDeque<PooledAdView>> = mutableMapOf()
 
-    fun preload(context: Context, adUnitId: String, count: Int = 1) {
-        val deque = pool.getOrPut(adUnitId) { ArrayDeque() }
-        repeat(count) {
-            deque.add(AdView(context).apply { this.adUnitId = adUnitId })
+    init {
+        fixedRateTimer("AdViewPoolCleanup", daemon = true, initialDelay = TIMEOUT_MS, period = TIMEOUT_MS) {
+            cleanup()
         }
     }
 
+    @Synchronized
+    fun preload(context: Context, adUnitId: String, count: Int = 1) {
+        val deque = pool.getOrPut(adUnitId) { ArrayDeque() }
+        repeat(count) {
+            if (deque.size < MAX_POOL_SIZE) {
+                deque.add(
+                    PooledAdView(
+                        AdView(context).apply { this.adUnitId = adUnitId },
+                        System.currentTimeMillis()
+                    )
+                )
+            }
+        }
+    }
+
+    @Synchronized
     fun acquire(context: Context, adUnitId: String): AdView {
         val deque = pool[adUnitId]
         return if (deque != null && deque.isNotEmpty()) {
-            deque.removeFirst()
+            deque.removeFirst().view
         } else {
             AdView(context).apply { this.adUnitId = adUnitId }
         }
     }
 
+    @Synchronized
     fun release(adUnitId: String, adView: AdView) {
+        cleanup()
         val deque = pool.getOrPut(adUnitId) { ArrayDeque() }
-        deque.add(adView)
+        if (deque.size >= MAX_POOL_SIZE) {
+            adView.destroy()
+        } else {
+            deque.add(PooledAdView(adView, System.currentTimeMillis()))
+        }
+    }
+
+    @Synchronized
+    private fun cleanup() {
+        val now = System.currentTimeMillis()
+        val iterator = pool.iterator()
+        while (iterator.hasNext()) {
+            val entry = iterator.next()
+            val deque = entry.value
+            val viewIterator = deque.iterator()
+            while (viewIterator.hasNext()) {
+                val pooled = viewIterator.next()
+                if (now - pooled.lastUsed > TIMEOUT_MS) {
+                    pooled.view.destroy()
+                    viewIterator.remove()
+                }
+            }
+            if (deque.isEmpty()) {
+                iterator.remove()
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- cap ad view pools with a max size per ad unit and store last-used timestamps
- add periodic cleanup that destroys expired pooled views and discard extras on release

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e0217308832daa78e213e15f7aaf