### PR TITLE
Add localized loading strings

### DIFF
--- a/apptoolkit/src/main/res/values-ar-rEG/strings.xml
+++ b/apptoolkit/src/main/res/values-ar-rEG/strings.xml
@@ -10,6 +10,7 @@
     <string name="summary_browse_terms_of_service_and_privacy_policy">اقرأ ووافق على شروط الخدمة وسياسة الخصوصية الخاصة بنا للمتابعة</string>
     <string name="agree">أوافق</string>
     <string name="error_loading_consent_info">فشل تحميل معلومات الموافقة</string>
+    <string name="loading">جارٍ التحميل…</string>
 
     <string name="skip_button_text">تخطي</string>
     <string name="skip_button_content_description">تخطي</string>

--- a/apptoolkit/src/main/res/values-bg-rBG/strings.xml
+++ b/apptoolkit/src/main/res/values-bg-rBG/strings.xml
@@ -10,6 +10,7 @@
     <string name="summary_browse_terms_of_service_and_privacy_policy">Прочетете и се съгласете с нашите Общи условия и Политика за поверителност, за да продължите</string>
     <string name="agree">Съгласен съм</string>
     <string name="error_loading_consent_info">Неуспешно зареждане на информация за съгласие</string>
+    <string name="loading">Зареждане…</string>
 
     <string name="skip_button_text">ПРОПУСНИ</string>
     <string name="skip_button_content_description">Пропусни</string>

--- a/apptoolkit/src/main/res/values-bn-rBD/strings.xml
+++ b/apptoolkit/src/main/res/values-bn-rBD/strings.xml
@@ -10,6 +10,7 @@
     <string name="summary_browse_terms_of_service_and_privacy_policy">চালিয়ে যেতে আমাদের পরিষেবার শর্তাবলী এবং গোপনীয়তা নীতি পড়ুন এবং সম্মত হন</string>
     <string name="agree">রাজি</string>
     <string name="error_loading_consent_info">সম্মতি তথ্য লোড করতে ব্যর্থ</string>
+    <string name="loading">লোড হচ্ছে…</string>
 
     <string name="skip_button_text">এড়িয়ে যান</string>
     <string name="skip_button_content_description">এড়িয়ে যান</string>

--- a/apptoolkit/src/main/res/values-de-rDE/strings.xml
+++ b/apptoolkit/src/main/res/values-de-rDE/strings.xml
@@ -10,6 +10,7 @@
     <string name="summary_browse_terms_of_service_and_privacy_policy">Lesen und akzeptieren Sie unsere Nutzungsbedingungen und Datenschutzrichtlinien, um fortzufahren</string>
     <string name="agree">Zustimmen</string>
     <string name="error_loading_consent_info">Fehler beim Laden der Einwilligungsinformationen</string>
+    <string name="loading">Wird geladen…</string>
 
     <string name="skip_button_text">ÜBERSPRINGEN</string>
     <string name="skip_button_content_description">Überspringen</string>

--- a/apptoolkit/src/main/res/values-es-rGQ/strings.xml
+++ b/apptoolkit/src/main/res/values-es-rGQ/strings.xml
@@ -10,6 +10,7 @@
     <string name="summary_browse_terms_of_service_and_privacy_policy">Lee y acepta nuestros Términos de servicio y Política de privacidad para continuar</string>
     <string name="agree">Aceptar</string>
     <string name="error_loading_consent_info">Error al cargar la información de consentimiento</string>
+    <string name="loading">Cargando…</string>
 
     <string name="skip_button_text">OMITIR</string>
     <string name="skip_button_content_description">Omitir</string>

--- a/apptoolkit/src/main/res/values-es-rMX/strings.xml
+++ b/apptoolkit/src/main/res/values-es-rMX/strings.xml
@@ -10,6 +10,7 @@
     <string name="summary_browse_terms_of_service_and_privacy_policy">Lee y acepta nuestros Términos de Servicio y Política de Privacidad para continuar</string>
     <string name="agree">Aceptar</string>
     <string name="error_loading_consent_info">Error al cargar la información de consentimiento</string>
+    <string name="loading">Cargando…</string>
 
     <string name="skip_button_text">OMITIR</string>
     <string name="skip_button_content_description">Omitir</string>

