### PR TITLE
Preload AdViews with AdRequest and return loaded views

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdBanner.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdBanner.kt
@@ -27,11 +27,11 @@ fun AdBanner(modifier : Modifier = Modifier , adsConfig : AdsConfig) {
     val showAds: Boolean by dataStore.adsEnabledFlow.collectAsStateWithLifecycle()
 
     if (showAds) {
+        val adRequest = remember { AdRequest.Builder().build() }
         val adView = remember(adsConfig.bannerAdUnitId) {
-            AdViewPool.preload(context, adsConfig.bannerAdUnitId)
+            AdViewPool.preload(context, adsConfig.bannerAdUnitId, adRequest)
             AdViewPool.acquire(context, adsConfig.bannerAdUnitId)
         }
-        val adRequest = remember { AdRequest.Builder().build() }
         val lifecycle = LocalLifecycleOwner.current.lifecycle
 
         LaunchedEffect(adView) {


### PR DESCRIPTION
## Summary
- load ads during preloading by passing an `AdRequest`
- return already-loaded AdViews when acquiring from pool
- build one `AdRequest` in `AdBanner` and supply it to the pool

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a1f5e206d8832d9345b787a8278697