### PR TITLE
Use lifecycle-aware state collection in support screen

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportScreen.kt
@@ -18,7 +18,7 @@ import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -49,7 +49,7 @@ fun SupportComposable(
     viewModel: SupportViewModel,
     activity: Activity,
 ) {
-    val screenState: UiStateScreen<SupportScreenUiState> by viewModel.uiState.collectAsState()
+    val screenState: UiStateScreen<SupportScreenUiState> by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState: SnackbarHostState = remember { SnackbarHostState() }
 
     LargeTopAppBarWithScaffold(


### PR DESCRIPTION
## Summary
- use collectAsStateWithLifecycle for support screen state flow

## Testing
- `./gradlew test` (fails: SDK location not found)
- `./gradlew :apptoolkit:test` (fails: SDK location not found)


------
https://chatgpt.com/codex/tasks/task_e_68ab814d9844832d8d4cc47d1e9c4126