### PR TITLE
Decouple AppInfo domain model from serialization

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/data/model/api/ApiResponse.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/data/model/api/ApiResponse.kt
@@ -1,6 +1,5 @@
 package com.d4rk.android.apps.apptoolkit.app.apps.list.data.model.api
 
-import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -11,19 +10,7 @@ data class ApiResponse(
 
 @Serializable
 data class AppDataWrapper(
-    @SerialName("apps") val apps: List<ApiAppInfo>
+    @SerialName("apps") val apps: List<AppInfoDto>
 )
 
-@Serializable
-data class ApiAppInfo(
-    @SerialName("name") val name: String,
-    @SerialName("packageName") val packageName: String,
-    @SerialName("iconLogo") val iconUrl: String,
-)
-
-fun ApiAppInfo.toAppInfo(): AppInfo = AppInfo(
-    name = name,
-    packageName = packageName,
-    iconUrl = iconUrl
-)
 

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/data/model/api/AppInfoDto.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/data/model/api/AppInfoDto.kt
@@ -1,0 +1,25 @@
+package com.d4rk.android.apps.apptoolkit.app.apps.list.data.model.api
+
+import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class AppInfoDto(
+    @SerialName("name") val name: String,
+    @SerialName("packageName") val packageName: String,
+    @SerialName("iconLogo") val iconUrl: String,
+)
+
+fun AppInfoDto.toDomain(): AppInfo = AppInfo(
+    name = name,
+    packageName = packageName,
+    iconUrl = iconUrl,
+)
+
+fun AppInfo.toDto(): AppInfoDto = AppInfoDto(
+    name = name,
+    packageName = packageName,
+    iconUrl = iconUrl,
+)
+

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/data/repository/DeveloperAppsRepositoryImpl.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/data/repository/DeveloperAppsRepositoryImpl.kt
@@ -2,7 +2,7 @@ package com.d4rk.android.apps.apptoolkit.app.apps.list.data.repository
 
 import com.d4rk.android.apps.apptoolkit.BuildConfig
 import com.d4rk.android.apps.apptoolkit.app.apps.list.data.model.api.ApiResponse
-import com.d4rk.android.apps.apptoolkit.app.apps.list.data.model.api.toAppInfo
+import com.d4rk.android.apps.apptoolkit.app.apps.list.data.model.api.toDomain
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.repository.DeveloperAppsRepository
 import com.d4rk.android.apps.apptoolkit.app.apps.list.utils.constants.api.ApiConstants
@@ -32,8 +32,8 @@ class DeveloperAppsRepositoryImpl(
             val httpResponse: HttpResponse = client.get(url)
             val apiResponse: ApiResponse = httpResponse.body()
 
-            apiResponse.data.apps
-                .map { it.toAppInfo() }
+              apiResponse.data.apps
+                  .map { it.toDomain() }
                 .sortedBy { it.name.lowercase() }
         }.onSuccess { apps ->
             emit(DataState.Success(data = apps))

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/model/AppInfo.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/model/AppInfo.kt
@@ -1,11 +1,7 @@
 package com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model
 
-import kotlinx.serialization.SerialName
-import kotlinx.serialization.Serializable
-
-@Serializable
 data class AppInfo(
-    @SerialName(value = "name") val name: String,
-    @SerialName(value = "packageName") val packageName: String,
-    @SerialName(value = "iconLogo") val iconUrl: String,
+    val name: String,
+    val packageName: String,
+    val iconUrl: String,
 )


### PR DESCRIPTION
## Summary
- Remove serialization annotations from domain `AppInfo` model
- Introduce `AppInfoDto` with serialization annotations and mapping helpers
- Map DTOs to domain objects in `DeveloperAppsRepositoryImpl`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a43aa56d14832da0e8d15e023c3018