### PR TITLE
Refine coroutine state exposure and dispatcher injection

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/SettingsModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/SettingsModule.kt
@@ -20,13 +20,17 @@ import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.DisplaySett
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.GeneralSettingsContentProvider
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.PrivacySettingsProvider
 import org.koin.core.module.dsl.viewModel
+import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 val settingsModule = module {
     single<SettingsProvider> { AppSettingsProvider() }
 
     viewModel {
-        SettingsViewModel(settingsProvider = get())
+        SettingsViewModel(
+            settingsProvider = get(),
+            dispatcher = get(named("io"))
+        )
     }
 
     single<AboutSettingsProvider> { AppAboutSettingsProvider(context = get()) }
@@ -41,7 +45,10 @@ val settingsModule = module {
 
     single<PermissionsProvider> { PermissionsSettingsProvider() }
     viewModel {
-        PermissionsViewModel(settingsProvider = get())
+        PermissionsViewModel(
+            settingsProvider = get(),
+            dispatcher = get(named("io"))
+        )
     }
 
     viewModel {

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/ui/AboutViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/ui/AboutViewModel.kt
@@ -46,7 +46,7 @@ open class AboutViewModel :
         }
     }
 
-    private inline fun updateUi(crossinline transform: UiAboutScreen.() -> UiAboutScreen) {
+    internal inline fun updateUi(crossinline transform: UiAboutScreen.() -> UiAboutScreen) {
         screenState.updateData(newState = screenState.value.screenState) { current: UiAboutScreen -> transform(current) }
     }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/base/ScreenViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/base/ScreenViewModel.kt
@@ -5,8 +5,10 @@ import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.ActionEvent
 import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.UiEvent
 import kotlinx.coroutines.flow.MutableStateFlow
 
-abstract class ScreenViewModel<T , E : UiEvent , A : ActionEvent>(initialState : UiStateScreen<T>) : BaseViewModel<UiStateScreen<T> , E , A>(initialState) {
-    open val screenState : MutableStateFlow<UiStateScreen<T>>
+abstract class ScreenViewModel<T , E : UiEvent , A : ActionEvent>(
+    initialState : UiStateScreen<T>
+) : BaseViewModel<UiStateScreen<T> , E , A>(initialState) {
+    protected val screenState : MutableStateFlow<UiStateScreen<T>>
         get() = _uiState
     protected val screenData : T?
         get() = currentState.data

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/about/ui/TestAboutViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/about/ui/TestAboutViewModel.kt
@@ -3,7 +3,6 @@ package com.d4rk.android.libs.apptoolkit.app.about.ui
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.about.domain.model.actions.AboutEvents
 import com.d4rk.android.libs.apptoolkit.app.about.domain.model.ui.UiAboutScreen
-import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.updateData
 import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.UnconfinedDispatcherExtension
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
 import com.google.common.truth.Truth.assertThat
@@ -129,7 +128,7 @@ class TestAboutViewModel {
         assertThat(viewModel.uiState.value.data?.showDeviceInfoCopiedSnackbar).isTrue()
         assertThat(viewModel.uiState.value.snackbar).isNotNull()
 
-        viewModel.screenState.updateData(viewModel.uiState.value.screenState) { UiAboutScreen() }
+        viewModel.updateUi { UiAboutScreen() }
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
 
         val state = viewModel.uiState.value


### PR DESCRIPTION
## Summary
- prevent external mutation of screen state by restricting `screenState` to subclasses
- inject IO dispatchers into settings-related ViewModels via Koin
- expose an internal `updateUi` helper in `AboutViewModel` and adjust tests accordingly

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae13b01acc832dab03ff543c97957c