### PR TITLE
Inject IssueReporterRepository via Koin

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppToolkitModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppToolkitModule.kt
@@ -3,6 +3,7 @@ package com.d4rk.android.apps.apptoolkit.core.di.modules
 import com.d4rk.android.apps.apptoolkit.BuildConfig
 import com.d4rk.android.apps.apptoolkit.app.startup.utils.interfaces.providers.AppStartupProvider
 import com.d4rk.android.libs.apptoolkit.app.help.domain.data.model.HelpScreenConfig
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.data.IssueReporterRepository
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.github.GithubTarget
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.ui.IssueReporterViewModel
 import com.d4rk.android.libs.apptoolkit.app.startup.utils.interfaces.providers.StartupProvider
@@ -22,9 +23,10 @@ val appToolkitModule : Module = module {
         SupportViewModel(billingRepository = get())
     }
 
+    single { IssueReporterRepository(get()) }
     viewModel {
         IssueReporterViewModel(
-            httpClient = get(),
+            repository = get(),
             githubTarget = get(),
             githubToken = get(named("github_token"))
         )

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/IssueReporterViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/IssueReporterViewModel.kt
@@ -22,7 +22,6 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.updateState
 import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.ScreenMessageType
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
-import io.ktor.client.HttpClient
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
@@ -30,7 +29,7 @@ import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
 
 class IssueReporterViewModel(
-    httpClient: HttpClient,
+    private val repository: IssueReporterRepository,
     private val githubTarget: GithubTarget,
     private val githubToken: String,
 ) : ScreenViewModel<UiIssueReporterScreen, IssueReporterEvent, IssueReporterAction>(
@@ -39,9 +38,6 @@ class IssueReporterViewModel(
         data = UiIssueReporterScreen()
     )
 ) {
-
-    private val repository = IssueReporterRepository(httpClient)
-
     override fun onEvent(event: IssueReporterEvent) {
         when (event) {
             is IssueReporterEvent.UpdateTitle -> updateTitle(event.value)

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/TestIssueReporterViewModelBase.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/TestIssueReporterViewModelBase.kt
@@ -1,5 +1,6 @@
 package com.d4rk.android.libs.apptoolkit.app.issuereporter.ui
 
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.data.IssueReporterRepository
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.github.GithubTarget
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
@@ -25,7 +26,8 @@ open class TestIssueReporterViewModelBase {
                 json()
             }
         }
-        viewModel = IssueReporterViewModel(client, githubTarget, githubToken)
+        val repository = IssueReporterRepository(client)
+        viewModel = IssueReporterViewModel(repository, githubTarget, githubToken)
         println("\u2705 [SETUP] ViewModel initialized")
     }
 }


### PR DESCRIPTION
## Summary
- inject `IssueReporterRepository` into `IssueReporterViewModel`
- provide `IssueReporterRepository` through Koin
- adjust view model tests for repository injection

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab7ff16d44832dbac9553a4d41e317