--- a/apptoolkit/src/main/res/values-fil-rPH/strings.xml
+++ b/apptoolkit/src/main/res/values-fil-rPH/strings.xml
@@ -10,6 +10,7 @@
     <string name="summary_browse_terms_of_service_and_privacy_policy">Basahin at sumang-ayon sa aming Mga Tuntunin ng Serbisyo at Patakaran sa Privacy upang magpatuloy</string>
     <string name="agree">Sumang-ayon</string>
     <string name="error_loading_consent_info">Nabigong i-load ang impormasyon ng pahintulot</string>
+    <string name="loading">Naglo-load…</string>
 
     <string name="skip_button_text">LAKTAWAN</string>
     <string name="skip_button_content_description">Laktawan</string>

--- a/apptoolkit/src/main/res/values-fr-rFR/strings.xml
+++ b/apptoolkit/src/main/res/values-fr-rFR/strings.xml
@@ -10,6 +10,7 @@
     <string name="summary_browse_terms_of_service_and_privacy_policy">Lisez et acceptez nos Conditions d\'utilisation et notre Politique de confidentialité pour continuer</string>
     <string name="agree">Accepter</string>
     <string name="error_loading_consent_info">Échec du chargement des informations de consentement</string>
+    <string name="loading">Chargement…</string>
 
     <string name="skip_button_text">PASSER</string>
     <string name="skip_button_content_description">Passer</string>

--- a/apptoolkit/src/main/res/values-hi-rIN/strings.xml
+++ b/apptoolkit/src/main/res/values-hi-rIN/strings.xml
@@ -10,6 +10,7 @@
     <string name="summary_browse_terms_of_service_and_privacy_policy">जारी रखने के लिए हमारी सेवा की शर्तें और गोपनीयता नीति पढ़ें और सहमति दें</string>
     <string name="agree">सहमत</string>
     <string name="error_loading_consent_info">सहमति जानकारी लोड करने में विफल</string>
+    <string name="loading">लोड हो रहा है…</string>
 
     <string name="skip_button_text">छोड़ें</string>
     <string name="skip_button_content_description">छोड़ें</string>

--- a/apptoolkit/src/main/res/values-hu-rHU/strings.xml
+++ b/apptoolkit/src/main/res/values-hu-rHU/strings.xml
@@ -10,6 +10,7 @@
     <string name="summary_browse_terms_of_service_and_privacy_policy">Olvasd el és fogadd el a Szolgáltatási feltételeinket és az Adatvédelmi irányelveinket a folytatáshoz</string>
     <string name="agree">Elfogadom</string>
     <string name="error_loading_consent_info">A hozzájárulási információ betöltése sikertelen</string>
+    <string name="loading">Betöltés…</string>
 
     <string name="skip_button_text">KIHAGYÁS</string>
     <string name="skip_button_content_description">Kihagyás</string>

--- a/apptoolkit/src/main/res/values-in-rID/strings.xml
+++ b/apptoolkit/src/main/res/values-in-rID/strings.xml
@@ -10,6 +10,7 @@
     <string name="summary_browse_terms_of_service_and_privacy_policy">Baca dan setujui Ketentuan Layanan dan Kebijakan Privasi kami untuk melanjutkan</string>
     <string name="agree">Setuju</string>
     <string name="error_loading_consent_info">Gagal memuat informasi persetujuan</string>
+    <string name="loading">Memuat…</string>
 
     <string name="skip_button_text">LEWATI</string>
     <string name="skip_button_content_description">Lewati</string>

--- a/apptoolkit/src/main/res/values-it-rIT/strings.xml
+++ b/apptoolkit/src/main/res/values-it-rIT/strings.xml
@@ -10,6 +10,7 @@
     <string name="summary_browse_terms_of_service_and_privacy_policy">Leggi e accetta i nostri Termini di Servizio e la Politica sulla Privacy per continuare</string>
     <string name="agree">Accetto</string>
     <string name="error_loading_consent_info">Caricamento delle informazioni sul consenso non riuscito</string>
+    <string name="loading">Caricamento…</string>
 
     <string name="skip_button_text">SALTA</string>
     <string name="skip_button_content_description">Salta</string>

--- a/apptoolkit/src/main/res/values-ja-rJP/strings.xml
+++ b/apptoolkit/src/main/res/values-ja-rJP/strings.xml
@@ -10,6 +10,7 @@
     <string name="summary_browse_terms_of_service_and_privacy_policy">続行するには、利用規約およびプライバシーポリシーをお読みいただき、同意してください</string>
     <string name="agree">同意する</string>
     <string name="error_loading_consent_info">同意情報の読み込みに失敗しました</string>
