### PR TITLE
Use Kotlin let for resolveActivity checks

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/onboarding/utils/interfaces/providers/OnboardingProvider.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/onboarding/utils/interfaces/providers/OnboardingProvider.kt
@@ -68,13 +68,11 @@ class AppOnboardingProvider : OnboardingProvider {
 
     override fun onOnboardingFinished(context: Context) {
         val intent = Intent(context, MainActivity::class.java)
-        if (intent.resolveActivity(context.packageManager) != null) {
+        intent.resolveActivity(context.packageManager)?.let {
             context.startActivity(intent)
             if (context is Activity) {
                 context.finish()
             }
-        } else {
-            Log.w("AppOnboardingProvider", "MainActivity not found to handle intent")
-        }
+        } ?: Log.w("AppOnboardingProvider", "MainActivity not found to handle intent")
     }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/display/DisplaySettingsList.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/display/DisplaySettingsList.kt
@@ -200,18 +200,12 @@ fun DisplaySettingsList(paddingValues : PaddingValues = PaddingValues() , provid
                                 "package" , context.packageName , null
                             )
                         )
-                        when {
-                            context.packageManager.resolveActivity(
-                                localeIntent , 0
-                            ) != null -> runCatching { context.startActivity(localeIntent) }
-
-                            context.packageManager.resolveActivity(
-                                detailsIntent , 0
-                            ) != null -> runCatching { context.startActivity(detailsIntent) }
-
-                            else -> {
-                                showLanguageDialog = true
-                            }
+                        localeIntent.resolveActivity(context.packageManager)?.let {
+                            runCatching { context.startActivity(localeIntent) }
+                        } ?: detailsIntent.resolveActivity(context.packageManager)?.let {
+                            runCatching { context.startActivity(detailsIntent) }
+                        } ?: run {
+                            showLanguageDialog = true
                         }
                     }
                     else {

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/components/pages/CrashlyticsOnboardingPageTab.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/components/pages/CrashlyticsOnboardingPageTab.kt
@@ -237,15 +237,13 @@ fun LearnMoreSection(context: Context) {
         OutlinedIconButtonWithText(
             onClick = {
                 val intent = Intent(Intent.ACTION_VIEW, AppLinks.PRIVACY_POLICY.toUri())
-                if (intent.resolveActivity(context.packageManager) != null) {
+                intent.resolveActivity(context.packageManager)?.let {
                     runCatching { context.startActivity(intent) }
-                } else {
-                    Toast.makeText(
-                        context,
-                        context.getString(R.string.error),
-                        Toast.LENGTH_SHORT
-                    ).show()
-                }
+                } ?: Toast.makeText(
+                    context,
+                    context.getString(R.string.error),
+                    Toast.LENGTH_SHORT
+                ).show()
             },
             icon = Icons.AutoMirrored.Filled.Launch,
             iconContentDescription = null,

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/GeneralSettingsActivity.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/GeneralSettingsActivity.kt
@@ -33,12 +33,9 @@ class GeneralSettingsActivity : AppCompatActivity() {
             }
 
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-            val resolvedActivity = intent.resolveActivity(context.packageManager)
-            if (resolvedActivity != null) {
+            intent.resolveActivity(context.packageManager)?.let {
                 runCatching { context.startActivity(intent) }
-            } else {
-                Log.e("GeneralSettingsActivity" , "Unable to resolve activity to handle intent")
-            }
+            } ?: Log.e("GeneralSettingsActivity" , "Unable to resolve activity to handle intent")
         }
     }
 

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/AppInfoHelper.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/AppInfoHelper.kt
@@ -43,14 +43,7 @@ open class AppInfoHelper {
             if (context !is Activity) {
                 launchIntent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             }
-            if (launchIntent.resolveActivity(context.packageManager) == null) {
-                Toast.makeText(
-                    context ,
-                    context.getString(R.string.app_not_installed) ,
-                    Toast.LENGTH_SHORT
-                ).show()
-                Result.failure(IllegalStateException("App not installed"))
-            } else {
+            launchIntent.resolveActivity(context.packageManager)?.let {
                 runCatching {
                     context.startActivity(launchIntent)
                     true
@@ -61,6 +54,13 @@ open class AppInfoHelper {
                         Toast.LENGTH_SHORT
                     ).show()
                 }
+            } ?: run {
+                Toast.makeText(
+                    context ,
+                    context.getString(R.string.app_not_installed) ,
+                    Toast.LENGTH_SHORT
+                ).show()
+                Result.failure(IllegalStateException("App not installed"))
             }
         }
         else {

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/IntentsHelper.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/IntentsHelper.kt
@@ -33,7 +33,7 @@ object IntentsHelper {
         val intent = Intent(Intent.ACTION_VIEW , url.toUri()).apply {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         }
-        return if (intent.resolveActivity(context.packageManager) != null) {
+        return intent.resolveActivity(context.packageManager)?.let {
             runCatching {
                 context.startActivity(intent)
                 true
@@ -41,10 +41,7 @@ object IntentsHelper {
                 it.printStackTrace()
                 false
             }
-        }
-        else {
-            false
-        }
+        } ?: false
     }
 
     /**
@@ -60,7 +57,7 @@ object IntentsHelper {
         val intent = Intent(context , activityClass).apply {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         }
-        return if (intent.resolveActivity(context.packageManager) != null) {
+        return intent.resolveActivity(context.packageManager)?.let {
             runCatching {
                 context.startActivity(intent)
                 true
@@ -68,10 +65,7 @@ object IntentsHelper {
                 it.printStackTrace()
                 false
             }
-        }
-        else {
-            false
-        }
+        } ?: false
     }
 
     /**
@@ -96,7 +90,7 @@ object IntentsHelper {
             }
         }
         intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
-        return if (intent.resolveActivity(context.packageManager) != null) {
+        return intent.resolveActivity(context.packageManager)?.let {
             runCatching {
                 context.startActivity(intent)
                 true
@@ -104,10 +98,7 @@ object IntentsHelper {
                 it.printStackTrace()
                 false
             }
-        }
-        else {
-            false
-        }
+        } ?: false
     }
 
     /**
@@ -130,27 +121,23 @@ object IntentsHelper {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         }
 
-        return when {
-            displayIntent.resolveActivity(packageManager) != null -> {
-                runCatching {
-                    context.startActivity(displayIntent)
-                    true
-                }.getOrElse {
-                    it.printStackTrace()
-                    false
-                }
+        return displayIntent.resolveActivity(packageManager)?.let {
+            runCatching {
+                context.startActivity(displayIntent)
+                true
+            }.getOrElse {
+                it.printStackTrace()
+                false
             }
-            settingsIntent.resolveActivity(packageManager) != null -> {
-                runCatching {
-                    context.startActivity(settingsIntent)
-                    true
-                }.getOrElse {
-                    it.printStackTrace()
-                    false
-                }
+        } ?: settingsIntent.resolveActivity(packageManager)?.let {
+            runCatching {
+                context.startActivity(settingsIntent)
+                true
+            }.getOrElse {
+                it.printStackTrace()
+                false
             }
-            else -> false
-        }
+        } ?: false
     }
 
     /**
@@ -168,7 +155,7 @@ object IntentsHelper {
         ).apply {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         }
-        return if (marketIntent.resolveActivity(context.packageManager) != null) {
+        return marketIntent.resolveActivity(context.packageManager)?.let {
             runCatching {
                 context.startActivity(marketIntent)
                 true
@@ -176,10 +163,7 @@ object IntentsHelper {
                 it.printStackTrace()
                 false
             }
-        }
-        else {
-            openUrl(context , "${AppLinks.PLAY_STORE_APP}$packageName")
-        }
+        } ?: openUrl(context , "${AppLinks.PLAY_STORE_APP}$packageName")
     }
 
     /**
@@ -206,7 +190,7 @@ object IntentsHelper {
         ).apply {
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         }
-        return if (chooser.resolveActivity(context.packageManager) != null) {
+        return chooser.resolveActivity(context.packageManager)?.let {
             runCatching {
                 context.startActivity(chooser)
                 true
@@ -214,10 +198,7 @@ object IntentsHelper {
                 it.printStackTrace()
                 false
             }
-        }
-        else {
-            false
-        }
+        } ?: false
     }
 
     /**
@@ -240,7 +221,7 @@ object IntentsHelper {
         val mailtoUri : Uri = "mailto:$developerEmail?subject=$subjectEncoded&body=$bodyEncoded".toUri()
         val emailIntent = Intent(Intent.ACTION_SENDTO , mailtoUri)
 
-        return if (emailIntent.resolveActivity(context.packageManager) != null) {
+        return emailIntent.resolveActivity(context.packageManager)?.let {
             val chooser = Intent.createChooser(
                 emailIntent , context.getString(R.string.send_email_using)
             ).apply {
@@ -253,9 +234,6 @@ object IntentsHelper {
                 it.printStackTrace()
                 false
             }
-        }
-        else {
-            false
-        }
+        } ?: false
     }
 }


### PR DESCRIPTION
## Summary
- Refactor resolveActivity checks to use Kotlin's `let` idiom across app and library modules
- Simplify intent launching in settings, onboarding, and helper utilities

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68a4819fea84832db41bbadd3aa99909