### PR TITLE
Preload ad views with shared request and return loaded views

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdBanner.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdBanner.kt
@@ -27,11 +27,11 @@ fun AdBanner(modifier : Modifier = Modifier , adsConfig : AdsConfig) {
     val showAds: Boolean by dataStore.adsEnabledFlow.collectAsStateWithLifecycle()
 
     if (showAds) {
+        val adRequest = remember { AdRequest.Builder().build() }
         val adView = remember(adsConfig.bannerAdUnitId) {
-            AdViewPool.preload(context, adsConfig.bannerAdUnitId)
+            AdViewPool.preload(context, adsConfig.bannerAdUnitId, adRequest)
             AdViewPool.acquire(context, adsConfig.bannerAdUnitId)
         }
-        val adRequest = remember { AdRequest.Builder().build() }
         val lifecycle = LocalLifecycleOwner.current.lifecycle
 
         LaunchedEffect(adView) {

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdViewPool.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdViewPool.kt
@@ -1,26 +1,39 @@
 package com.d4rk.android.libs.apptoolkit.core.ui.components.ads
 
 import android.content.Context
+import com.google.android.gms.ads.AdRequest
 import com.google.android.gms.ads.AdView
 import kotlin.collections.ArrayDeque
 
 object AdViewPool {
     private val pool: MutableMap<String, ArrayDeque<AdView>> = mutableMapOf()
 
-    fun preload(context: Context, adUnitId: String, count: Int = 1) {
+    fun preload(context: Context, adUnitId: String, adRequest: AdRequest, count: Int = 1) {
         val deque = pool.getOrPut(adUnitId) { ArrayDeque() }
         repeat(count) {
-            deque.add(AdView(context).apply { this.adUnitId = adUnitId })
+            deque.add(
+                AdView(context).apply {
+                    this.adUnitId = adUnitId
+                    loadAd(adRequest)
+                }
+            )
         }
     }
 
     fun acquire(context: Context, adUnitId: String): AdView {
         val deque = pool[adUnitId]
-        return if (deque != null && deque.isNotEmpty()) {
-            deque.removeFirst()
-        } else {
-            AdView(context).apply { this.adUnitId = adUnitId }
+        if (deque != null && deque.isNotEmpty()) {
+            val iterator = deque.iterator()
+            while (iterator.hasNext()) {
+                val adView = iterator.next()
+                if (adView.responseInfo != null) {
+                    iterator.remove()
+                    return adView
+                }
+            }
+            return deque.removeFirst()
         }
+        return AdView(context).apply { this.adUnitId = adUnitId }
     }
 
     fun release(adUnitId: String, adView: AdView) {


### PR DESCRIPTION
## Summary
- load ad views during `AdViewPool.preload` using provided `AdRequest`
- reuse a single `AdRequest` in `AdBanner` when preloading and loading ads
- prefer already-loaded ad views when acquiring from `AdViewPool`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1e0143d10832da23007baf9f3e87b