### PR TITLE
Handle missing clipboard service

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/ClipboardHelper.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/ClipboardHelper.kt
@@ -4,6 +4,7 @@ import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import android.os.Build
+import android.util.Log
 
 /**
  *  A helper object for managing clipboard operations.
@@ -21,12 +22,19 @@ object ClipboardHelper {
      *                     This callback is typically used to display a visual confirmation (e.g., a Snackbar).
      */
     fun copyTextToClipboard(context : Context , label : String , text : String , onShowSnackbar : () -> Unit = {}) {
-        val clipboard : ClipboardManager = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
-        val clip : ClipData = ClipData.newPlainText(label , text)
-        clipboard.setPrimaryClip(clip)
+        val clipboard : ClipboardManager? = runCatching {
+            context.getSystemService(Context.CLIPBOARD_SERVICE) as? ClipboardManager
+        }.getOrNull()
 
-        if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
-            onShowSnackbar()
+        if (clipboard != null) {
+            val clip : ClipData = ClipData.newPlainText(label , text)
+            clipboard.setPrimaryClip(clip)
+
+            if (Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2) {
+                onShowSnackbar()
+            }
+        } else {
+            Log.w("ClipboardHelper" , "Clipboard service unavailable")
         }
     }
 }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestClipboardHelper.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestClipboardHelper.kt
@@ -41,15 +41,15 @@ class TestClipboardHelper {
     }
 
     @Test
-    fun `copyTextToClipboard throws when manager missing`() {
-        println("🚀 [TEST] copyTextToClipboard throws when manager missing")
+    fun `copyTextToClipboard handles missing manager gracefully`() {
+        println("🚀 [TEST] copyTextToClipboard handles missing manager gracefully")
         val context = mockk<Context>()
         every { context.getSystemService(Context.CLIPBOARD_SERVICE) } returns null
 
-        assertFailsWith<NullPointerException> {
-            ClipboardHelper.copyTextToClipboard(context, "l", "t")
-        }
-        println("🏁 [TEST DONE] copyTextToClipboard throws when manager missing")
+        ClipboardHelper.copyTextToClipboard(context, "l", "t")
+
+        verify { context.getSystemService(Context.CLIPBOARD_SERVICE) }
+        println("🏁 [TEST DONE] copyTextToClipboard handles missing manager gracefully")
     }
 
     @Test
@@ -208,15 +208,15 @@ class TestClipboardHelper {
     }
 
     @Test
-    fun `copyTextToClipboard throws when clipboard service type unexpected`() {
-        println("🚀 [TEST] copyTextToClipboard throws when clipboard service type unexpected")
+    fun `copyTextToClipboard handles unexpected clipboard service type`() {
+        println("🚀 [TEST] copyTextToClipboard handles unexpected clipboard service type")
         val context = mockk<Context>()
         every { context.getSystemService(Context.CLIPBOARD_SERVICE) } returns "not a manager"
 
-        assertFailsWith<ClassCastException> {
-            ClipboardHelper.copyTextToClipboard(context, "l", "t")
-        }
-        println("🏁 [TEST DONE] copyTextToClipboard throws when clipboard service type unexpected")
+        ClipboardHelper.copyTextToClipboard(context, "l", "t")
+
+        verify { context.getSystemService(Context.CLIPBOARD_SERVICE) }
+        println("🏁 [TEST DONE] copyTextToClipboard handles unexpected clipboard service type")
     }
 }
 


### PR DESCRIPTION
## Summary
- Safely obtain the clipboard manager and guard failures
- Skip clipboard writes and log a warning when service is unavailable
- Adjust clipboard helper tests for new null-safety

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a40a125840832db337f88ecefcfb85