### PR TITLE
Handle banner ads by size

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdBanner.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdBanner.kt
@@ -29,8 +29,8 @@ fun AdBanner(modifier : Modifier = Modifier , adsConfig : AdsConfig) {
     if (showAds) {
         val adRequest = remember { AdRequest.Builder().build() }
         val adView = remember(adsConfig.bannerAdUnitId) {
-            AdViewPool.preload(context, adsConfig.bannerAdUnitId, adRequest)
-            AdViewPool.acquire(context, adsConfig.bannerAdUnitId)
+            AdViewPool.preload(context, adsConfig.bannerAdUnitId, adsConfig.adSize, adRequest)
+            AdViewPool.acquire(context, adsConfig.bannerAdUnitId, adsConfig.adSize)
         }
         val lifecycle = LocalLifecycleOwner.current.lifecycle
 
@@ -51,7 +51,7 @@ fun AdBanner(modifier : Modifier = Modifier , adsConfig : AdsConfig) {
             lifecycle.addObserver(observer)
             onDispose {
                 lifecycle.removeObserver(observer)
-                AdViewPool.release(adsConfig.bannerAdUnitId, adView)
+                AdViewPool.release(adsConfig.bannerAdUnitId, adsConfig.adSize, adView)
             }
         }
 


### PR DESCRIPTION
## Summary
- key AdViewPool entries by ad unit and AdSize
- pass ad size through preload/acquire/release and set it before loading
- forward banner ad size to the pool when rendering

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a2450f7220832d86a613dccf6a95dc