### PR TITLE
Refactor app list fetching to use repository

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/data/model/api/ApiResponse.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/data/model/api/ApiResponse.kt
@@ -11,5 +11,19 @@ data class ApiResponse(
 
 @Serializable
 data class AppDataWrapper(
-    @SerialName("apps") val apps: List<AppInfo>
+    @SerialName("apps") val apps: List<ApiAppInfo>
 )
+
+@Serializable
+data class ApiAppInfo(
+    @SerialName("name") val name: String,
+    @SerialName("packageName") val packageName: String,
+    @SerialName("iconLogo") val iconUrl: String,
+)
+
+fun ApiAppInfo.toAppInfo(): AppInfo = AppInfo(
+    name = name,
+    packageName = packageName,
+    iconUrl = iconUrl
+)
+

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/data/repository/DeveloperAppsRepositoryImpl.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/data/repository/DeveloperAppsRepositoryImpl.kt
@@ -1,0 +1,45 @@
+package com.d4rk.android.apps.apptoolkit.app.apps.list.data.repository
+
+import com.d4rk.android.apps.apptoolkit.BuildConfig
+import com.d4rk.android.apps.apptoolkit.app.apps.list.data.model.api.ApiResponse
+import com.d4rk.android.apps.apptoolkit.app.apps.list.data.model.api.toAppInfo
+import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
+import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.repository.DeveloperAppsRepository
+import com.d4rk.android.apps.apptoolkit.app.apps.list.utils.constants.api.ApiConstants
+import com.d4rk.android.apps.apptoolkit.app.apps.list.utils.constants.api.ApiEnvironments
+import com.d4rk.android.apps.apptoolkit.app.apps.list.utils.constants.api.ApiPaths
+import com.d4rk.android.apps.apptoolkit.core.domain.model.network.Errors
+import com.d4rk.android.apps.apptoolkit.core.utils.extensions.toError
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.RootError
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.statement.HttpResponse
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+
+class DeveloperAppsRepositoryImpl(
+    private val client: HttpClient
+) : DeveloperAppsRepository {
+
+    override fun fetchDeveloperApps(): Flow<DataState<List<AppInfo>, RootError>> = flow {
+        runCatching {
+            val url = BuildConfig.DEBUG.let { isDebug ->
+                val environment = if (isDebug) ApiEnvironments.ENV_DEBUG else ApiEnvironments.ENV_RELEASE
+                "${ApiConstants.BASE_REPOSITORY_URL}/$environment${ApiPaths.DEVELOPER_APPS_API}"
+            }
+            val httpResponse: HttpResponse = client.get(url)
+            val apiResponse: ApiResponse = httpResponse.body()
+
+            apiResponse.data.apps
+                .map { it.toAppInfo() }
+                .sortedBy { it.name.lowercase() }
+        }.onSuccess { apps ->
+            emit(DataState.Success(data = apps))
+        }.onFailure { error ->
+            emit(DataState.Error(error = error.toError(default = Errors.UseCase.FAILED_TO_LOAD_APPS)))
+        }
+    }
+}
+

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/repository/DeveloperAppsRepository.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/repository/DeveloperAppsRepository.kt
@@ -1,0 +1,11 @@
+package com.d4rk.android.apps.apptoolkit.app.apps.list.domain.repository
+
+import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.RootError
+import kotlinx.coroutines.flow.Flow
+
+interface DeveloperAppsRepository {
+    fun fetchDeveloperApps(): Flow<DataState<List<AppInfo>, RootError>>
+}
+

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/usecases/FetchDeveloperAppsUseCase.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/usecases/FetchDeveloperAppsUseCase.kt
@@ -1,40 +1,17 @@
 package com.d4rk.android.apps.apptoolkit.app.apps.list.domain.usecases
 
-import com.d4rk.android.apps.apptoolkit.BuildConfig
-import com.d4rk.android.apps.apptoolkit.app.apps.list.data.model.api.ApiResponse
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
-import com.d4rk.android.apps.apptoolkit.app.apps.list.utils.constants.api.ApiConstants
-import com.d4rk.android.apps.apptoolkit.app.apps.list.utils.constants.api.ApiEnvironments
-import com.d4rk.android.apps.apptoolkit.app.apps.list.utils.constants.api.ApiPaths
-import com.d4rk.android.apps.apptoolkit.core.domain.model.network.Errors
-import com.d4rk.android.apps.apptoolkit.core.utils.extensions.toError
+import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.repository.DeveloperAppsRepository
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.RootError
 import com.d4rk.android.libs.apptoolkit.core.domain.usecases.RepositoryWithoutParam
-import io.ktor.client.HttpClient
-import io.ktor.client.call.body
-import io.ktor.client.request.get
-import io.ktor.client.statement.HttpResponse
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 
-class FetchDeveloperAppsUseCase(private val client: HttpClient) : RepositoryWithoutParam<Flow<DataState<List<AppInfo> , RootError>>> {
+class FetchDeveloperAppsUseCase(
+    private val repository: DeveloperAppsRepository
+) : RepositoryWithoutParam<Flow<DataState<List<AppInfo>, RootError>>> {
 
-    override suspend operator fun invoke(): Flow<DataState<List<AppInfo> , RootError>> = flow {
-        runCatching {
-            val url = BuildConfig.DEBUG.let { isDebug ->
-                val environment = if (isDebug) ApiEnvironments.ENV_DEBUG else ApiEnvironments.ENV_RELEASE
-                "${ApiConstants.BASE_REPOSITORY_URL}/$environment${ApiPaths.DEVELOPER_APPS_API}"
-            }
-            val httpResponse: HttpResponse = client.get(url)
-            val apiResponse: ApiResponse = httpResponse.body()
-
-            val sortedApps = apiResponse.data.apps.sortedBy { it.name.lowercase() }
-            sortedApps
-        }.onSuccess { foundApps ->
-            emit(DataState.Success(data = foundApps))
-        }.onFailure { error ->
-            emit(DataState.Error(error = error.toError(default = Errors.UseCase.FAILED_TO_LOAD_APPS)))
-        }
-    }
+    override suspend operator fun invoke(): Flow<DataState<List<AppInfo>, RootError>> =
+        repository.fetchDeveloperApps()
 }
+

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppModule.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import com.d4rk.android.apps.apptoolkit.BuildConfig
 import com.d4rk.android.apps.apptoolkit.R
 import com.d4rk.android.apps.apptoolkit.app.apps.favorites.ui.FavoriteAppsViewModel
+import com.d4rk.android.apps.apptoolkit.app.apps.list.data.repository.DeveloperAppsRepositoryImpl
+import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.repository.DeveloperAppsRepository
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.usecases.FetchDeveloperAppsUseCase
 import com.d4rk.android.apps.apptoolkit.app.apps.list.ui.AppsListViewModel
 import com.d4rk.android.apps.apptoolkit.app.main.ui.MainViewModel
@@ -34,7 +36,8 @@ val appModule : Module = module {
 
     viewModel { MainViewModel(dispatcherProvider = get()) }
 
-    single { FetchDeveloperAppsUseCase(client = get()) }
+    single<DeveloperAppsRepository> { DeveloperAppsRepositoryImpl(client = get()) }
+    single { FetchDeveloperAppsUseCase(repository = get()) }
     viewModel {
         AppsListViewModel(
             fetchDeveloperAppsUseCase = get(),
@@ -50,3 +53,4 @@ val appModule : Module = module {
         )
     }
 }
+


### PR DESCRIPTION
## Summary
- add `DeveloperAppsRepository` abstraction
- implement `DeveloperAppsRepositoryImpl` with network mapping
- refactor `FetchDeveloperAppsUseCase` to use repository
- wire repository into DI modules

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a435211bb8832db6696d3453dcb15d