### PR TITLE
Dispatch AdView lifecycle to main thread

### DIFF
--- a/apptoolkit/src/androidTest/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdViewPoolInstrumentationTest.kt
+++ b/apptoolkit/src/androidTest/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdViewPoolInstrumentationTest.kt
@@ -1,0 +1,44 @@
+package com.d4rk.android.libs.apptoolkit.core.ui.components.ads
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.google.android.gms.ads.AdSize
+import com.google.android.gms.ads.AdView
+import kotlin.collections.ArrayDeque
+import org.junit.Test
+import org.junit.runner.RunWith
+import com.google.common.truth.Truth.assertThat
+
+@RunWith(AndroidJUnit4::class)
+class AdViewPoolInstrumentationTest {
+
+    @Test
+    fun cleanup_destroys_expired_views_on_main_thread() {
+        val context = InstrumentationRegistry.getInstrumentation().targetContext
+        val adView = AdView(context)
+        adView.adUnitId = "unit"
+        adView.setAdSize(AdSize.BANNER)
+
+        // Release to pool from background thread
+        AdViewPool.release("unit", AdSize.BANNER, adView)
+
+        val poolField = AdViewPool::class.java.getDeclaredField("pool").apply { isAccessible = true }
+        @Suppress("UNCHECKED_CAST")
+        val pool = poolField.get(AdViewPool) as MutableMap<Pair<String, AdSize>, ArrayDeque<*>>
+        val key = "unit" to AdSize.BANNER
+        val deque = pool[key] ?: ArrayDeque()
+        if (deque.isNotEmpty()) {
+            val pooled = deque.first()
+            val lastUsedField = pooled::class.java.getDeclaredField("lastUsed").apply { isAccessible = true }
+            lastUsedField.setLong(pooled, System.currentTimeMillis() - (5 * 60 * 1000L) - 1000)
+        }
+
+        val cleanupMethod = AdViewPool::class.java.getDeclaredMethod("cleanup").apply { isAccessible = true }
+        cleanupMethod.invoke(AdViewPool)
+        InstrumentationRegistry.getInstrumentation().waitForIdleSync()
+
+        assertThat(deque.isEmpty()).isTrue()
+        pool.clear()
+    }
+}
+

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdViewPool.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdViewPool.kt
@@ -5,10 +5,11 @@ import com.google.android.gms.ads.AdRequest
 import com.google.android.gms.ads.AdSize
 import com.google.android.gms.ads.AdView
 import kotlin.collections.ArrayDeque
