### PR TITLE
Handle cache deletion failures gracefully

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/advanced/utils/CleanHelper.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/advanced/utils/CleanHelper.kt
@@ -1,9 +1,11 @@
 package com.d4rk.android.libs.apptoolkit.app.advanced.utils
 
 import android.content.Context
+import android.util.Log
 import android.widget.Toast
 import com.d4rk.android.libs.apptoolkit.R
 import java.io.File
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -12,24 +14,38 @@ import kotlinx.coroutines.withContext
 
 object CleanHelper {
 
-    suspend fun clearApplicationCache(context : Context) {
-        val cacheDirectories : List<File> = listOf(context.cacheDir , context.codeCacheDir , context.filesDir)
+    private const val TAG = "CleanHelper"
 
-        val allDeleted : Boolean = withContext(context = Dispatchers.IO) {
+    suspend fun clearApplicationCache(
+        context: Context,
+        ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    ) {
+        val cacheDirectories: List<File> = listOf(context.cacheDir, context.codeCacheDir, context.filesDir)
+
+        val results: List<Pair<File, Boolean>> = withContext(context = ioDispatcher) {
             coroutineScope {
                 cacheDirectories
                     .map { directory ->
-                        async { directory.deleteRecursively() }
+                        async {
+                            val deleted = runCatching { directory.deleteRecursively() }
+                                .getOrElse { false }
+                            directory to deleted
+                        }
                     }
                     .awaitAll()
-                    .all { it }
             }
         }
 
-        val messageResId : Int = if (allDeleted) R.string.cache_cleared_success else R.string.cache_cleared_error
+        val failedDirs = results.filterNot { it.second }.map { it.first }
+        if (failedDirs.isNotEmpty()) {
+            Log.w(TAG, "Failed to delete directories: ${failedDirs.joinToString { it.path }}")
+        }
+
+        val allDeleted = failedDirs.isEmpty()
+        val messageResId: Int = if (allDeleted) R.string.cache_cleared_success else R.string.cache_cleared_error
 
         withContext(context = Dispatchers.Main) {
-            Toast.makeText(context , context.getString(messageResId) , Toast.LENGTH_SHORT).show()
+            Toast.makeText(context, context.getString(messageResId), Toast.LENGTH_SHORT).show()
         }
     }
 }


### PR DESCRIPTION
## Summary
- Wrap cache directory deletion in `runCatching` and log failures
- Aggregate deletion results and show success or error toast accordingly
- Inject IO dispatcher for easier testing and thread control

## Testing
- `./gradlew apptoolkit:test` *(fails: SDK licenses not accepted)*

------
https://chatgpt.com/codex/tasks/task_e_68a42e50d68c832db8931164309fdf23