### PR TITLE
Handle coroutine errors in permissions view model

### DIFF
--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/permissions/ui/TestPermissionsViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/permissions/ui/TestPermissionsViewModel.kt
@@ -3,13 +3,9 @@ package com.d4rk.android.libs.apptoolkit.app.permissions.ui
 import android.content.Context
 import com.d4rk.android.libs.apptoolkit.app.permissions.domain.actions.PermissionsEvent
 import com.d4rk.android.libs.apptoolkit.app.permissions.utils.interfaces.PermissionsProvider
-import com.d4rk.android.libs.apptoolkit.app.settings.settings.domain.model.SettingsCategory
 import com.d4rk.android.libs.apptoolkit.app.settings.settings.domain.model.SettingsConfig
-import com.d4rk.android.libs.apptoolkit.app.settings.settings.domain.model.SettingsPreference
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
-import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.setErrors
 import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.UnconfinedDispatcherExtension
-import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
 import com.google.common.truth.Truth.assertThat
 import io.mockk.every
 import io.mockk.mockk
@@ -47,7 +43,8 @@ class TestPermissionsViewModel {
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
 
         val state = viewModel.uiState.value
-        assertThat(state.screenState).isInstanceOf(ScreenState.IsLoading::class.java)
+        assertThat(state.screenState).isInstanceOf(ScreenState.Error::class.java)
+        assertThat(state.errors).isNotEmpty()
         println("🏁 [TEST DONE] load permissions provider throws")
     }
 }


### PR DESCRIPTION
## Summary
- Improve PermissionsViewModel coroutine structure with explicit IO dispatching and failure handling
- Update test to verify error state and snackbar population when permissions config fails

## Testing
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab81262ea0832d9901787cda39ca99