### PR TITLE
Refactor issue report result handling

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/domain/usecases/SendIssueReportUseCase.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/domain/usecases/SendIssueReportUseCase.kt
@@ -10,7 +10,7 @@ import kotlinx.coroutines.withContext
 
 class SendIssueReportUseCase(
     private val repository: IssueReporterRepository
-) : Repository<SendIssueReportUseCase.Params, IssueReportResult?> {
+) : Repository<SendIssueReportUseCase.Params, Result<IssueReportResult>> {
 
     data class Params(
         val report: Report,
@@ -18,11 +18,10 @@ class SendIssueReportUseCase(
         val token: String?
     )
 
-    override suspend fun invoke(param: Params): IssueReportResult? =
+    override suspend fun invoke(param: Params): Result<IssueReportResult> =
         withContext(Dispatchers.IO) {
             runCatching {
                 repository.sendReport(param.report, param.target, param.token)
-            }.onFailure { it.printStackTrace() }
-                .getOrNull()
+            }
         }
 }


### PR DESCRIPTION
## Summary
- Wrap issue report send use case results in Kotlin `Result`
- Handle success, API errors, and failures in `IssueReporterViewModel` without null branches

## Testing
- `./gradlew :apptoolkit:test` *(fails: Failed to install the following Android SDK packages as some licences have not been accepted)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0f04ca24832db839fa79157e544d