### PR TITLE
Remove explicit IO dispatcher from app view models

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListViewModel.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListViewModel.kt
@@ -12,34 +12,31 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.RootError
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiSnackbar
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.showSnackbar
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.updateData
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.updateState
-import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.showSnackbar
-import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiSnackbar
-import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
-import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.ScreenMessageType
 import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
-import kotlinx.coroutines.CoroutineDispatcher
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.ScreenMessageType
+import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
 import kotlinx.coroutines.CoroutineStart
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 class AppsListViewModel(
     private val fetchDeveloperAppsUseCase : FetchDeveloperAppsUseCase,
     private val observeFavoritesUseCase: ObserveFavoritesUseCase,
     private val toggleFavoriteUseCase: ToggleFavoriteUseCase,
-    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
-) : ScreenViewModel<UiHomeScreen , HomeEvent , HomeAction>(initialState = UiStateScreen(screenState = ScreenState.IsLoading() , data = UiHomeScreen())) {
+) : ScreenViewModel<UiHomeScreen , HomeEvent , HomeAction>(
+    initialState = UiStateScreen(screenState = ScreenState.IsLoading() , data = UiHomeScreen())
+) {
 
     private val _favorites = MutableStateFlow<Set<String>>(emptySet())
     private val favoritesLoaded = MutableStateFlow(false)
@@ -51,7 +48,7 @@ class AppsListViewModel(
     )
 
     init {
-        viewModelScope.launch(context = ioDispatcher, start = CoroutineStart.UNDISPATCHED) {
+        viewModelScope.launch(start = CoroutineStart.UNDISPATCHED) {
             runCatching {
                 observeFavoritesUseCase()
                     .onEach {
@@ -62,7 +59,7 @@ class AppsListViewModel(
             }
         }
 
-        viewModelScope.launch(context = ioDispatcher, start = CoroutineStart.UNDISPATCHED) {
+        viewModelScope.launch(start = CoroutineStart.UNDISPATCHED) {
             favoritesLoaded.filter { it }.first()
             onEvent(HomeEvent.FetchApps)
         }
@@ -75,42 +72,39 @@ class AppsListViewModel(
     }
 
     private fun fetchDeveloperApps() {
-        viewModelScope.launch(context = ioDispatcher) {
-            fetchDeveloperAppsUseCase().flowOn(ioDispatcher).collect { result : DataState<List<AppInfo> , RootError> ->
+        viewModelScope.launch {
+            fetchDeveloperAppsUseCase().collect { result: DataState<List<AppInfo>, RootError> ->
                 when (result) {
                     is DataState.Success -> {
                         val apps = result.data
-                        withContext(Dispatchers.Main) {
-                            if (apps.isEmpty()) {
-                                screenState.update { currentState ->
-                                    currentState.copy(screenState = ScreenState.NoData(), data = currentState.data?.copy(apps = emptyList()))
-                                }
-                            } else {
-                                screenState.updateData(newState = ScreenState.Success()) { currentData ->
-                                    currentData.copy(apps = apps)
-                                }
+                        if (apps.isEmpty()) {
+                            screenState.update { currentState ->
+                                currentState.copy(
+                                    screenState = ScreenState.NoData(),
+                                    data = currentState.data?.copy(apps = emptyList()),
+                                )
+                            }
+                        } else {
+                            screenState.updateData(newState = ScreenState.Success()) { currentData ->
+                                currentData.copy(apps = apps)
                             }
                         }
                     }
 
                     is DataState.Error -> {
-                        withContext(Dispatchers.Main) {
-                            screenState.updateState(ScreenState.Error())
-                            screenState.showSnackbar(
-                                UiSnackbar(
-                                    message = UiTextHelper.DynamicString("Failed to load apps"),
-                                    isError = true,
-                                    timeStamp = System.currentTimeMillis(),
-                                    type = ScreenMessageType.SNACKBAR
-                                )
+                        screenState.updateState(ScreenState.Error())
+                        screenState.showSnackbar(
+                            UiSnackbar(
+                                message = UiTextHelper.DynamicString("Failed to load apps"),
+                                isError = true,
+                                timeStamp = System.currentTimeMillis(),
+                                type = ScreenMessageType.SNACKBAR,
                             )
-                        }
+                        )
                     }
 
                     is DataState.Loading -> {
-                        withContext(Dispatchers.Main) {
-                            screenState.updateState(ScreenState.IsLoading())
-                        }
+                        screenState.updateState(ScreenState.IsLoading())
                     }
                 }
             }
@@ -118,15 +112,13 @@ class AppsListViewModel(
     }
 
     fun toggleFavorite(packageName: String) {
-        viewModelScope.launch(context = ioDispatcher) {
+        viewModelScope.launch {
             runCatching {
                 toggleFavoriteUseCase(packageName)
             }.onFailure { error ->
                 error.printStackTrace()
-                withContext(Dispatchers.Main) {
-                    screenState.update { currentState ->
-                        currentState.copy(screenState = ScreenState.Error())
-                    }
+                screenState.update { currentState ->
+                    currentState.copy(screenState = ScreenState.Error())
                 }
             }
         }

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModelBase.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModelBase.kt
@@ -76,7 +76,6 @@ open class TestFavoriteAppsViewModelBase {
             fetchDeveloperAppsUseCase = fetchUseCase,
             observeFavoritesUseCase = observeFavoritesUseCase,
             toggleFavoriteUseCase = toggleFavoriteUseCase,
-            ioDispatcher = dispatcher
         )
         println("\u2705 [SETUP] ViewModel initialized")
     }

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModelBase.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModelBase.kt
@@ -71,7 +71,7 @@ open class TestAppsListViewModelBase {
         val observeFavoritesUseCase = ObserveFavoritesUseCase(favoritesRepository)
         val toggleFavoriteUseCase = ToggleFavoriteUseCase(favoritesRepository, dispatcher)
 
-        viewModel = AppsListViewModel(fetchUseCase, observeFavoritesUseCase, toggleFavoriteUseCase, dispatcher)
+        viewModel = AppsListViewModel(fetchUseCase, observeFavoritesUseCase, toggleFavoriteUseCase)
         println("\u2705 [SETUP] ViewModel initialized")
     }
 


### PR DESCRIPTION
## Summary
- Launch app list and favorite view model work on the main dispatcher
- Rely on use cases for threading and drop `ioDispatcher` wiring
- Update tests for new view model signatures

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad7bae4ff4832d8a2742aa34c22afc