### PR TITLE
refactor: suspend device info creation

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/IssueReporterScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/IssueReporterScreen.kt
@@ -43,6 +43,7 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
@@ -317,9 +318,11 @@ fun IssueReporterScreenContent(
                         )
                     }
                     AnimatedVisibility(visible = deviceExpanded) {
-                        val info = remember { DeviceInfo(context).toString() }
+                        val info = produceState(initialValue = "") {
+                            value = DeviceInfo.create(context).toString()
+                        }
                         Text(
-                            text = info,
+                            text = info.value,
                             style = MaterialTheme.typography.bodySmall,
                             modifier = Modifier
                                 .padding(SizeConstants.LargeSize)

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/IssueReporterViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/IssueReporterViewModel.kt
@@ -91,7 +91,7 @@ class IssueReporterViewModel(
         launch(dispatcherProvider.io) {
             screenState.updateState(ScreenState.IsLoading())
             yield()
-            val deviceInfo = DeviceInfo(context)
+            val deviceInfo = DeviceInfo.create(context)
             val extraInfo = ExtraInfo()
             val report = Report(
                 title = data.title,

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/data/TestIssueReporterRepository.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/data/TestIssueReporterRepository.kt
@@ -33,7 +33,7 @@ class TestIssueReporterRepository {
             install(ContentNegotiation) { json() }
         }
         val repository = IssueReporterRepository(client)
-        val report = Report("title", "desc", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo(android.app.Application()), ExtraInfo(), "me@test.com")
+        val report = Report("title", "desc", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo.create(android.app.Application()), ExtraInfo(), "me@test.com")
         val target = GithubTarget("user", "repo")
         val result = repository.sendReport(report, target, token = "token123")
 
@@ -49,7 +49,7 @@ class TestIssueReporterRepository {
         val engine = MockEngine { respond("fail", HttpStatusCode.BadRequest) }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
         val repository = IssueReporterRepository(client)
-        val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo(android.app.Application()), ExtraInfo(), null)
+        val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo.create(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
         val result = repository.sendReport(report, target)
 
@@ -69,7 +69,7 @@ class TestIssueReporterRepository {
         }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
         val repository = IssueReporterRepository(client)
-        val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo(android.app.Application()), ExtraInfo(), null)
+        val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo.create(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
 
         val result = repository.sendReport(report, target, token = null)
@@ -83,7 +83,7 @@ class TestIssueReporterRepository {
         val engine = MockEngine { throw SocketTimeoutException("timeout") }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
         val repository = IssueReporterRepository(client)
-        val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo(android.app.Application()), ExtraInfo(), null)
+        val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo.create(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
 
         assertFailsWith<SocketTimeoutException> {
@@ -96,7 +96,7 @@ class TestIssueReporterRepository {
         val engine = MockEngine { respond("{", HttpStatusCode.Created) }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
         val repository = IssueReporterRepository(client)
-        val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo(android.app.Application()), ExtraInfo(), null)
+        val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo.create(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
 
         assertFailsWith<kotlinx.serialization.SerializationException> {
@@ -109,7 +109,7 @@ class TestIssueReporterRepository {
         val engine = MockEngine { respond("weird", HttpStatusCode.PaymentRequired) }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
         val repository = IssueReporterRepository(client)
-        val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo(android.app.Application()), ExtraInfo(), null)
+        val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo.create(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
 
         val result = repository.sendReport(report, target)
@@ -128,7 +128,7 @@ class TestIssueReporterRepository {
         }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
         val repository = IssueReporterRepository(client)
-        val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo(android.app.Application()), ExtraInfo(), null)
+        val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo.create(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
 
         repository.sendReport(report, target)
@@ -140,7 +140,7 @@ class TestIssueReporterRepository {
         val engine = MockEngine { respond("broke", HttpStatusCode.BadGateway) }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
         val repository = IssueReporterRepository(client)
-        val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo(android.app.Application()), ExtraInfo(), null)
+        val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo.create(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
 
         val result = repository.sendReport(report, target)
@@ -155,7 +155,7 @@ class TestIssueReporterRepository {
         val engine = MockEngine { respond("hot", HttpStatusCode.fromValue(418)) }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
         val repository = IssueReporterRepository(client)
-        val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo(android.app.Application()), ExtraInfo(), null)
+        val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo.create(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
 
         val result = repository.sendReport(report, target)
@@ -170,7 +170,7 @@ class TestIssueReporterRepository {
         val engine = MockEngine { throw NullPointerException("boom") }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
         val repository = IssueReporterRepository(client)
-        val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo(android.app.Application()), ExtraInfo(), null)
+        val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo.create(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
 
         assertFailsWith<NullPointerException> {
@@ -183,7 +183,7 @@ class TestIssueReporterRepository {
         val engine = MockEngine { throw IllegalStateException("illegal") }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
         val repository = IssueReporterRepository(client)
-        val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo(android.app.Application()), ExtraInfo(), null)
+        val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo.create(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
 
         assertFailsWith<IllegalStateException> {
@@ -196,7 +196,7 @@ class TestIssueReporterRepository {
         val engine = MockEngine { respond("unauth", HttpStatusCode.Unauthorized) }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
         val repository = IssueReporterRepository(client)
-        val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo(android.app.Application()), ExtraInfo(), null)
+        val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo.create(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
 
         val result = repository.sendReport(report, target)
@@ -211,7 +211,7 @@ class TestIssueReporterRepository {
         val engine = MockEngine { respond("stop", HttpStatusCode.Forbidden) }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
         val repository = IssueReporterRepository(client)
-        val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo(android.app.Application()), ExtraInfo(), null)
+        val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo.create(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
 
         val result = repository.sendReport(report, target)
@@ -226,7 +226,7 @@ class TestIssueReporterRepository {
         val engine = MockEngine { respond("{}", HttpStatusCode.Created) }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
         val repository = IssueReporterRepository(client)
-        val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo(android.app.Application()), ExtraInfo(), null)
+        val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo.create(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
 
         val result = repository.sendReport(report, target)


### PR DESCRIPTION
## Summary
- fetch app package info in `DeviceInfo.create` using `withContext(Dispatchers.IO)`
- use `DeviceInfo.create` in issue reporter components and tests

## Testing
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a247ceda24832d8f02a7ae0b19ecab