+    <string name="loading">読み込み中…</string>
 
     <string name="skip_button_text">スキップ</string>
     <string name="skip_button_content_description">スキップ</string>

--- a/apptoolkit/src/main/res/values-ko-rKR/strings.xml
+++ b/apptoolkit/src/main/res/values-ko-rKR/strings.xml
@@ -10,6 +10,7 @@
     <string name="summary_browse_terms_of_service_and_privacy_policy">계속하려면 서비스 약관 및 개인정보처리방침을 읽고 동의하세요.</string>
     <string name="agree">동의</string>
     <string name="error_loading_consent_info">동의 정보를 로드하지 못했습니다.</string>
+    <string name="loading">로딩 중…</string>
 
     <string name="skip_button_text">건너뛰기</string>
     <string name="skip_button_content_description">건너뛰기</string>

--- a/apptoolkit/src/main/res/values-pl-rPL/strings.xml
+++ b/apptoolkit/src/main/res/values-pl-rPL/strings.xml
@@ -10,6 +10,7 @@
     <string name="summary_browse_terms_of_service_and_privacy_policy">Przeczytaj i zaakceptuj nasze Warunki korzystania z usługi oraz Politykę prywatności, aby kontynuować</string>
     <string name="agree">Zgadzam się</string>
     <string name="error_loading_consent_info">Nie udało się załadować informacji o zgodzie</string>
+    <string name="loading">Ładowanie…</string>
 
     <string name="skip_button_text">POMIŃ</string>
     <string name="skip_button_content_description">Pomiń</string>

--- a/apptoolkit/src/main/res/values-pt-rBR/strings.xml
+++ b/apptoolkit/src/main/res/values-pt-rBR/strings.xml
@@ -10,6 +10,7 @@
     <string name="summary_browse_terms_of_service_and_privacy_policy">Leia e concorde com nossos Termos de Serviço e Política de Privacidade para continuar</string>
     <string name="agree">Concordo</string>
     <string name="error_loading_consent_info">Falha ao carregar as informações de consentimento</string>
+    <string name="loading">Carregando…</string>
 
     <string name="skip_button_text">PULAR</string>
     <string name="skip_button_content_description">Pular</string>

--- a/apptoolkit/src/main/res/values-ro-rRO/strings.xml
+++ b/apptoolkit/src/main/res/values-ro-rRO/strings.xml
@@ -10,6 +10,7 @@
     <string name="summary_browse_terms_of_service_and_privacy_policy">Citește și acceptă Termenii de utilizare și Politica de confidențialitate pentru a continua</string>
     <string name="agree">Sunt de acord</string>
     <string name="error_loading_consent_info">Încărcarea informațiilor privind consimțământul a eșuat</string>
+    <string name="loading">Se încarcă…</string>
 
     <string name="skip_button_text">OMITE</string>
     <string name="skip_button_content_description">Omite</string>

--- a/apptoolkit/src/main/res/values-ru-rRU/strings.xml
+++ b/apptoolkit/src/main/res/values-ru-rRU/strings.xml
@@ -10,6 +10,7 @@
     <string name="summary_browse_terms_of_service_and_privacy_policy">Прочтите и согласитесь с нашими Условиями использования и Политикой конфиденциальности, чтобы продолжить</string>
     <string name="agree">Согласен</string>
     <string name="error_loading_consent_info">Не удалось загрузить информацию о согласии</string>
+    <string name="loading">Загрузка…</string>
 
     <string name="skip_button_text">ПРОПУСТИТЬ</string>
     <string name="skip_button_content_description">Пропустить</string>

--- a/apptoolkit/src/main/res/values-sv-rSE/strings.xml
+++ b/apptoolkit/src/main/res/values-sv-rSE/strings.xml
@@ -10,6 +10,7 @@
     <string name="summary_browse_terms_of_service_and_privacy_policy">Läs och godkänn våra användarvillkor och integritetspolicy för att fortsätta</string>
     <string name="agree">Godkänn</string>
     <string name="error_loading_consent_info">Misslyckades med att läsa in samtyckesinformationen</string>
+    <string name="loading">Läser in…</string>
 
     <string name="skip_button_text">HOPPA ÖVER</string>
     <string name="skip_button_content_description">Hoppa över</string>

