### PR TITLE
refactor: inject DataStore via Koin

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/data/datastore/DataStore.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/data/datastore/DataStore.kt
@@ -3,16 +3,4 @@ package com.d4rk.android.apps.apptoolkit.core.data.datastore
 import android.content.Context
 import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
 
-class DataStore(context : Context) : CommonDataStore(context) {
-
-    companion object {
-        @Volatile
-        private var instance : DataStore? = null
-
-        fun getInstance(context : Context) : DataStore {
-            return instance ?: synchronized(lock = this) {
-                instance ?: DataStore(context.applicationContext).also { instance = it }
-            }
-        }
-    }
-}
+class DataStore(context: Context) : CommonDataStore(context)

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppModule.kt
@@ -24,7 +24,7 @@ import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 val appModule : Module = module {
-    single<DataStore> { DataStore.getInstance(context = get()) }
+    single<DataStore> { DataStore(context = get()) }
     single<AdsCoreManager> { AdsCoreManager(context = get() , get()) }
     single { KtorClient().createClient(enableLogging = BuildConfig.DEBUG) }
 


### PR DESCRIPTION
## Summary
- remove DataStore singleton companion
- provide DataStore via Koin module singleton

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab83d49550832d886857ede5c84145