### PR TITLE
Refine coroutine handling in AboutViewModel

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/ui/AboutViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/ui/AboutViewModel.kt
@@ -26,10 +26,8 @@ open class AboutViewModel :
     }
 
     private fun copyDeviceInfo() {
-        updateUi {
-            copy(showDeviceInfoCopiedSnackbar = true)
-        }
         viewModelScope.launch {
+            updateUi { copy(showDeviceInfoCopiedSnackbar = true) }
             screenState.showSnackbar(
                 snackbar = UiSnackbar(
                     message = UiTextHelper.StringResource(resourceId = R.string.snack_device_info_copied),
@@ -42,15 +40,13 @@ open class AboutViewModel :
     }
 
     private fun dismissSnack() {
-        updateUi { copy(showDeviceInfoCopiedSnackbar = false) }
         viewModelScope.launch {
+            updateUi { copy(showDeviceInfoCopiedSnackbar = false) }
             screenState.dismissSnackbar()
         }
     }
 
     private inline fun updateUi(crossinline transform: UiAboutScreen.() -> UiAboutScreen) {
-        viewModelScope.launch {
-            screenState.updateData(newState = screenState.value.screenState) { current: UiAboutScreen -> transform(current) }
-        }
+        screenState.updateData(newState = screenState.value.screenState) { current: UiAboutScreen -> transform(current) }
     }
 }


### PR DESCRIPTION
## Summary
- streamline AboutViewModel coroutine usage by grouping UI and snackbar updates into single launches
- convert updateUi into synchronous state update to avoid nested coroutines

## Testing
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab80d4f1d0832da33a697f9c7e85ff