### PR TITLE
test: use unconfined dispatcher where eager

### DIFF
--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModel.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModel.kt
@@ -1,13 +1,12 @@
 package com.d4rk.android.apps.apptoolkit.app.apps.favorites
 
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
-import com.d4rk.android.apps.apptoolkit.app.core.utils.dispatchers.StandardDispatcherExtension
+import com.d4rk.android.apps.apptoolkit.app.core.utils.dispatchers.UnconfinedDispatcherExtension
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Error
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.advanceUntilIdle
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 
@@ -16,7 +15,7 @@ class TestFavoriteAppsViewModel : TestFavoriteAppsViewModelBase() {
     companion object {
         @JvmField
         @RegisterExtension
-        val dispatcherExtension = StandardDispatcherExtension()
+        val dispatcherExtension = UnconfinedDispatcherExtension()
     }
 
     @Test
@@ -34,9 +33,7 @@ class TestFavoriteAppsViewModel : TestFavoriteAppsViewModelBase() {
             dispatcher = dispatcherExtension.testDispatcher
         )
 
-        advanceUntilIdle()
         viewModel.toggleFavorite("pkg")
-        advanceUntilIdle()
         assertThat(viewModel.favorites.value.contains("pkg")).isFalse()
         println("\uD83C\uDFC1 [TEST DONE] toggle favorite throws after load")
     }

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModelBase.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModelBase.kt
@@ -19,7 +19,6 @@ import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -140,7 +139,6 @@ open class TestFavoriteAppsViewModelBase {
         println("Favorites before: ${viewModel.favorites.value}")
         viewModel.toggleFavorite(packageName)
         println("\uD83D\uDD04 [ACTION] toggled $packageName")
-        advanceUntilIdle()
         val favorites = viewModel.favorites.value
         println("Favorites after: $favorites")
         if (favorites.contains(packageName) == expected) {

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModel.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModel.kt
@@ -1,7 +1,7 @@
 package com.d4rk.android.apps.apptoolkit.app.apps.list
 
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
-import com.d4rk.android.apps.apptoolkit.app.core.utils.dispatchers.StandardDispatcherExtension
+import com.d4rk.android.apps.apptoolkit.app.core.utils.dispatchers.UnconfinedDispatcherExtension
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Error
 import kotlinx.coroutines.flow.flow
@@ -14,7 +14,7 @@ class TestAppsListViewModel : TestAppsListViewModelBase() {
     companion object {
         @JvmField
         @RegisterExtension
-        val dispatcherExtension = StandardDispatcherExtension()
+        val dispatcherExtension = UnconfinedDispatcherExtension()
     }
 
     @Test

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModelBase.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModelBase.kt
@@ -19,7 +19,6 @@ import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.cancel
 import androidx.lifecycle.viewModelScope
 import org.junit.jupiter.api.AfterEach
@@ -135,7 +134,6 @@ open class TestAppsListViewModelBase {
         println("Favorites before: ${viewModel.favorites.value}")
         viewModel.toggleFavorite(packageName)
         println("\uD83D\uDD04 [ACTION] toggled $packageName")
-        advanceUntilIdle()
         val favorites = viewModel.favorites.value
         println("Favorites after: $favorites")
         if (favorites.contains(packageName) == expected) {


### PR DESCRIPTION
## Summary
- use UnconfinedDispatcherExtension in app ViewModel tests
- drop manual advanceUntilIdle calls when using eager dispatcher

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adca655850832da5779f89e20d7092