### PR TITLE
Check intent resolves before launching privacy link

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/components/pages/CrashlyticsOnboardingPageTab.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/components/pages/CrashlyticsOnboardingPageTab.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.content.Intent
 import android.view.SoundEffectConstants
 import android.view.View
+import android.widget.Toast
 import androidx.compose.animation.ExperimentalAnimationApi
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.clickable
@@ -236,7 +237,15 @@ fun LearnMoreSection(context: Context) {
         OutlinedIconButtonWithText(
             onClick = {
                 val intent = Intent(Intent.ACTION_VIEW, AppLinks.PRIVACY_POLICY.toUri())
-                runCatching { context.startActivity(intent) }
+                if (intent.resolveActivity(context.packageManager) != null) {
+                    runCatching { context.startActivity(intent) }
+                } else {
+                    Toast.makeText(
+                        context,
+                        context.getString(R.string.error),
+                        Toast.LENGTH_SHORT
+                    ).show()
+                }
             },
             icon = Icons.AutoMirrored.Filled.Launch,
             iconContentDescription = null,


### PR DESCRIPTION
## Summary
- validate privacy policy intent before launching in Crashlytics onboarding
- show error toast if no handler for privacy link

## Testing
- `./gradlew :apptoolkit:lint :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4334a4fe0832da13d4bd8bae72589