### PR TITLE
feat: add favorites repository and use cases

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/domain/repository/FavoritesRepository.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/domain/repository/FavoritesRepository.kt
@@ -1,0 +1,9 @@
+package com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.repository
+
+import kotlinx.coroutines.flow.Flow
+
+interface FavoritesRepository {
+    fun observeFavorites(): Flow<Set<String>>
+    suspend fun toggleFavorite(packageName: String)
+}
+

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/domain/usecases/ObserveFavoritesUseCase.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/domain/usecases/ObserveFavoritesUseCase.kt
@@ -1,0 +1,10 @@
+package com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases
+
+import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.repository.FavoritesRepository
+import com.d4rk.android.libs.apptoolkit.core.domain.usecases.RepositoryWithoutParam
+import kotlinx.coroutines.flow.Flow
+
+class ObserveFavoritesUseCase(private val repository: FavoritesRepository) : RepositoryWithoutParam<Flow<Set<String>>> {
+    override suspend operator fun invoke(): Flow<Set<String>> = repository.observeFavorites()
+}
+

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/domain/usecases/ToggleFavoriteUseCase.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/domain/usecases/ToggleFavoriteUseCase.kt
@@ -1,0 +1,11 @@
+package com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases
+
+import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.repository.FavoritesRepository
+import com.d4rk.android.libs.apptoolkit.core.domain.usecases.Repository
+
+class ToggleFavoriteUseCase(private val repository: FavoritesRepository) : Repository<String, Unit> {
+    override suspend operator fun invoke(param: String) {
+        repository.toggleFavorite(param)
+    }
+}
+

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsViewModel.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsViewModel.kt
@@ -5,7 +5,8 @@ import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.actions.Favori
 import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.actions.FavoriteAppsEvent
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.ui.UiHomeScreen
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.usecases.FetchDeveloperAppsUseCase
-import com.d4rk.android.apps.apptoolkit.core.data.datastore.DataStore
+import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases.ObserveFavoritesUseCase
+import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases.ToggleFavoriteUseCase
 import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
@@ -27,9 +28,10 @@ import kotlinx.coroutines.launch
 
 class FavoriteAppsViewModel(
     private val fetchDeveloperAppsUseCase: FetchDeveloperAppsUseCase,
-    val dataStore: DataStore,
+    private val observeFavoritesUseCase: ObserveFavoritesUseCase,
+    private val toggleFavoriteUseCase: ToggleFavoriteUseCase,
     private val dispatcherProvider: DispatcherProvider
-) : ScreenViewModel<UiHomeScreen, FavoriteAppsEvent, FavoriteAppsAction>(
+ ) : ScreenViewModel<UiHomeScreen, FavoriteAppsEvent, FavoriteAppsAction>(
     initialState = UiStateScreen(screenState = ScreenState.IsLoading(), data = UiHomeScreen())
 ) {
 
@@ -45,7 +47,7 @@ class FavoriteAppsViewModel(
     init {
         viewModelScope.launch(context = dispatcherProvider.io, start = CoroutineStart.UNDISPATCHED) {
             runCatching {
-                dataStore.favoriteApps
+                observeFavoritesUseCase()
                     .onEach {
                         favoritesLoaded.value = true
                         _favorites.value = it
@@ -99,7 +101,7 @@ class FavoriteAppsViewModel(
     fun toggleFavorite(packageName: String) {
         viewModelScope.launch(context = dispatcherProvider.io) {
             runCatching {
-                dataStore.toggleFavoriteApp(packageName)
+                toggleFavoriteUseCase(packageName)
             }
         }
     }

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/data/favorites/FavoritesRepositoryImpl.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/data/favorites/FavoritesRepositoryImpl.kt
@@ -1,0 +1,14 @@
+package com.d4rk.android.apps.apptoolkit.core.data.favorites
+
+import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.repository.FavoritesRepository
+import com.d4rk.android.apps.apptoolkit.core.data.datastore.DataStore
+import kotlinx.coroutines.flow.Flow
+
+class FavoritesRepositoryImpl(private val dataStore: DataStore) : FavoritesRepository {
+    override fun observeFavorites(): Flow<Set<String>> = dataStore.favoriteApps
+
+    override suspend fun toggleFavorite(packageName: String) {
+        dataStore.toggleFavoriteApp(packageName)
+    }
+}
+

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppModule.kt
@@ -9,6 +9,10 @@ import com.d4rk.android.apps.apptoolkit.app.apps.list.ui.AppsListViewModel
 import com.d4rk.android.apps.apptoolkit.app.main.ui.MainViewModel
 import com.d4rk.android.apps.apptoolkit.app.onboarding.utils.interfaces.providers.AppOnboardingProvider
 import com.d4rk.android.apps.apptoolkit.core.data.datastore.DataStore
+import com.d4rk.android.apps.apptoolkit.core.data.favorites.FavoritesRepositoryImpl
+import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.repository.FavoritesRepository
+import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases.ObserveFavoritesUseCase
+import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases.ToggleFavoriteUseCase
 import com.d4rk.android.libs.apptoolkit.app.onboarding.utils.interfaces.providers.OnboardingProvider
 import com.d4rk.android.libs.apptoolkit.data.client.KtorClient
 import com.d4rk.android.libs.apptoolkit.data.core.ads.AdsCoreManager
@@ -21,6 +25,10 @@ val appModule : Module = module {
     single<DataStore> { DataStore.getInstance(context = get()) }
     single<AdsCoreManager> { AdsCoreManager(context = get() , get()) }
     single { KtorClient().createClient(enableLogging = BuildConfig.DEBUG) }
+
+    single<FavoritesRepository> { FavoritesRepositoryImpl(dataStore = get()) }
+    single { ObserveFavoritesUseCase(repository = get()) }
+    single { ToggleFavoriteUseCase(repository = get()) }
 
     single<List<String>>(qualifier = named(name = "startup_entries")) {
         get<Context>().resources.getStringArray(R.array.preference_startup_entries).toList()
@@ -45,7 +53,8 @@ val appModule : Module = module {
     viewModel {
         FavoriteAppsViewModel(
             fetchDeveloperAppsUseCase = get(),
-            dataStore = get(),
+            observeFavoritesUseCase = get(),
+            toggleFavoriteUseCase = get(),
             dispatcherProvider = get()
         )
     }


### PR DESCRIPTION
## Summary
- add FavoritesRepository interface and use cases to manage favorite apps
- implement repository via DataStore and refactor FavoriteAppsViewModel to use it
- wire repository and use cases through Koin module

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a435280e40832d8873dea5b4ee2d97