### PR TITLE
Refactor app info serialization and add repository layer

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/data/model/api/ApiResponse.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/data/model/api/ApiResponse.kt
@@ -1,6 +1,5 @@
 package com.d4rk.android.apps.apptoolkit.app.apps.list.data.model.api
 
-import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -11,5 +10,5 @@ data class ApiResponse(
 
 @Serializable
 data class AppDataWrapper(
-    @SerialName("apps") val apps: List<AppInfo>
+    @SerialName("apps") val apps: List<AppInfoDto>
 )

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/data/model/api/AppInfoDto.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/data/model/api/AppInfoDto.kt
@@ -1,0 +1,27 @@
+package com.d4rk.android.apps.apptoolkit.app.apps.list.data.model.api
+
+import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AppInfoDto(
+    @SerialName("name") val name: String,
+    @SerialName("packageName") val packageName: String,
+    @SerialName("iconLogo") val iconUrl: String,
+)
+
+fun AppInfoDto.toDomain(): AppInfo =
+    AppInfo(
+        name = name,
+        packageName = packageName,
+        iconUrl = iconUrl,
+    )
+
+fun AppInfo.toDto(): AppInfoDto =
+    AppInfoDto(
+        name = name,
+        packageName = packageName,
+        iconUrl = iconUrl,
+    )
+

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/data/repository/DeveloperAppsRepositoryImpl.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/data/repository/DeveloperAppsRepositoryImpl.kt
@@ -1,0 +1,31 @@
+package com.d4rk.android.apps.apptoolkit.app.apps.list.data.repository
+
+import com.d4rk.android.apps.apptoolkit.BuildConfig
+import com.d4rk.android.apps.apptoolkit.app.apps.list.data.model.api.ApiResponse
+import com.d4rk.android.apps.apptoolkit.app.apps.list.data.model.api.toDomain
+import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
+import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.repository.DeveloperAppsRepository
+import com.d4rk.android.apps.apptoolkit.app.apps.list.utils.constants.api.ApiConstants
+import com.d4rk.android.apps.apptoolkit.app.apps.list.utils.constants.api.ApiEnvironments
+import com.d4rk.android.apps.apptoolkit.app.apps.list.utils.constants.api.ApiPaths
+import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.request.get
+import io.ktor.client.statement.HttpResponse
+
+class DeveloperAppsRepositoryImpl(private val client: HttpClient) : DeveloperAppsRepository {
+    override suspend fun fetchDeveloperApps(): List<AppInfo> {
+        val url = BuildConfig.DEBUG.let { isDebug ->
+            val environment = if (isDebug) ApiEnvironments.ENV_DEBUG else ApiEnvironments.ENV_RELEASE
+            "${'$'}{ApiConstants.BASE_REPOSITORY_URL}/$environment${ApiPaths.DEVELOPER_APPS_API}"
+        }
+        val httpResponse: HttpResponse = client.get(url)
+        val apiResponse: ApiResponse = httpResponse.body()
+
+        return apiResponse.data.apps
+            .map { it.toDomain() }
+            .sortedBy { it.name.lowercase() }
+    }
+}
+
+

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/model/AppInfo.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/model/AppInfo.kt
@@ -1,11 +1,7 @@
 package com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model
 
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
-
-@Serializable
 data class AppInfo(
-    @SerialName(value = "name") val name: String,
-    @SerialName(value = "packageName") val packageName: String,
-    @SerialName(value = "iconLogo") val iconUrl: String,
+    val name: String,
+    val packageName: String,
+    val iconUrl: String,
 )

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/repository/DeveloperAppsRepository.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/repository/DeveloperAppsRepository.kt
@@ -1,0 +1,8 @@
+package com.d4rk.android.apps.apptoolkit.app.apps.list.domain.repository
+
+import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
+
+interface DeveloperAppsRepository {
+    suspend fun fetchDeveloperApps(): List<AppInfo>
+}
+

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/usecases/FetchDeveloperAppsUseCase.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/usecases/FetchDeveloperAppsUseCase.kt
@@ -1,36 +1,20 @@
 package com.d4rk.android.apps.apptoolkit.app.apps.list.domain.usecases
 
-import com.d4rk.android.apps.apptoolkit.BuildConfig
-import com.d4rk.android.apps.apptoolkit.app.apps.list.data.model.api.ApiResponse
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
-import com.d4rk.android.apps.apptoolkit.app.apps.list.utils.constants.api.ApiConstants
-import com.d4rk.android.apps.apptoolkit.app.apps.list.utils.constants.api.ApiEnvironments
-import com.d4rk.android.apps.apptoolkit.app.apps.list.utils.constants.api.ApiPaths
+import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.repository.DeveloperAppsRepository
 import com.d4rk.android.apps.apptoolkit.core.domain.model.network.Errors
 import com.d4rk.android.apps.apptoolkit.core.utils.extensions.toError
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.RootError
 import com.d4rk.android.libs.apptoolkit.core.domain.usecases.RepositoryWithoutParam
-import io.ktor.client.HttpClient
-import io.ktor.client.call.body
-import io.ktor.client.request.get
-import io.ktor.client.statement.HttpResponse
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
-class FetchDeveloperAppsUseCase(private val client: HttpClient) : RepositoryWithoutParam<Flow<DataState<List<AppInfo> , RootError>>> {
+class FetchDeveloperAppsUseCase(private val repository: DeveloperAppsRepository) : RepositoryWithoutParam<Flow<DataState<List<AppInfo>, RootError>>> {
 
-    override suspend operator fun invoke(): Flow<DataState<List<AppInfo> , RootError>> = flow {
+    override suspend operator fun invoke(): Flow<DataState<List<AppInfo>, RootError>> = flow {
         runCatching {
-            val url = BuildConfig.DEBUG.let { isDebug ->
-                val environment = if (isDebug) ApiEnvironments.ENV_DEBUG else ApiEnvironments.ENV_RELEASE
-                "${ApiConstants.BASE_REPOSITORY_URL}/$environment${ApiPaths.DEVELOPER_APPS_API}"
-            }
-            val httpResponse: HttpResponse = client.get(url)
-            val apiResponse: ApiResponse = httpResponse.body()
-
-            val sortedApps = apiResponse.data.apps.sortedBy { it.name.lowercase() }
-            sortedApps
+            repository.fetchDeveloperApps()
         }.onSuccess { foundApps ->
             emit(DataState.Success(data = foundApps))
         }.onFailure { error ->
@@ -38,3 +22,4 @@ class FetchDeveloperAppsUseCase(private val client: HttpClient) : RepositoryWith
         }
     }
 }
+

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppModule.kt
@@ -4,6 +4,8 @@ import android.content.Context
 import com.d4rk.android.apps.apptoolkit.BuildConfig
 import com.d4rk.android.apps.apptoolkit.R
 import com.d4rk.android.apps.apptoolkit.app.apps.favorites.ui.FavoriteAppsViewModel
+import com.d4rk.android.apps.apptoolkit.app.apps.list.data.repository.DeveloperAppsRepositoryImpl
+import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.repository.DeveloperAppsRepository
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.usecases.FetchDeveloperAppsUseCase
 import com.d4rk.android.apps.apptoolkit.app.apps.list.ui.AppsListViewModel
 import com.d4rk.android.apps.apptoolkit.app.main.ui.MainViewModel
@@ -34,7 +36,8 @@ val appModule : Module = module {
 
     viewModel { MainViewModel(dispatcherProvider = get()) }
 
-    single { FetchDeveloperAppsUseCase(client = get()) }
+    single<DeveloperAppsRepository> { DeveloperAppsRepositoryImpl(client = get()) }
+    single { FetchDeveloperAppsUseCase(repository = get()) }
     viewModel {
         AppsListViewModel(
             fetchDeveloperAppsUseCase = get(),


### PR DESCRIPTION
## Summary
- remove serialization annotations from domain `AppInfo`
- add `AppInfoDto` with mapping utilities
- introduce `DeveloperAppsRepository` and implementation to convert DTOs to domain
- wire repository into `FetchDeveloperAppsUseCase` and DI

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4352ce6d0832db180a5066c3d1aa0