### PR TITLE
Refactor coroutines to inject dispatchers

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/advanced/utils/CleanHelper.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/advanced/utils/CleanHelper.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import android.widget.Toast
 import com.d4rk.android.libs.apptoolkit.R
 import java.io.File
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
@@ -12,10 +13,14 @@ import kotlinx.coroutines.withContext
 
 object CleanHelper {
 
-    suspend fun clearApplicationCache(context : Context) {
+    suspend fun clearApplicationCache(
+        context: Context,
+        ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+        mainDispatcher: CoroutineDispatcher = Dispatchers.Main
+    ) {
         val cacheDirectories : List<File> = listOf(context.cacheDir , context.codeCacheDir , context.filesDir)
 
-        val allDeleted : Boolean = withContext(context = Dispatchers.IO) {
+        val allDeleted : Boolean = withContext(context = ioDispatcher) {
             coroutineScope {
                 cacheDirectories
                     .map { directory ->
@@ -28,7 +33,7 @@ object CleanHelper {
 
         val messageResId : Int = if (allDeleted) R.string.cache_cleared_success else R.string.cache_cleared_error
 
-        withContext(context = Dispatchers.Main) {
+        withContext(context = mainDispatcher) {
             Toast.makeText(context , context.getString(messageResId) , Toast.LENGTH_SHORT).show()
         }
     }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/main/ui/components/dialogs/ChangelogDialog.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/main/ui/components/dialogs/ChangelogDialog.kt
@@ -26,6 +26,7 @@ import dev.jeziellago.compose.markdowntext.MarkdownText
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -36,6 +37,7 @@ fun ChangelogDialog(
     changelogUrl: String,
     buildInfoProvider: BuildInfoProvider,
     onDismiss: () -> Unit,
+    ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) {
     val context = LocalContext.current
     val changelogText: MutableState<String?> = remember {
@@ -46,7 +48,7 @@ fun ChangelogDialog(
     val httpClient: HttpClient = koinInject()
 
     suspend fun loadChangelog() {
-        withContext(Dispatchers.IO) {
+        withContext(ioDispatcher) {
             runCatching {
                 val content: String = httpClient.get(changelogUrl).body()
                 val section = extractChangesForVersion(content, buildInfoProvider.appVersion)

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/core/BaseCoreManager.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/core/BaseCoreManager.kt
@@ -13,6 +13,7 @@ import com.google.firebase.appcheck.playintegrity.PlayIntegrityAppCheckProviderF
 import com.google.firebase.initialize
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
@@ -24,7 +25,8 @@ import org.koin.android.ext.android.inject
 open class BaseCoreManager : MultiDexApplication(), Application.ActivityLifecycleCallbacks, LifecycleObserver {
 
     protected val billingRepository: BillingRepository by inject()
-    private val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    protected open val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+    private val applicationScope = CoroutineScope(SupervisorJob() + ioDispatcher)
 
     companion object {
         var isAppLoaded : Boolean = false

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/datastore/CommonDataStore.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/datastore/CommonDataStore.kt
@@ -13,6 +13,7 @@ import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.datastore.DataStoreNamesConstants
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
@@ -34,9 +35,12 @@ val Context.commonDataStore : DataStore<Preferences> by preferencesDataStore(nam
  *
  * @property dataStore The DataStore instance for storing preferences.
  */
-open class CommonDataStore(context : Context) {
+open class CommonDataStore(
+    context : Context,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+) {
     val dataStore : DataStore<Preferences> = context.commonDataStore
-    private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
+    private val scope = CoroutineScope(SupervisorJob() + ioDispatcher)
 
     companion object {
         @Volatile


### PR DESCRIPTION
## Summary
- Inject CoroutineDispatcher into ChangelogDialog and CleanHelper instead of hardcoding Dispatchers
- Allow BaseCoreManager and CommonDataStore to override IO dispatcher for their scopes

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ad9f075b6c832d91525dd086f5fa73