### PR TITLE
Pause AdView before pooling and resume on reuse

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdViewPool.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdViewPool.kt
@@ -64,6 +64,7 @@ object AdViewPool {
                 val pooled = iterator.next()
                 if (pooled.view.responseInfo != null) {
                     iterator.remove()
+                    pooled.view.resume()
                     return pooled.view
                 }
             }
@@ -86,6 +87,7 @@ object AdViewPool {
         if (deque.size >= MAX_POOL_SIZE) {
             adView.destroy()
         } else {
+            adView.pause()
             deque.add(PooledAdView(adView, System.currentTimeMillis()))
         }
     }


### PR DESCRIPTION
## Summary
- Pause AdView instances when releasing them to the pool
- Resume pooled AdView instances when acquired

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a455b01dec832d964cb8c9ec3e1c5c