### PR TITLE
Check intent resolution before launching MainActivity

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/onboarding/utils/interfaces/providers/OnboardingProvider.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/onboarding/utils/interfaces/providers/OnboardingProvider.kt
@@ -3,6 +3,7 @@ package com.d4rk.android.apps.apptoolkit.app.onboarding.utils.interfaces.provide
 import android.app.Activity
 import android.content.Context
 import android.content.Intent
+import android.util.Log
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.AccountCircle
 import androidx.compose.material.icons.outlined.Build
@@ -66,9 +67,14 @@ class AppOnboardingProvider : OnboardingProvider {
     }
 
     override fun onOnboardingFinished(context: Context) {
-        context.startActivity(Intent(context, MainActivity::class.java))
-        if (context is Activity) {
-            context.finish()
+        val intent = Intent(context, MainActivity::class.java)
+        if (intent.resolveActivity(context.packageManager) != null) {
+            context.startActivity(intent)
+            if (context is Activity) {
+                context.finish()
+            }
+        } else {
+            Log.w("AppOnboardingProvider", "MainActivity not found to handle intent")
         }
     }
 }


### PR DESCRIPTION
## Summary
- ensure onboarding flow checks MainActivity intent can resolve
- log when MainActivity cannot be resolved instead of launching

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a433408248832da6d82a98917d11ab