### PR TITLE
Cancel ViewModel scopes after tests

### DIFF
--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModelBase.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModelBase.kt
@@ -23,6 +23,9 @@ import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.jupiter.api.Assertions.assertTrue
+import kotlinx.coroutines.cancel
+import androidx.lifecycle.viewModelScope
+import org.junit.jupiter.api.AfterEach
 
 @OptIn(ExperimentalCoroutinesApi::class)
 open class TestFavoriteAppsViewModelBase {
@@ -149,5 +152,12 @@ open class TestFavoriteAppsViewModelBase {
         }
         assertThat(favorites.contains(packageName)).isEqualTo(expected)
         println("\uD83C\uDFC1 [TEST END] toggleAndAssert")
+    }
+
+    @AfterEach
+    fun tearDown() {
+        if (this::viewModel.isInitialized) {
+            viewModel.viewModelScope.cancel()
+        }
     }
 }

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModelBase.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModelBase.kt
@@ -17,6 +17,9 @@ import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeout
+import kotlinx.coroutines.cancel
+import androidx.lifecycle.viewModelScope
+import org.junit.jupiter.api.AfterEach
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -139,5 +142,12 @@ open class TestAppsListViewModelBase {
         }
         assertThat(favorites.contains(packageName)).isEqualTo(expected)
         println("\uD83C\uDFC1 [TEST END] toggleAndAssert")
+    }
+
+    @AfterEach
+    fun tearDown() {
+        if (this::viewModel.isInitialized) {
+            viewModel.viewModelScope.cancel()
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Cancel ViewModel `viewModelScope` after each unit test to prevent lingering coroutines accessing `Dispatchers.Main`
- Ensure coroutine scopes are disposed in both apps list and favorites test bases

## Testing
- `./gradlew testDebugUnitTest --tests "com.*"` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab8b1b5d4c832db58bcfa1fc932cc4