### PR TITLE
Offload MobileAds initialization to background dispatchers

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainActivity.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainActivity.kt
@@ -59,7 +59,7 @@ class MainActivity : AppCompatActivity() {
     private fun initializeDependencies() {
         lifecycleScope.launch {
             coroutineScope {
-                val adsInitialization = async { MobileAds.initialize(this@MainActivity) {} }
+                val adsInitialization = async(Dispatchers.Default) { MobileAds.initialize(this@MainActivity) {} }
                 val consentInitialization = async(Dispatchers.IO) {
                     ConsentManagerHelper.applyInitialConsent(dataStore)
                 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/core/ads/AdsCoreManager.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/core/ads/AdsCoreManager.kt
@@ -27,7 +27,7 @@ open class AdsCoreManager(protected val context : Context , val buildInfoProvide
             dataStore.ads(default = !buildInfoProvider.isDebugBuild).first()
         }
         if (isAdsChecked) {
-            MobileAds.initialize(context)
+            withContext(Dispatchers.IO) { MobileAds.initialize(context) }
             appOpenAdManager = AppOpenAdManager(appOpenUnitId)
         }
     }


### PR DESCRIPTION
## Summary
- initialize Google Mobile Ads on a background dispatcher in MainActivity
- wrap AdsCoreManager's MobileAds initialization in `withContext(Dispatchers.IO)` and create ad manager after completion

## Testing
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a44a921b34832d8ca9b939bcd8350a