### PR TITLE
Fix SupportViewModel failed purchase test

### DIFF
--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportViewModelTest.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportViewModelTest.kt
@@ -95,8 +95,7 @@ class SupportViewModelTest {
             awaitItem()
             purchaseResultFlow.emit(PurchaseResult.Failed(error))
             dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
-            awaitItem() // state after updateData
-            val state = awaitItem() // state after showSnackbar
+            val state = awaitItem()
             assertThat(state.screenState).isInstanceOf(ScreenState.Error::class.java)
             assertThat(state.data!!.error).isEqualTo(error)
             val snackbar = state.snackbar!!


### PR DESCRIPTION
## Summary
- Correct SupportViewModel failed purchase unit test to await only a single updated state

## Testing
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8a015558832d917f8f9992cb9aea