### PR TITLE
Use ToggleFavoriteUseCase in AppsListViewModel

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppModule.kt
@@ -50,7 +50,8 @@ val appModule : Module = module {
     viewModel {
         AppsListViewModel(
             fetchDeveloperAppsUseCase = get(),
-            dataStore = get()
+            observeFavoritesUseCase = get(),
+            toggleFavoriteUseCase = get()
         )
     }
     viewModel {


### PR DESCRIPTION
## Summary
- replace direct DataStore favorite toggling with ToggleFavoriteUseCase
- wire AppsListViewModel through Koin with favorite use cases
- adjust AppsListViewModel tests for new use case dependencies

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac14c213e8832dad045d266520ebe5