### PR TITLE
Fix flakiness in IssueReporterViewModel test

### DIFF
--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/TestIssueReporterViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/TestIssueReporterViewModel.kt
@@ -471,7 +471,12 @@ class TestIssueReporterViewModel : TestIssueReporterViewModelBase() {
             awaitItem()
             viewModel.onEvent(IssueReporterEvent.UpdateTitle("Bug"))
             viewModel.onEvent(IssueReporterEvent.UpdateDescription("Desc"))
-            skipItems(2)
+
+            // Wait until both title and description updates are reflected in the state
+            var updated = awaitItem()
+            while (updated.data?.description != "Desc") {
+                updated = awaitItem()
+            }
 
             viewModel.onEvent(IssueReporterEvent.Send(context))
 


### PR DESCRIPTION
## Summary
- Handle state updates deterministically in `send report when package manager throws` test to avoid Turbine timeouts

## Testing
- `./gradlew apptoolkit:testDebugUnitTest --tests "*send report when package manager throws*"` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac12ed5d40832d88490346bb165bc7