--- a/apptoolkit/src/main/res/values-th-rTH/strings.xml
+++ b/apptoolkit/src/main/res/values-th-rTH/strings.xml
@@ -10,6 +10,7 @@
     <string name="summary_browse_terms_of_service_and_privacy_policy">โปรดอ่านและยอมรับเงื่อนไขการให้บริการและนโยบายความเป็นส่วนตัวเพื่อดำเนินการต่อ</string>
     <string name="agree">ยอมรับ</string>
     <string name="error_loading_consent_info">ไม่สามารถโหลดข้อมูลความยินยอมได้</string>
+    <string name="loading">กำลังโหลด…</string>
 
     <string name="skip_button_text">ข้าม</string>
     <string name="skip_button_content_description">ข้าม</string>

--- a/apptoolkit/src/main/res/values-tr-rTR/strings.xml
+++ b/apptoolkit/src/main/res/values-tr-rTR/strings.xml
@@ -10,6 +10,7 @@
     <string name="summary_browse_terms_of_service_and_privacy_policy">Devam etmek için Hizmet Şartlarımızı ve Gizlilik Politikamızı okuyun ve kabul edin</string>
     <string name="agree">Kabul et</string>
     <string name="error_loading_consent_info">Onay bilgileri yüklenemedi</string>
+    <string name="loading">Yükleniyor…</string>
 
     <string name="skip_button_text">ATLA</string>
     <string name="skip_button_content_description">Atla</string>

--- a/apptoolkit/src/main/res/values-uk-rUA/strings.xml
+++ b/apptoolkit/src/main/res/values-uk-rUA/strings.xml
@@ -10,6 +10,7 @@
     <string name="summary_browse_terms_of_service_and_privacy_policy">Прочитайте та погодьтеся з нашими Умовами використання та Політикою конфіденційності, щоб продовжити</string>
     <string name="agree">Погодитися</string>
     <string name="error_loading_consent_info">Не вдалося завантажити інформацію про згоду</string>
+    <string name="loading">Завантаження…</string>
 
     <string name="skip_button_text">ПРОПУСТИТИ</string>
     <string name="skip_button_content_description">Пропустити</string>

--- a/apptoolkit/src/main/res/values-ur-rPK/strings.xml
+++ b/apptoolkit/src/main/res/values-ur-rPK/strings.xml
@@ -10,6 +10,7 @@
     <string name="summary_browse_terms_of_service_and_privacy_policy">جاری رکھنے کے لیے ہماری سروس کی شرائط اور رازداری کی پالیسی کو پڑھیں اور ان سے اتفاق کریں</string>
     <string name="agree">متفق ہوں</string>
     <string name="error_loading_consent_info">رضامندی کی معلومات لوڈ کرنے میں ناکام</string>
+    <string name="loading">لوڈ ہو رہا ہے…</string>
 
     <string name="skip_button_text">اسکپ کریں</string>
     <string name="skip_button_content_description">اسکپ کریں</string>

--- a/apptoolkit/src/main/res/values-vi-rVN/strings.xml
+++ b/apptoolkit/src/main/res/values-vi-rVN/strings.xml
@@ -10,6 +10,7 @@
     <string name="summary_browse_terms_of_service_and_privacy_policy">Đọc và đồng ý với Điều khoản dịch vụ và Chính sách quyền riêng tư của chúng tôi để tiếp tục</string>
     <string name="agree">Đồng ý</string>
     <string name="error_loading_consent_info">Không thể tải thông tin chấp thuận</string>
+    <string name="loading">Đang tải…</string>
 
     <string name="skip_button_text">BỎ QUA</string>
     <string name="skip_button_content_description">Bỏ qua\"</string>

--- a/apptoolkit/src/main/res/values-zh-rTW/strings.xml
+++ b/apptoolkit/src/main/res/values-zh-rTW/strings.xml
@@ -10,6 +10,7 @@
     <string name="summary_browse_terms_of_service_and_privacy_policy">閱讀並同意我們的服務條款和隱私政策以繼續</string>
     <string name="agree">同意</string>
     <string name="error_loading_consent_info">載入同意資訊失敗</string>
+    <string name="loading">載入中…</string>
 
     <string name="skip_button_text">跳過</string>
     <string name="skip_button_content_description">跳過</string>


### PR DESCRIPTION
## Summary
- add "loading" translations for 25 languages in apptoolkit module

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7c60db50832db14ea7de865066e9