### PR TITLE
Inject dispatcher into BillingRepository for testable coroutines

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppToolkitModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppToolkitModule.kt
@@ -19,7 +19,12 @@ import org.koin.dsl.module
 val appToolkitModule : Module = module {
     single<StartupProvider> { AppStartupProvider() }
 
-    single(createdAtStart = true) { BillingRepository.getInstance(context = get()) }
+    single(createdAtStart = true) {
+        BillingRepository.getInstance(
+            context = get(),
+            ioDispatcher = get(named("io"))
+        )
+    }
     viewModel {
         SupportViewModel(billingRepository = get())
     }


### PR DESCRIPTION
## Summary
- inject `CoroutineDispatcher` into `BillingRepository` for better coroutine control
- pass dispatcher via Koin module so tests can supply custom dispatchers

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adc3eed690832dbd59c99ce880e972