### PR TITLE
Use singleTop navigation for tablet bottom items

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainScreen.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainScreen.kt
@@ -175,7 +175,12 @@ fun MainScaffoldTabletContent() {
             currentRoute = currentRoute,
             isRailExpanded = isRailExpanded,
             paddingValues = paddingValues,
-            onBottomItemClick = { item: BottomBarItem -> navController.navigate(item.route) },
+            onBottomItemClick = { item: BottomBarItem ->
+                navController.navigate(item.route) {
+                    launchSingleTop = true
+                    popUpTo(navController.graph.startDestinationId)
+                }
+            },
             onDrawerItemClick = { item: NavigationDrawerItem ->
                 handleNavigationItemClick(
                     context = context,


### PR DESCRIPTION
## Summary
- use singleTop navigation with popUpTo for tablet bottom navigation items

## Testing
- `./gradlew test` *(fails: SDK location not found; attempted installing android-sdk but ca-certificates-java error)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0efa3014832daeecefabba7f648d