### PR TITLE
Wrap startActivity calls in runCatching

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/display/DisplaySettingsList.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/display/DisplaySettingsList.kt
@@ -203,11 +203,11 @@ fun DisplaySettingsList(paddingValues : PaddingValues = PaddingValues() , provid
                         when {
                             context.packageManager.resolveActivity(
                                 localeIntent , 0
-                            ) != null -> context.startActivity(localeIntent)
+                            ) != null -> runCatching { context.startActivity(localeIntent) }
 
                             context.packageManager.resolveActivity(
                                 detailsIntent , 0
-                            ) != null -> context.startActivity(detailsIntent)
+                            ) != null -> runCatching { context.startActivity(detailsIntent) }
 
                             else -> {
                                 showLanguageDialog = true

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/components/pages/CrashlyticsOnboardingPageTab.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/components/pages/CrashlyticsOnboardingPageTab.kt
@@ -236,7 +236,7 @@ fun LearnMoreSection(context: Context) {
         OutlinedIconButtonWithText(
             onClick = {
                 val intent = Intent(Intent.ACTION_VIEW, AppLinks.PRIVACY_POLICY.toUri())
-                context.startActivity(intent)
+                runCatching { context.startActivity(intent) }
             },
             icon = Icons.AutoMirrored.Filled.Launch,
             iconContentDescription = null,

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/GeneralSettingsActivity.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/GeneralSettingsActivity.kt
@@ -32,7 +32,7 @@ class GeneralSettingsActivity : AppCompatActivity() {
             }
 
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            context.startActivity(intent)
+            runCatching { context.startActivity(intent) }
         }
     }
 


### PR DESCRIPTION
## Summary
- guard startActivity in Crashlytics onboarding, display settings, and general settings activity with runCatching

## Testing
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a409fdc954832dbc41882381eff271