### PR TITLE
Refine coroutine context in settings view model

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsViewModel.kt
@@ -16,7 +16,6 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.updateState
 import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -28,20 +27,20 @@ class SettingsViewModel(private val settingsProvider : SettingsProvider) : Scree
         }
     }
 
-    private fun loadSettings(context : Context) {
-        viewModelScope.launch(context = Dispatchers.IO) {
-            flowOf(value = settingsProvider.provideSettingsConfig(context = context)).collect { result : SettingsConfig ->
-                withContext(Dispatchers.Main) {
-                    if (result.categories.isNotEmpty()) {
-                        screenState.successData {
-                            copy(title = result.title , categories = result.categories)
-                        }
-                    }
-                    else {
-                        screenState.setErrors(listOf(UiSnackbar(message = UiTextHelper.StringResource(R.string.error_no_settings_found))))
-                        screenState.updateState(ScreenState.NoData())
-                    }
+    private fun loadSettings(context: Context) {
+        viewModelScope.launch {
+            val result: SettingsConfig = withContext(Dispatchers.IO) {
+                settingsProvider.provideSettingsConfig(context = context)
+            }
+            if (result.categories.isNotEmpty()) {
+                screenState.successData {
+                    copy(title = result.title, categories = result.categories)
                 }
+            } else {
+                screenState.setErrors(
+                    listOf(UiSnackbar(message = UiTextHelper.StringResource(R.string.error_no_settings_found)))
+                )
+                screenState.updateState(ScreenState.NoData())
             }
         }
     }


### PR DESCRIPTION
## Summary
- simplify settings loading by switching to structured coroutine context and removing redundant flow wrapper

## Testing
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*
- `apt-get install -y android-sdk` *(fails: ca-certificates-java post-installation script error)*

------
https://chatgpt.com/codex/tasks/task_e_68ab813dc60c832da102ec7f382c535c