### PR TITLE
Emit loading state before fetching developer apps

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsViewModel.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsViewModel.kt
@@ -12,6 +12,7 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState.*
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.updateData
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.updateState
 import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
 import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
@@ -101,7 +102,7 @@ class FavoriteAppsViewModel(
 
                     is DataState.Loading -> {
                         withContext(Dispatchers.Main) {
-                            screenState.update { it.copy(screenState = IsLoading()) }
+                            screenState.updateState(IsLoading())
                         }
                     }
 

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/data/repository/DeveloperAppsRepositoryImpl.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/data/repository/DeveloperAppsRepositoryImpl.kt
@@ -28,6 +28,7 @@ class DeveloperAppsRepositoryImpl(
 ) : DeveloperAppsRepository {
 
     override fun fetchDeveloperApps(): Flow<DataState<List<AppInfo>, RootError>> = flow {
+        emit(DataState.Loading<List<AppInfo>, RootError>())
         runCatching {
             val url = BuildConfig.DEBUG.let { isDebug ->
                 val environment = if (isDebug) ApiEnvironments.ENV_DEBUG else ApiEnvironments.ENV_RELEASE

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListViewModel.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListViewModel.kt
@@ -103,7 +103,11 @@ class AppsListViewModel(
                         }
                     }
 
-                    is DataState.Loading -> {}
+                    is DataState.Loading -> {
+                        withContext(Dispatchers.Main) {
+                            screenState.updateState(ScreenState.IsLoading())
+                        }
+                    }
                 }
             }
         }


### PR DESCRIPTION
## Summary
- emit `DataState.Loading` before requesting developer apps
- update apps list and favorites view models to show a loading state when `DataState.Loading` is received

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0f0288b0832db802ea5c350c2781