### PR TITLE
Use IO dispatcher for AppInfoHelper package checks

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/AppCard.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/AppCard.kt
@@ -20,6 +20,7 @@ import androidx.compose.material.icons.outlined.StarOutline
 import androidx.compose.material3.Card
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -39,6 +40,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeVertical
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.AppInfoHelper
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.IntentsHelper
+import kotlinx.coroutines.launch
 
 @Composable
 fun AppCard(
@@ -50,6 +52,7 @@ fun AppCard(
     val context: Context = LocalContext.current
     val hapticFeedback : HapticFeedback = LocalHapticFeedback.current
     val view : View = LocalView.current
+    val coroutineScope = rememberCoroutineScope()
     Card(
         modifier = modifier
             .bounceClick()
@@ -60,26 +63,28 @@ fun AppCard(
                 view.playSoundEffect(SoundEffectConstants.CLICK)
                 hapticFeedback.performHapticFeedback(hapticFeedbackType = HapticFeedbackType.ContextClick)
                 if (appInfo.packageName.isNotEmpty()) {
-                    if (AppInfoHelper().isAppInstalled(
-                            context = context,
-                            packageName = appInfo.packageName
-                        )
-                    ) {
-                        if (!AppInfoHelper().openApp(
+                    coroutineScope.launch {
+                        if (AppInfoHelper().isAppInstalled(
                                 context = context,
                                 packageName = appInfo.packageName
                             )
                         ) {
+                            if (!AppInfoHelper().openApp(
+                                    context = context,
+                                    packageName = appInfo.packageName
+                                )
+                            ) {
+                                IntentsHelper.openPlayStoreForApp(
+                                    context = context,
+                                    packageName = appInfo.packageName
+                                )
+                            }
+                        } else {
                             IntentsHelper.openPlayStoreForApp(
                                 context = context,
                                 packageName = appInfo.packageName
                             )
                         }
-                    } else {
-                        IntentsHelper.openPlayStoreForApp(
-                            context = context,
-                            packageName = appInfo.packageName
-                        )
                     }
                 }
             }) {

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/AppInfoHelper.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/AppInfoHelper.kt
@@ -3,6 +3,8 @@ package com.d4rk.android.libs.apptoolkit.core.utils.helpers
 import android.content.Context
 import android.widget.Toast
 import com.d4rk.android.libs.apptoolkit.R
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
 open class AppInfoHelper {
 
@@ -10,19 +12,25 @@ open class AppInfoHelper {
      * Checks if a specific app is installed on the device.
      * @return True if the app is installed, false otherwise.
      */
-    fun isAppInstalled(context : Context , packageName : String) : Boolean = runCatching { context.packageManager.getApplicationInfo(packageName , 0) }.isSuccess
+    suspend fun isAppInstalled(context : Context , packageName : String) : Boolean = withContext(Dispatchers.IO) {
+        runCatching { context.packageManager.getApplicationInfo(packageName , 0) }.isSuccess
+    }
 
     /**
      * Opens a specific app if installed.
      * @return True if the app was opened, false otherwise.
      */
-    fun openApp(context : Context , packageName : String) : Boolean = runCatching {
-        context.packageManager.getLaunchIntentForPackage(packageName)?.let {
-            context.startActivity(it)
+    suspend fun openApp(context : Context , packageName : String) : Boolean {
+        val launchIntent = withContext(Dispatchers.IO) {
+            runCatching { context.packageManager.getLaunchIntentForPackage(packageName) }.getOrNull()
+        }
+
+        return if (launchIntent != null) {
+            context.startActivity(launchIntent)
             true
-        } == true
-    }.getOrElse {
-        Toast.makeText(context , context.getString(R.string.app_not_installed) , Toast.LENGTH_SHORT).show()
-        false
+        } else {
+            Toast.makeText(context , context.getString(R.string.app_not_installed) , Toast.LENGTH_SHORT).show()
+            false
+        }
     }
 }


### PR DESCRIPTION
## Summary
- mark isAppInstalled and openApp as suspend and move package-manager calls to Dispatchers.IO
- update AppCard to launch coroutines when using AppInfoHelper helpers

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a40b03d148832da3315738d9c10abe