### PR TITLE
Use Turbine for favorites toggling tests

### DIFF
--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModel.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModel.kt
@@ -4,10 +4,11 @@ import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
 import com.d4rk.android.apps.apptoolkit.app.core.utils.dispatchers.StandardDispatcherExtension
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Error
+import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.advanceUntilIdle
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 
@@ -34,10 +35,14 @@ class TestFavoriteAppsViewModel : TestFavoriteAppsViewModelBase() {
             dispatcher = dispatcherExtension.testDispatcher
         )
 
-        advanceUntilIdle()
-        viewModel.toggleFavorite("pkg")
-        advanceUntilIdle()
-        assertThat(viewModel.favorites.value.contains("pkg")).isFalse()
+        viewModel.favorites.test {
+            awaitItem()
+            viewModel.toggleFavorite("pkg")
+            runCurrent()
+            expectNoEvents()
+            assertThat(viewModel.favorites.value.contains("pkg")).isFalse()
+            cancelAndIgnoreRemainingEvents()
+        }
         println("\uD83C\uDFC1 [TEST DONE] toggle favorite throws after load")
     }
 }

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModelBase.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModelBase.kt
@@ -19,7 +19,6 @@ import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.cancel
 import androidx.lifecycle.viewModelScope
 import org.junit.jupiter.api.AfterEach
@@ -132,18 +131,23 @@ open class TestAppsListViewModelBase {
 
     protected suspend fun toggleAndAssert(packageName: String, expected: Boolean) {
         println("\uD83D\uDE80 [TEST START] toggleAndAssert for $packageName expecting $expected")
-        println("Favorites before: ${viewModel.favorites.value}")
-        viewModel.toggleFavorite(packageName)
-        println("\uD83D\uDD04 [ACTION] toggled $packageName")
-        advanceUntilIdle()
-        val favorites = viewModel.favorites.value
-        println("Favorites after: $favorites")
-        if (favorites.contains(packageName) == expected) {
-            println("\uD83D\uDC4D [ASSERTION PASSED] favorite state matches $expected")
-        } else {
-            println("\u274C [ASSERTION FAILED] expected $expected but was ${favorites.contains(packageName)}")
+        viewModel.favorites.test {
+            val before = awaitItem()
+            println("Favorites before: $before")
+
+            viewModel.toggleFavorite(packageName)
+            println("\uD83D\uDD04 [ACTION] toggled $packageName")
+
+            val after = awaitItem()
+            println("Favorites after: $after")
+            if (after.contains(packageName) == expected) {
+                println("\uD83D\uDC4D [ASSERTION PASSED] favorite state matches $expected")
+            } else {
+                println("\u274C [ASSERTION FAILED] expected $expected but was ${after.contains(packageName)}")
+            }
+            assertThat(after.contains(packageName)).isEqualTo(expected)
+            cancelAndIgnoreRemainingEvents()
         }
-        assertThat(favorites.contains(packageName)).isEqualTo(expected)
         println("\uD83C\uDFC1 [TEST END] toggleAndAssert")
     }
 


### PR DESCRIPTION
## Summary
- Wrap `viewModel.favorites` in Turbine `test` blocks in toggle helpers
- Trigger `toggleFavorite` inside Turbine blocks and assert with `awaitItem`
- Update failing toggle test to use Turbine and remove `advanceUntilIdle`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adca646988832d95d471c8a33758bb