### PR TITLE
Use collectAsStateWithLifecycle for lifecycle-aware state

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -147,6 +147,7 @@ android {
 
 dependencies {
     implementation(dependencyNotation = project(path = ":apptoolkit"))
+    implementation(dependencyNotation = libs.androidx.lifecycle.runtime.compose)
 
     // Unit Tests
     testImplementation(dependencyNotation = libs.bundles.unitTest)

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsScreen.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsScreen.kt
@@ -4,7 +4,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Android
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import com.d4rk.android.apps.apptoolkit.R
 import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.actions.FavoriteAppsEvent
@@ -19,7 +19,7 @@ import org.koin.compose.viewmodel.koinViewModel
 @Composable
 fun FavoriteAppsScreen(paddingValues: PaddingValues) {
     val viewModel: FavoriteAppsViewModel = koinViewModel()
-    val screenState: UiStateScreen<UiHomeScreen> by viewModel.uiState.collectAsState()
+    val screenState: UiStateScreen<UiHomeScreen> by viewModel.uiState.collectAsStateWithLifecycle()
 
     ScreenStateHandler(
         screenState = screenState,
@@ -31,7 +31,7 @@ fun FavoriteAppsScreen(paddingValues: PaddingValues) {
             )
         },
         onSuccess = { uiHomeScreen ->
-            val favorites by viewModel.favorites.collectAsState()
+            val favorites by viewModel.favorites.collectAsStateWithLifecycle()
             AppsList(
                 uiHomeScreen = uiHomeScreen,
                 favorites = favorites,

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListScreen.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListScreen.kt
@@ -2,7 +2,7 @@ package com.d4rk.android.apps.apptoolkit.app.apps.list.ui
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.actions.HomeEvent
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.ui.UiHomeScreen
@@ -16,8 +16,8 @@ import org.koin.compose.viewmodel.koinViewModel
 @Composable
 fun AppsListScreen(paddingValues: PaddingValues) {
     val viewModel: AppsListViewModel = koinViewModel()
-    val screenState: UiStateScreen<UiHomeScreen> by viewModel.uiState.collectAsState()
-    val favorites by viewModel.favorites.collectAsState()
+    val screenState: UiStateScreen<UiHomeScreen> by viewModel.uiState.collectAsStateWithLifecycle()
+    val favorites by viewModel.favorites.collectAsStateWithLifecycle()
 
     ScreenStateHandler(
         screenState = screenState, onLoading = {

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/AppsList.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/AppsList.kt
@@ -11,7 +11,7 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.snapshots.SnapshotStateList
@@ -48,7 +48,7 @@ fun AppsList(
     val listState: LazyGridState = rememberLazyGridState()
     val adFrequency = 4
     val dataStore: DataStore = remember { koin.get() }
-    val adsEnabled: Boolean by remember { dataStore.ads(default = true) }.collectAsState(initial = true)
+    val adsEnabled: Boolean by remember { dataStore.ads(default = true) }.collectAsStateWithLifecycle(initialValue = true)
     val items: List<AppListItem> = remember(key1 = apps, key2 = adsEnabled) {
         buildList {
             apps.forEachIndexed { index: Int, appInfo: AppInfo ->

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainScreen.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainScreen.kt
@@ -19,7 +19,7 @@ import androidx.compose.material3.TopAppBarScrollBehavior
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -60,7 +60,7 @@ import org.koin.core.qualifier.named
 @Composable
 fun MainScreen() {
     val viewModel: MainViewModel = koinViewModel()
-    val screenState: UiStateScreen<UiMainScreen> by viewModel.uiState.collectAsState()
+    val screenState: UiStateScreen<UiMainScreen> by viewModel.uiState.collectAsStateWithLifecycle()
     val context: Context = LocalContext.current
     val isTabletOrLandscape: Boolean = ScreenHelper.isLandscapeOrTablet(context = context)
 
@@ -132,7 +132,7 @@ fun MainScaffoldTabletContent() {
     var showChangelog by rememberSaveable { mutableStateOf(false) }
 
     val viewModel: MainViewModel = koinViewModel()
-    val screenState: UiStateScreen<UiMainScreen> by viewModel.uiState.collectAsState()
+    val screenState: UiStateScreen<UiMainScreen> by viewModel.uiState.collectAsStateWithLifecycle()
     val uiState: UiMainScreen = screenState.data ?: UiMainScreen()
     val navController: NavHostController = rememberNavController()
 

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/components/navigation/AppNavigationHost.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/components/navigation/AppNavigationHost.kt
@@ -5,7 +5,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.material3.DrawerState
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
@@ -27,7 +27,7 @@ fun AppNavigationHost(
     navController : NavHostController , snackbarHostState : SnackbarHostState , onFabVisibilityChanged : (Boolean) -> Unit , paddingValues : PaddingValues
 ) {
     val dataStore : DataStore = koinInject()
-    val startupRoute by dataStore.getStartupPage(default = NavigationRoutes.ROUTE_APPS_LIST).collectAsState(initial = NavigationRoutes.ROUTE_APPS_LIST)
+    val startupRoute by dataStore.getStartupPage(default = NavigationRoutes.ROUTE_APPS_LIST).collectAsStateWithLifecycle(initialValue = NavigationRoutes.ROUTE_APPS_LIST)
 
     NavigationHost(
         navController = navController , startDestination = startupRoute.ifBlank { NavigationRoutes.ROUTE_APPS_LIST }

--- a/apptoolkit/build.gradle.kts
+++ b/apptoolkit/build.gradle.kts
@@ -132,7 +132,7 @@ dependencies {
     api(dependencyNotation = libs.androidx.lifecycle.process)
     api(dependencyNotation = libs.androidx.lifecycle.viewmodel.ktx)
     api(dependencyNotation = libs.androidx.lifecycle.viewmodel.compose)
-    api(dependencyNotation = libs.androidx.lifecycle.runtime.compose)
+    implementation(dependencyNotation = libs.androidx.lifecycle.runtime.compose)
 
     // About
     api(dependencyNotation = libs.aboutlibraries.compose.m3)

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/ui/AboutSettingsList.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/ui/AboutSettingsList.kt
@@ -9,7 +9,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -36,7 +36,7 @@ import org.koin.compose.viewmodel.koinViewModel
 fun AboutSettingsList(paddingValues : PaddingValues = PaddingValues() , deviceProvider : AboutSettingsProvider , configProvider : BuildInfoProvider , snackbarHostState : SnackbarHostState) {
     val context : Context = LocalContext.current
     val viewModel : AboutViewModel = koinViewModel()
-    val screenState : UiStateScreen<UiAboutScreen> by viewModel.uiState.collectAsState()
+    val screenState : UiStateScreen<UiAboutScreen> by viewModel.uiState.collectAsStateWithLifecycle()
     val deviceInfo : String = stringResource(id = R.string.device_info)
     LazyColumn(modifier = Modifier.fillMaxHeight() , contentPadding = paddingValues) {
         item {

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/ui/UsageAndDiagnosticsList.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/ui/UsageAndDiagnosticsList.kt
@@ -17,7 +17,7 @@ import androidx.compose.material.icons.outlined.Campaign
 import androidx.compose.material.icons.outlined.Storage
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -49,16 +49,16 @@ fun UsageAndDiagnosticsList(paddingValues: PaddingValues, configProvider: BuildI
     val coroutineScope: CoroutineScope = rememberCoroutineScope()
     val switchState: State<Boolean> =
         dataStore.usageAndDiagnostics(default = !configProvider.isDebugBuild)
-            .collectAsState(initial = !configProvider.isDebugBuild)
+            .collectAsStateWithLifecycle(initialValue = !configProvider.isDebugBuild)
 
     val analyticsState: State<Boolean> = dataStore.analyticsConsent(default = !configProvider.isDebugBuild)
-        .collectAsState(initial = !configProvider.isDebugBuild)
+        .collectAsStateWithLifecycle(initialValue = !configProvider.isDebugBuild)
     val adStorageState: State<Boolean> = dataStore.adStorageConsent(default = !configProvider.isDebugBuild)
-        .collectAsState(initial = !configProvider.isDebugBuild)
+        .collectAsStateWithLifecycle(initialValue = !configProvider.isDebugBuild)
     val adUserDataState: State<Boolean> = dataStore.adUserDataConsent(default = !configProvider.isDebugBuild)
-        .collectAsState(initial = !configProvider.isDebugBuild)
+        .collectAsStateWithLifecycle(initialValue = !configProvider.isDebugBuild)
     val adPersonalizationState: State<Boolean> = dataStore.adPersonalizationConsent(default = !configProvider.isDebugBuild)
-        .collectAsState(initial = !configProvider.isDebugBuild)
+        .collectAsStateWithLifecycle(initialValue = !configProvider.isDebugBuild)
 
 
     var advancedSettingsExpanded: Boolean by remember { mutableStateOf(value = false) }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/display/DisplaySettingsList.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/display/DisplaySettingsList.kt
@@ -15,7 +15,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -49,7 +49,7 @@ fun DisplaySettingsList(paddingValues : PaddingValues = PaddingValues() , provid
     var showLanguageDialog : Boolean by remember { mutableStateOf(value = false) }
     var showStartupDialog : Boolean by remember { mutableStateOf(value = false) }
 
-    val currentThemeModeKey : String by dataStore.themeMode.collectAsState(initial = DataStoreNamesConstants.THEME_MODE_FOLLOW_SYSTEM)
+    val currentThemeModeKey : String by dataStore.themeMode.collectAsStateWithLifecycle(initialValue = DataStoreNamesConstants.THEME_MODE_FOLLOW_SYSTEM)
     val isSystemDarkTheme : Boolean = isSystemInDarkTheme()
 
     val isDarkThemeActive : Boolean = when (currentThemeModeKey) {
@@ -67,9 +67,9 @@ fun DisplaySettingsList(paddingValues : PaddingValues = PaddingValues() , provid
             stringResource(id = R.string.will_turn_on_automatically_by_system)
     }
 
-    val isDynamicColors : State<Boolean> = dataStore.dynamicColors.collectAsState(initial = true)
-    val bouncyButtons : Boolean by dataStore.bouncyButtons.collectAsState(initial = true)
-    val showLabelsOnBottomBar : Boolean by dataStore.getShowBottomBarLabels().collectAsState(initial = true)
+    val isDynamicColors : State<Boolean> = dataStore.dynamicColors.collectAsStateWithLifecycle(initialValue = true)
+    val bouncyButtons : Boolean by dataStore.bouncyButtons.collectAsStateWithLifecycle(initialValue = true)
+    val showLabelsOnBottomBar : Boolean by dataStore.getShowBottomBarLabels().collectAsStateWithLifecycle(initialValue = true)
 
     LazyColumn(contentPadding = paddingValues , modifier = Modifier.fillMaxHeight()) {
         item {

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/display/components/dialogs/SelectStartupScreenAlertDialog.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/display/components/dialogs/SelectStartupScreenAlertDialog.kt
@@ -10,7 +10,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -33,7 +33,7 @@ fun SelectStartupScreenAlertDialog(onDismiss: () -> Unit, onStartupSelected: (St
     val selectedPage = remember { mutableStateOf("") }
     val entries: List<String> = koinInject(qualifier = named("startup_entries"))
     val values: List<String> = koinInject(qualifier = named("startup_values"))
-    val startupRoute by dataStore.getStartupPage(default = values.first()).collectAsState(initial = values.first())
+    val startupRoute by dataStore.getStartupPage(default = values.first()).collectAsStateWithLifecycle(initialValue = values.first())
 
     LaunchedEffect(startupRoute) {
         selectedPage.value = startupRoute

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/IssueReporterScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/IssueReporterScreen.kt
@@ -40,7 +40,7 @@ import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.produceState
@@ -88,7 +88,7 @@ fun IssueReporterScreen(activity: Activity) {
     val isFabExtended: MutableState<Boolean> = remember { mutableStateOf(value = true) }
     val viewModel: IssueReporterViewModel = koinViewModel()
     val snackBarHostState: SnackbarHostState = remember { SnackbarHostState() }
-    val uiStateScreen: UiStateScreen<UiIssueReporterScreen> by viewModel.uiState.collectAsState()
+    val uiStateScreen: UiStateScreen<UiIssueReporterScreen> by viewModel.uiState.collectAsStateWithLifecycle()
     val target: GithubTarget = koinInject()
 
     LaunchedEffect(key1 = scrollBehavior.state.contentOffset) {

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/main/ui/components/navigation/BottomNavigationBar.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/main/ui/components/navigation/BottomNavigationBar.kt
@@ -10,7 +10,7 @@ import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.NavigationBarItem
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.key
 import androidx.compose.ui.Modifier
@@ -46,7 +46,7 @@ fun BottomNavigationBar(
     val adsConfig: AdsConfig = koinInject(qualifier = named("full_banner"))
 
     val showLabels: Boolean =
-        dataStore.getShowBottomBarLabels().collectAsState(initial = true).value
+        dataStore.getShowBottomBarLabels().collectAsStateWithLifecycle(initialValue = true).value
 
     Column(modifier = modifier) {
         key("bottom_ad") {

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/components/pages/CrashlyticsOnboardingPageTab.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/components/pages/CrashlyticsOnboardingPageTab.kt
@@ -38,7 +38,7 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -85,7 +85,7 @@ fun CrashlyticsOnboardingPageTab(configProvider: BuildInfoProvider = koinInject(
     val coroutineScope: CoroutineScope = rememberCoroutineScope()
     val switchState: State<Boolean> =
         dataStore.usageAndDiagnostics(default = !configProvider.isDebugBuild)
-            .collectAsState(initial = !configProvider.isDebugBuild)
+            .collectAsStateWithLifecycle(initialValue = !configProvider.isDebugBuild)
     val showCrashlyticsDialog = CrashlyticsOnboardingStateManager.showCrashlyticsDialog
 
     Column(
@@ -266,16 +266,16 @@ fun CrashlyticsConsentDialog(
 
     val analyticsState: State<Boolean> =
         dataStore.analyticsConsent(default = initialConsentValue)
-            .collectAsState(initial = initialConsentValue)
+            .collectAsStateWithLifecycle(initialValue = initialConsentValue)
     val adStorageState: State<Boolean> =
         dataStore.adStorageConsent(default = initialConsentValue)
-            .collectAsState(initial = initialConsentValue)
+            .collectAsStateWithLifecycle(initialValue = initialConsentValue)
     val adUserDataState: State<Boolean> =
         dataStore.adUserDataConsent(default = initialConsentValue)
-            .collectAsState(initial = initialConsentValue)
+            .collectAsStateWithLifecycle(initialValue = initialConsentValue)
     val adPersonalizationState: State<Boolean> =
         dataStore.adPersonalizationConsent(default = initialConsentValue)
-            .collectAsState(initial = initialConsentValue)
+            .collectAsStateWithLifecycle(initialValue = initialConsentValue)
 
     fun updateConsentState(type: String, value: Boolean) {
         coroutineScope.launch {

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/components/pages/ThemeOnboardingPageTab.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/components/pages/ThemeOnboardingPageTab.kt
@@ -15,7 +15,7 @@ import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
@@ -44,8 +44,8 @@ fun ThemeOnboardingPageTab() {
     val dataStore: CommonDataStore = CommonDataStore.getInstance(context = context)
 
     val defaultThemeModeName: String = stringResource(id = R.string.follow_system)
-    val currentThemeMode: String by dataStore.themeMode.collectAsState(initial = defaultThemeModeName)
-    val isAmoledMode: Boolean by dataStore.amoledMode.collectAsState(initial = false)
+    val currentThemeMode: String by dataStore.themeMode.collectAsStateWithLifecycle(initialValue = defaultThemeModeName)
+    val isAmoledMode: Boolean by dataStore.amoledMode.collectAsStateWithLifecycle(initialValue = false)
 
     val themeChoices: List<OnboardingThemeChoice> = listOf(
         OnboardingThemeChoice(

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/permissions/ui/PermissionsScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/permissions/ui/PermissionsScreen.kt
@@ -11,7 +11,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -34,7 +34,7 @@ import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun PermissionsScreen(viewModel : PermissionsViewModel) {
-    val screenState : UiStateScreen<SettingsConfig> by viewModel.uiState.collectAsState()
+    val screenState : UiStateScreen<SettingsConfig> by viewModel.uiState.collectAsStateWithLifecycle()
     val context = LocalContext.current
 
     LargeTopAppBarWithScaffold(

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsScreen.kt
@@ -26,7 +26,7 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -67,7 +67,7 @@ import org.koin.compose.viewmodel.koinViewModel
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun SettingsScreen(viewModel : SettingsViewModel , contentProvider : GeneralSettingsContentProvider) {
-    val screenState : UiStateScreen<SettingsConfig> by viewModel.uiState.collectAsState()
+    val screenState : UiStateScreen<SettingsConfig> by viewModel.uiState.collectAsStateWithLifecycle()
     val context : Context = LocalContext.current
 
     LargeTopAppBarWithScaffold(title = stringResource(id = R.string.settings) , onBackClicked = { (context as Activity).finish() }) { paddingValues ->

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportScreen.kt
@@ -18,7 +18,7 @@ import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
@@ -49,7 +49,7 @@ fun SupportComposable(
     viewModel: SupportViewModel,
     activity: Activity,
 ) {
-    val screenState: UiStateScreen<SupportScreenUiState> by viewModel.uiState.collectAsState()
+    val screenState: UiStateScreen<SupportScreenUiState> by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState: SnackbarHostState = remember { SnackbarHostState() }
 
     LargeTopAppBarWithScaffold(

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/theme/ThemeSettingsList.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/theme/ThemeSettingsList.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
@@ -37,8 +37,8 @@ fun ThemeSettingsList(paddingValues : PaddingValues) {
     val context : Context = LocalContext.current
     val dataStore : CommonDataStore = CommonDataStore.getInstance(context = context)
 
-    val currentThemeModeKey : String by dataStore.themeMode.collectAsState(initial = DataStoreNamesConstants.THEME_MODE_FOLLOW_SYSTEM)
-    val isAmoledMode : State<Boolean> = dataStore.amoledMode.collectAsState(initial = false)
+    val currentThemeModeKey : String by dataStore.themeMode.collectAsStateWithLifecycle(initialValue = DataStoreNamesConstants.THEME_MODE_FOLLOW_SYSTEM)
+    val isAmoledMode : State<Boolean> = dataStore.amoledMode.collectAsStateWithLifecycle(initialValue = false)
 
     val themeOptions : List<ThemeSettingOption> = listOf(
         ThemeSettingOption(

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/theme/style/Theme.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/theme/style/Theme.kt
@@ -15,7 +15,7 @@ import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
@@ -64,9 +64,9 @@ private fun getColorScheme(isDarkTheme : Boolean , isAmoledMode : Boolean , isDy
 fun AppTheme(content : @Composable () -> Unit) {
     val context : Context = LocalContext.current
     val dataStore : CommonDataStore = CommonDataStore.getInstance(context = context)
-    val themeMode : String = dataStore.themeMode.collectAsState(initial = DataStoreNamesConstants.THEME_MODE_FOLLOW_SYSTEM).value
-    val isDynamicColors : Boolean = dataStore.dynamicColors.collectAsState(initial = true).value
-    val isAmoledMode : Boolean = dataStore.amoledMode.collectAsState(initial = false).value
+    val themeMode : String = dataStore.themeMode.collectAsStateWithLifecycle(initialValue = DataStoreNamesConstants.THEME_MODE_FOLLOW_SYSTEM).value
+    val isDynamicColors : Boolean = dataStore.dynamicColors.collectAsStateWithLifecycle(initialValue = true).value
+    val isAmoledMode : Boolean = dataStore.amoledMode.collectAsStateWithLifecycle(initialValue = false).value
 
     val isSystemDarkTheme : Boolean = isSystemInDarkTheme()
     val isDarkTheme : Boolean = when (themeMode) {

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/modifiers/Animations.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/modifiers/Animations.kt
@@ -8,7 +8,7 @@ import androidx.compose.foundation.gestures.waitForUpOrCancellation
 import androidx.compose.foundation.layout.offset
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
-import androidx.compose.runtime.collectAsState
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -39,7 +39,7 @@ fun Modifier.bounceClick(
     var buttonState : ButtonState by remember { mutableStateOf(value = ButtonState.Idle) }
     val context: Context = LocalContext.current
     val dataStore: CommonDataStore = CommonDataStore.getInstance(context = context)
-    val bouncyButtonsEnabled : Boolean by dataStore.bouncyButtons.collectAsState(initial = true)
+    val bouncyButtonsEnabled : Boolean by dataStore.bouncyButtons.collectAsStateWithLifecycle(initialValue = true)
     val scale : Float by animateFloatAsState(
         if (buttonState == ButtonState.Pressed && animationEnabled && bouncyButtonsEnabled) 0.96f else 1f , label = "Button Press Scale Animation"
     )


### PR DESCRIPTION
## Summary
- replace `collectAsState` with `collectAsStateWithLifecycle` across composables
- add `androidx.lifecycle:lifecycle-runtime-compose` dependency
- move lifecycle runtime dependency to the library module

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad80638cf0832d8f6e185fd6cf1e83