### PR TITLE
Make favorites repository context-agnostic

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/domain/usecases/ToggleFavoriteUseCase.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/domain/usecases/ToggleFavoriteUseCase.kt
@@ -2,10 +2,18 @@ package com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases
 
 import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.repository.FavoritesRepository
 import com.d4rk.android.libs.apptoolkit.core.domain.usecases.Repository
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 
-class ToggleFavoriteUseCase(private val repository: FavoritesRepository) : Repository<String, Unit> {
+class ToggleFavoriteUseCase(
+    private val repository: FavoritesRepository,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : Repository<String, Unit> {
     override suspend operator fun invoke(param: String) {
-        repository.toggleFavorite(param)
+        withContext(dispatcher) {
+            repository.toggleFavorite(param)
+        }
     }
 }
 

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/data/favorites/FavoritesRepositoryImpl.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/data/favorites/FavoritesRepositoryImpl.kt
@@ -2,17 +2,13 @@ package com.d4rk.android.apps.apptoolkit.core.data.favorites
 
 import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.repository.FavoritesRepository
 import com.d4rk.android.apps.apptoolkit.core.data.datastore.DataStore
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.withContext
 
 class FavoritesRepositoryImpl(private val dataStore: DataStore) : FavoritesRepository {
     override fun observeFavorites(): Flow<Set<String>> = dataStore.favoriteApps
 
     override suspend fun toggleFavorite(packageName: String) {
-        withContext(context = Dispatchers.IO) {
-            dataStore.toggleFavoriteApp(packageName)
-        }
+        dataStore.toggleFavoriteApp(packageName)
     }
 }
 

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppModule.kt
@@ -18,6 +18,7 @@ import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases.Toggl
 import com.d4rk.android.libs.apptoolkit.app.onboarding.utils.interfaces.providers.OnboardingProvider
 import com.d4rk.android.libs.apptoolkit.data.client.KtorClient
 import com.d4rk.android.libs.apptoolkit.data.core.ads.AdsCoreManager
+import kotlinx.coroutines.Dispatchers
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.viewModel
 import org.koin.core.qualifier.named
@@ -30,7 +31,7 @@ val appModule : Module = module {
 
     single<FavoritesRepository> { FavoritesRepositoryImpl(dataStore = get()) }
     single { ObserveFavoritesUseCase(repository = get()) }
-    single { ToggleFavoriteUseCase(repository = get()) }
+    single { ToggleFavoriteUseCase(repository = get(), dispatcher = Dispatchers.IO) }
 
     single<List<String>>(qualifier = named(name = "startup_entries")) {
         get<Context>().resources.getStringArray(R.array.preference_startup_entries).toList()

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModelBase.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModelBase.kt
@@ -17,6 +17,7 @@ import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.withTimeout
 import kotlinx.coroutines.flow.Flow
@@ -69,7 +70,7 @@ open class TestFavoriteAppsViewModelBase {
         coEvery { fetchUseCase.invoke() } returns fetchFlow
 
         val observeFavoritesUseCase = ObserveFavoritesUseCase(favoritesRepository)
-        val toggleFavoriteUseCase = ToggleFavoriteUseCase(favoritesRepository)
+        val toggleFavoriteUseCase = ToggleFavoriteUseCase(favoritesRepository, dispatcher = Dispatchers.IO)
 
         viewModel = FavoriteAppsViewModel(
             fetchDeveloperAppsUseCase = fetchUseCase,


### PR DESCRIPTION
## Summary
- Remove hardcoded Dispatchers.IO from FavoritesRepositoryImpl to let callers choose coroutine context
- Ensure ToggleFavoriteUseCase runs on a supplied dispatcher and wire it through DI and tests

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac0f0aa550832d98baea6d3e3facc6