-import kotlin.concurrent.fixedRateTimer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.isActive
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -20,10 +21,14 @@ private data class PooledAdView(val view: AdView, var lastUsed: Long)
 object AdViewPool {
     private val pool: MutableMap<Pair<String, AdSize>, ArrayDeque<PooledAdView>> = mutableMapOf()
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val mainScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
 
     init {
-        fixedRateTimer("AdViewPoolCleanup", daemon = true, initialDelay = TIMEOUT_MS, period = TIMEOUT_MS) {
-            cleanup()
+        mainScope.launch {
+            while (isActive) {
+                delay(TIMEOUT_MS)
+                cleanup()
+            }
         }
     }
 
@@ -52,7 +57,7 @@ object AdViewPool {
                         if (deque.size < MAX_POOL_SIZE) {
                             deque.add(PooledAdView(view, System.currentTimeMillis()))
                         } else {
-                            view.destroy()
+                            view.post { view.destroy() }
                         }
                     }
                 }
@@ -70,7 +75,7 @@ object AdViewPool {
                 val pooled = iterator.next()
                 if (pooled.view.responseInfo != null) {
                     iterator.remove()
-                    pooled.view.resume()
+                    pooled.view.post { pooled.view.resume() }
                     return pooled.view
                 }
             }
@@ -91,9 +96,9 @@ object AdViewPool {
         val key = adUnitId to adSize
         val deque = pool.getOrPut(key) { ArrayDeque() }
         if (deque.size >= MAX_POOL_SIZE) {
-            adView.destroy()
+            adView.post { adView.destroy() }
         } else {
-            adView.pause()
+            adView.post { adView.pause() }
             deque.add(PooledAdView(adView, System.currentTimeMillis()))
         }
     }
@@ -109,7 +114,7 @@ object AdViewPool {
             while (viewIterator.hasNext()) {
                 val pooled = viewIterator.next()
                 if (now - pooled.lastUsed > TIMEOUT_MS) {
-                    pooled.view.destroy()
+                    pooled.view.post { pooled.view.destroy() }
                     viewIterator.remove()
                 }
             }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdViewPoolTest.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdViewPoolTest.kt
@@ -6,7 +6,9 @@ import com.google.android.gms.ads.AdSize
 import com.google.android.gms.ads.AdView
 import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.UnconfinedDispatcherExtension
 import io.mockk.Runs
+import io.mockk.anyConstructed
 import io.mockk.every
+import io.mockk.just
 import io.mockk.mockk
 import io.mockk.mockkConstructor
 import io.mockk.unmockkConstructor

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdViewPoolTest.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdViewPoolTest.kt
@@ -1,0 +1,54 @@
+package com.d4rk.android.libs.apptoolkit.core.ui.components.ads
+
+import android.content.Context
+import com.google.android.gms.ads.AdRequest
+import com.google.android.gms.ads.AdSize
+import com.google.android.gms.ads.AdView
+import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.UnconfinedDispatcherExtension
+import io.mockk.anyConstructed
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.unmockkConstructor
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.runBlocking
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.junit.jupiter.api.assertDoesNotThrow
+
+@ExtendWith(UnconfinedDispatcherExtension::class)
+class AdViewPoolTest {
+
+    @AfterEach
+    fun teardown() {
+        unmockkConstructor(AdView::class)
+        val field = AdViewPool::class.java.getDeclaredField("pool")
+        field.isAccessible = true
+        @Suppress("UNCHECKED_CAST")
+        (field.get(AdViewPool) as MutableMap<*, *>).clear()
+    }
+
+    @Test
+    fun `preload does not throw when exceeding pool size`() = runBlocking {
+        mockkConstructor(AdView::class)
+        val context = mockk<Context>(relaxed = true)
+        every { context.applicationContext } returns context
+        every { anyConstructed<AdView>().adUnitId = any() } justRun {}
+        every { anyConstructed<AdView>().setAdSize(any()) } justRun {}
+        every { anyConstructed<AdView>().loadAd(any()) } justRun {}
+        every { anyConstructed<AdView>().destroy() } justRun {}
+        every { anyConstructed<AdView>().post(any()) } answers {
+            firstArg<Runnable>().run()
+            true
+        }
+        val adRequest = mockk<AdRequest>()
+
+        assertDoesNotThrow {
+            AdViewPool.preload(context, "unit", AdSize.BANNER, adRequest, 4)
+        }
+        delay(50)
+    }
+}
+

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdViewPoolTest.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdViewPoolTest.kt
@@ -1,17 +1,12 @@
 package com.d4rk.android.libs.apptoolkit.core.ui.components.ads
 
 import android.content.Context
+import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.UnconfinedDispatcherExtension
 import com.google.android.gms.ads.AdRequest
 import com.google.android.gms.ads.AdSize
 import com.google.android.gms.ads.AdView
-import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.UnconfinedDispatcherExtension
-import io.mockk.Runs
-import io.mockk.anyConstructed
 import io.mockk.every
-import io.mockk.just
 import io.mockk.mockk
-import io.mockk.mockkConstructor
-import io.mockk.unmockkConstructor
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.runBlocking
 import org.junit.jupiter.api.AfterEach
@@ -22,9 +17,11 @@ import org.junit.jupiter.api.assertDoesNotThrow
 @ExtendWith(UnconfinedDispatcherExtension::class)
 class AdViewPoolTest {
 
+    private val defaultFactory = AdViewPool.viewFactory
+
     @AfterEach
     fun teardown() {
-        unmockkConstructor(AdView::class)
+        AdViewPool.viewFactory = defaultFactory
         val field = AdViewPool::class.java.getDeclaredField("pool")
         field.isAccessible = true
         @Suppress("UNCHECKED_CAST")
@@ -33,17 +30,13 @@ class AdViewPoolTest {
 
     @Test
     fun `preload does not throw when exceeding pool size`() = runBlocking {
-        mockkConstructor(AdView::class)
         val context = mockk<Context>(relaxed = true)
-        every { context.applicationContext } returns context
-        every { anyConstructed<AdView>().adUnitId = any() } just Runs
-        every { anyConstructed<AdView>().setAdSize(any()) } just Runs
-        every { anyConstructed<AdView>().loadAd(any()) } just Runs
-        every { anyConstructed<AdView>().destroy() } just Runs
-        every { anyConstructed<AdView>().post(any()) } answers {
+        val adView = mockk<AdView>(relaxed = true)
+        every { adView.post(any()) } answers {
             firstArg<Runnable>().run()
             true
         }
+        AdViewPool.viewFactory = { _, _, _ -> adView }
         val adRequest = mockk<AdRequest>()
 
         assertDoesNotThrow {
@@ -52,4 +45,3 @@ class AdViewPoolTest {
         delay(50)
     }
 }
-

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdViewPoolTest.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdViewPoolTest.kt
@@ -5,9 +5,8 @@ import com.google.android.gms.ads.AdRequest
 import com.google.android.gms.ads.AdSize
 import com.google.android.gms.ads.AdView
 import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.UnconfinedDispatcherExtension
-import io.mockk.anyConstructed
+import io.mockk.Runs
 import io.mockk.every
-import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.mockkConstructor
 import io.mockk.unmockkConstructor
@@ -35,10 +34,10 @@ class AdViewPoolTest {
         mockkConstructor(AdView::class)
         val context = mockk<Context>(relaxed = true)
         every { context.applicationContext } returns context
-        every { anyConstructed<AdView>().adUnitId = any() } justRun {}
-        every { anyConstructed<AdView>().setAdSize(any()) } justRun {}
-        every { anyConstructed<AdView>().loadAd(any()) } justRun {}
-        every { anyConstructed<AdView>().destroy() } justRun {}
+        every { anyConstructed<AdView>().adUnitId = any() } just Runs
+        every { anyConstructed<AdView>().setAdSize(any()) } just Runs
+        every { anyConstructed<AdView>().loadAd(any()) } just Runs
+        every { anyConstructed<AdView>().destroy() } just Runs
         every { anyConstructed<AdView>().post(any()) } answers {
             firstArg<Runnable>().run()
             true


### PR DESCRIPTION
## Summary
- Replace timer-based `AdViewPool` cleanup with a coroutine loop on `Dispatchers.Main`.
- Post `destroy`, `pause`, and `resume` calls to the main thread across `preload`, `acquire`, `release`, and `cleanup`.
- Add unit and instrumentation tests for pool preload limits and cleanup.

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew connectedAndroidTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acc45de70c832d8f88ae8e817f922c