### PR TITLE
Persist changelog dialog visibility

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/components/navigation/NavigationDrawer.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/components/navigation/NavigationDrawer.kt
@@ -9,8 +9,8 @@ import androidx.compose.material3.rememberDrawerState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -34,7 +34,7 @@ fun NavigationDrawer(screenState : UiStateScreen<UiMainScreen>) {
     val context : Context = LocalContext.current
     val changelogUrl: String = koinInject(qualifier = named("github_changelog"))
     val buildInfoProvider: BuildInfoProvider = koinInject()
-    var showChangelog by remember { mutableStateOf(false) }
+    var showChangelog by rememberSaveable { mutableStateOf(false) }
     val uiState : UiMainScreen = screenState.data ?: UiMainScreen()
 
     ModalNavigationDrawer(


### PR DESCRIPTION
## Summary
- preserve changelog dialog visibility across process death using `rememberSaveable`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac14e29fcc832d9af6cc99d05fa729