### PR TITLE
Handle errors when toggling favorite apps

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListViewModel.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListViewModel.kt
@@ -95,6 +95,13 @@ class AppsListViewModel(
         viewModelScope.launch(context = Dispatchers.IO) {
             runCatching {
                 dataStore.toggleFavoriteApp(packageName)
+            }.onFailure { error ->
+                error.printStackTrace()
+                withContext(Dispatchers.Main) {
+                    screenState.update { currentState ->
+                        currentState.copy(screenState = ScreenState.Error())
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- log and surface errors when toggling favorites fails

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab83e538b8832d829ead25533418be