### PR TITLE
fix: use state flow in support viewmodel test

### DIFF
--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/TestIssueReporterViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/TestIssueReporterViewModel.kt
@@ -264,12 +264,19 @@ class TestIssueReporterViewModel : TestIssueReporterViewModelBase() {
             awaitItem()
             viewModel.onEvent(IssueReporterEvent.UpdateTitle("Bug"))
             viewModel.onEvent(IssueReporterEvent.UpdateDescription("Desc"))
-            skipItems(2)
+
+            var updated = awaitItem()
+            while (updated.data?.description != "Desc") {
+                updated = awaitItem()
+            }
+
             viewModel.onEvent(IssueReporterEvent.Send(context))
 
-            awaitItem()
+            var state = awaitItem() // loading
             dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
-            val state = awaitItem()
+            while (state.screenState is ScreenState.IsLoading) {
+                state = awaitItem()
+            }
             val snackbar = state.snackbar!!
             assertThat(snackbar.isError).isTrue()
             val msg = snackbar.message as UiTextHelper.StringResource

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/TestIssueReporterViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/TestIssueReporterViewModel.kt
@@ -472,7 +472,6 @@ class TestIssueReporterViewModel : TestIssueReporterViewModelBase() {
             viewModel.onEvent(IssueReporterEvent.UpdateTitle("Bug"))
             viewModel.onEvent(IssueReporterEvent.UpdateDescription("Desc"))
 
-            // Wait until both title and description updates are reflected in the state
             var updated = awaitItem()
             while (updated.data?.description != "Desc") {
                 updated = awaitItem()
@@ -480,11 +479,11 @@ class TestIssueReporterViewModel : TestIssueReporterViewModelBase() {
 
             viewModel.onEvent(IssueReporterEvent.Send(context))
 
-            awaitItem() // loading
+            var state = awaitItem() // loading
             dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
-            // Skip intermediate emissions for data and snackbar updates
-            skipItems(2)
-            val state = awaitItem()
+            while (state.screenState is ScreenState.IsLoading) {
+                state = awaitItem()
+            }
             assertThat(state.screenState).isInstanceOf(ScreenState.Success::class.java)
             assertThat(state.data?.issueUrl).isEqualTo("https://ex.com/1")
             cancelAndIgnoreRemainingEvents()

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportViewModelTest.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportViewModelTest.kt
@@ -14,6 +14,7 @@ import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
@@ -26,7 +27,7 @@ class SupportViewModelTest {
         val dispatcherExtension = UnconfinedDispatcherExtension()
     }
 
-    private val productDetailsFlow = MutableSharedFlow<Map<String, ProductDetails>>(replay = 1)
+    private val productDetailsFlow = MutableStateFlow<Map<String, ProductDetails>>(emptyMap())
     private val purchaseResultFlow = MutableSharedFlow<PurchaseResult>()
     private val billingRepository = mockk<BillingRepository>(relaxed = true) {
         every { productDetails } returns productDetailsFlow
@@ -36,7 +37,7 @@ class SupportViewModelTest {
     }
 
     private fun createViewModel(): SupportViewModel {
-        productDetailsFlow.resetReplayCache()
+        productDetailsFlow.value = emptyMap()
         return SupportViewModel(billingRepository)
     }
 

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportViewModelTest.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportViewModelTest.kt
@@ -49,10 +49,12 @@ class SupportViewModelTest {
 
         viewModel.uiState.test {
             awaitItem() // initial state
-            productDetailsFlow.emit(linkedMapOf("a" to p1, "b" to p2))
+            productDetailsFlow.value = linkedMapOf("a" to p1, "b" to p2)
             dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
-            val state = awaitItem()
-            assertThat(state.screenState).isInstanceOf(ScreenState.Success::class.java)
+            var state = awaitItem()
+            while (state.screenState !is ScreenState.Success) {
+                state = awaitItem()
+            }
             assertThat(state.data!!.products).containsExactly(p1, p2)
         }
     }


### PR DESCRIPTION
## Summary
- fix SupportViewModel test to use `MutableStateFlow` for product details

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1ac5ca60832dbbad952113ab2f7a