### PR TITLE
Add test AdMob app ID for instrumentation tests

### DIFF
--- a/apptoolkit/src/androidTest/AndroidManifest.xml
+++ b/apptoolkit/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <meta-data
+            android:name="com.google.android.gms.ads.APPLICATION_ID"
+            android:value="ca-app-pub-3940256099942544~3347511713" />
+    </application>
+</manifest>


### PR DESCRIPTION
## Summary
- add AndroidManifest for androidTest with Google official test AdMob application ID to avoid process crash

## Testing
- `./gradlew apptoolkit:connectedAndroidTest` *(fails: Failed to install the following Android SDK packages as some licences have not been accepted)*

------
https://chatgpt.com/codex/tasks/task_e_68a246335548832d8b92d3240e2de071