### PR TITLE
Use SupervisorJob scope in datastore and cleanup on shutdown

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/core/BaseCoreManager.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/core/BaseCoreManager.kt
@@ -6,6 +6,7 @@ import android.os.Bundle
 import androidx.lifecycle.LifecycleObserver
 import androidx.multidex.MultiDexApplication
 import com.d4rk.android.libs.apptoolkit.app.support.billing.BillingRepository
+import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
 import com.google.firebase.Firebase
 import com.google.firebase.appcheck.appCheck
 import com.google.firebase.appcheck.playintegrity.PlayIntegrityAppCheckProviderFactory
@@ -67,6 +68,7 @@ open class BaseCoreManager : MultiDexApplication(), Application.ActivityLifecycl
     override fun onTerminate() {
         super.onTerminate()
         billingRepository.close()
+        CommonDataStore.getInstance(this).close()
         applicationScope.cancel()
     }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/datastore/CommonDataStore.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/datastore/CommonDataStore.kt
@@ -14,6 +14,8 @@ import androidx.datastore.preferences.preferencesDataStore
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.datastore.DataStoreNamesConstants
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
@@ -34,7 +36,7 @@ val Context.commonDataStore : DataStore<Preferences> by preferencesDataStore(nam
  */
 open class CommonDataStore(context : Context) {
     val dataStore : DataStore<Preferences> = context.commonDataStore
-    private val scope = CoroutineScope(context = Dispatchers.IO)
+    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     companion object {
         @Volatile
@@ -45,6 +47,10 @@ open class CommonDataStore(context : Context) {
                 instance ?: CommonDataStore(context.applicationContext).also { instance = it }
             }
         }
+    }
+
+    fun close() {
+        scope.cancel()
     }
 
     // Last used app notifications


### PR DESCRIPTION
## Summary
- use SupervisorJob+Dispatchers.IO for CommonDataStore coroutine scope
- add close method to cancel datastore scope
- close datastore during application termination

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab86967310832da797116905640512