### PR TITLE
Handle missing launch activity in AppInfoHelper

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/AppInfoHelper.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/AppInfoHelper.kt
@@ -43,15 +43,24 @@ open class AppInfoHelper {
             if (context !is Activity) {
                 launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             }
-            runCatching {
-                context.startActivity(launchIntent)
-                true
-            }.onFailure {
+            if (launchIntent.resolveActivity(context.packageManager) == null) {
                 Toast.makeText(
                     context ,
                     context.getString(R.string.app_not_installed) ,
                     Toast.LENGTH_SHORT
                 ).show()
+                Result.failure(IllegalStateException("App not installed"))
+            } else {
+                runCatching {
+                    context.startActivity(launchIntent)
+                    true
+                }.onFailure {
+                    Toast.makeText(
+                        context ,
+                        context.getString(R.string.app_not_installed) ,
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
             }
         }
         else {


### PR DESCRIPTION
## Summary
- Ensure AppInfoHelper checks if launch intent resolves to an activity
- Show toast and return failure when the app isn't installed or launch activity missing

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a432fb1604832db32d35ba172b176d