### PR TITLE
Refactor IssueReporter to use use case and streamline coroutines

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppToolkitModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppToolkitModule.kt
@@ -5,6 +5,7 @@ import com.d4rk.android.apps.apptoolkit.app.startup.utils.interfaces.providers.A
 import com.d4rk.android.libs.apptoolkit.app.help.domain.data.model.HelpScreenConfig
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.data.IssueReporterRepository
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.github.GithubTarget
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.usecases.SendIssueReportUseCase
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.ui.IssueReporterViewModel
 import com.d4rk.android.libs.apptoolkit.app.startup.utils.interfaces.providers.StartupProvider
 import com.d4rk.android.libs.apptoolkit.app.support.billing.BillingRepository
@@ -24,9 +25,10 @@ val appToolkitModule : Module = module {
     }
 
     single { IssueReporterRepository(get()) }
+    single { SendIssueReportUseCase(get()) }
     viewModel {
         IssueReporterViewModel(
-            repository = get(),
+            sendIssueReport = get(),
             githubTarget = get(),
             githubToken = get(named("github_token"))
         )

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/data/IssueReporterRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/data/IssueReporterRepository.kt
@@ -13,8 +13,6 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
@@ -25,7 +23,7 @@ class IssueReporterRepository(private val client : HttpClient) {
         report: Report,
         target: GithubTarget,
         token: String? = null
-    ): IssueReportResult = withContext(Dispatchers.IO) {
+    ): IssueReportResult {
         val url = "https://api.github.com/repos/${target.username}/${target.repository}/issues"
         val response: HttpResponse = client.post(url) {
             contentType(ContentType.Application.Json)
@@ -40,7 +38,7 @@ class IssueReporterRepository(private val client : HttpClient) {
         }
 
         val responseBody = response.bodyAsText()
-        if (response.status == HttpStatusCode.Created) {
+        return if (response.status == HttpStatusCode.Created) {
             val json = Json.parseToJsonElement(responseBody).jsonObject
             val issueUrl = json["html_url"]?.jsonPrimitive?.content ?: ""
             IssueReportResult.Success(issueUrl)

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/domain/usecases/SendIssueReportUseCase.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/domain/usecases/SendIssueReportUseCase.kt
@@ -1,0 +1,28 @@
+package com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.usecases
+
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.data.IssueReporterRepository
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.IssueReportResult
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.Report
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.github.GithubTarget
+import com.d4rk.android.libs.apptoolkit.core.domain.usecases.Repository
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+class SendIssueReportUseCase(
+    private val repository: IssueReporterRepository
+) : Repository<SendIssueReportUseCase.Params, IssueReportResult?> {
+
+    data class Params(
+        val report: Report,
+        val target: GithubTarget,
+        val token: String?
+    )
+
+    override suspend fun invoke(param: Params): IssueReportResult? =
+        withContext(Dispatchers.IO) {
+            runCatching {
+                repository.sendReport(param.report, param.target, param.token)
+            }.onFailure { it.printStackTrace() }
+                .getOrNull()
+        }
+}

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/TestIssueReporterViewModelBase.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/TestIssueReporterViewModelBase.kt
@@ -2,6 +2,7 @@ package com.d4rk.android.libs.apptoolkit.app.issuereporter.ui
 
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.data.IssueReporterRepository
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.github.GithubTarget
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.usecases.SendIssueReportUseCase
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.plugins.contentnegotiation.ContentNegotiation
@@ -27,7 +28,8 @@ open class TestIssueReporterViewModelBase {
             }
         }
         val repository = IssueReporterRepository(client)
-        viewModel = IssueReporterViewModel(repository, githubTarget, githubToken)
+        val useCase = SendIssueReportUseCase(repository)
+        viewModel = IssueReporterViewModel(useCase, githubTarget, githubToken)
         println("\u2705 [SETUP] ViewModel initialized")
     }
 }


### PR DESCRIPTION
## Summary
- add SendIssueReportUseCase to encapsulate repository access
- simplify IssueReporterViewModel coroutine flow and use new use case
- wire use case into DI and tests

## Testing
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8113a224832d872c795b89e6b77e