### PR TITLE
test: replace MockK with fake repositories

### DIFF
--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/FakeFavoritesRepository.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/FakeFavoritesRepository.kt
@@ -1,0 +1,75 @@
+package com.d4rk.android.apps.apptoolkit.app.apps.favorites
+
+import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.repository.FavoritesRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+
+/**
+ * Simple in-memory implementation of [FavoritesRepository] for tests.
+ *
+ * The repository holds favorites in a mutable flow so that tests can observe
+ * changes and toggle values without relying on mocking frameworks.
+ */
+class FakeFavoritesRepository(
+    initialFavorites: Set<String> = emptySet(),
+    favoritesFlow: Flow<Set<String>>? = null,
+    private val toggleError: Throwable? = null,
+) : FavoritesRepository {
+
+    private val stateFlow: MutableStateFlow<Set<String>>?
+    private val sharedFlow: MutableSharedFlow<Set<String>>?
+    private val flow: Flow<Set<String>>
+
+    init {
+        when (favoritesFlow) {
+            is MutableStateFlow -> {
+                stateFlow = favoritesFlow
+                sharedFlow = null
+                flow = favoritesFlow
+                if (favoritesFlow.value.isEmpty() && initialFavorites.isNotEmpty()) {
+                    favoritesFlow.value = initialFavorites
+                }
+            }
+            is MutableSharedFlow -> {
+                stateFlow = null
+                sharedFlow = favoritesFlow
+                flow = favoritesFlow
+                if (initialFavorites.isNotEmpty()) {
+                    favoritesFlow.tryEmit(initialFavorites)
+                }
+            }
+            null -> {
+                val state = MutableStateFlow(initialFavorites)
+                stateFlow = state
+                sharedFlow = null
+                flow = state
+            }
+            else -> {
+                // Non-mutable flow provided; toggling will be no-op
+                stateFlow = null
+                sharedFlow = null
+                flow = favoritesFlow
+            }
+        }
+    }
+
+    override fun observeFavorites(): Flow<Set<String>> = flow
+
+    override suspend fun toggleFavorite(packageName: String) {
+        toggleError?.let { throw it }
+        val current = when {
+            stateFlow != null -> stateFlow.value.toMutableSet()
+            sharedFlow != null -> sharedFlow.replayCache.lastOrNull()?.toMutableSet() ?: mutableSetOf()
+            else -> return
+        }
+        if (!current.add(packageName)) {
+            current.remove(packageName)
+        }
+        when {
+            stateFlow != null -> stateFlow.value = current
+            sharedFlow != null -> sharedFlow.emit(current)
+        }
+    }
+}
+

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModelBase.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModelBase.kt
@@ -1,28 +1,24 @@
 package com.d4rk.android.apps.apptoolkit.app.apps.favorites
 
 import app.cash.turbine.test
-import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.repository.FavoritesRepository
 import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases.ObserveFavoritesUseCase
 import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases.ToggleFavoriteUseCase
 import com.d4rk.android.apps.apptoolkit.app.apps.favorites.ui.FavoriteAppsViewModel
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.ui.UiHomeScreen
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.usecases.FetchDeveloperAppsUseCase
+import com.d4rk.android.apps.apptoolkit.app.apps.favorites.FakeFavoritesRepository
+import com.d4rk.android.apps.apptoolkit.app.apps.list.FakeDeveloperAppsRepository
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.RootError
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.google.common.truth.Truth.assertThat
-import io.mockk.coEvery
-import io.mockk.every
-import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.jupiter.api.Assertions.assertTrue
 import kotlinx.coroutines.cancel
 import androidx.lifecycle.viewModelScope
@@ -32,9 +28,6 @@ import org.junit.jupiter.api.AfterEach
 open class TestFavoriteAppsViewModelBase {
 
     protected lateinit var viewModel: FavoriteAppsViewModel
-    private lateinit var fetchUseCase: FetchDeveloperAppsUseCase
-    private lateinit var favoritesRepository: FavoritesRepository
-
     protected fun setup(
         fetchFlow: Flow<DataState<List<AppInfo>, RootError>>,
         initialFavorites: Set<String> = emptySet(),
@@ -43,36 +36,11 @@ open class TestFavoriteAppsViewModelBase {
         dispatcher: CoroutineDispatcher = Dispatchers.Main
     ) {
         println("\uD83E\uDDEA [SETUP] Initial favorites: $initialFavorites")
-        fetchUseCase = mockk()
-        favoritesRepository = mockk(relaxed = true)
-
-        val favFlow = favoritesFlow ?: MutableStateFlow(initialFavorites)
-        every { favoritesRepository.observeFavorites() } returns favFlow
-
-        if (toggleError != null) {
-            coEvery { favoritesRepository.toggleFavorite(any()) } throws toggleError
-        } else if (favFlow is MutableStateFlow<Set<String>> || favFlow is MutableSharedFlow<Set<String>>) {
-            coEvery { favoritesRepository.toggleFavorite(any()) } coAnswers {
-                val pkg = it.invocation.args[0] as String
-                val current = when (favFlow) {
-                    is MutableStateFlow -> favFlow.value
-                    else -> favFlow.replayCache.lastOrNull() ?: emptySet()
-                }.toMutableSet()
-                if (!current.add(pkg)) current.remove(pkg)
-                when (favFlow) {
-                    is MutableStateFlow -> favFlow.value = current
-                    else -> favFlow.emit(current)
-                }
-            }
-        } else {
-            coEvery { favoritesRepository.toggleFavorite(any()) } returns Unit
-        }
-
-        coEvery { fetchUseCase.invoke() } returns fetchFlow
-
+        val developerAppsRepository = FakeDeveloperAppsRepository(fetchFlow)
+        val fetchUseCase = FetchDeveloperAppsUseCase(developerAppsRepository)
+        val favoritesRepository = FakeFavoritesRepository(initialFavorites, favoritesFlow, toggleError)
         val observeFavoritesUseCase = ObserveFavoritesUseCase(favoritesRepository)
         val toggleFavoriteUseCase = ToggleFavoriteUseCase(favoritesRepository, dispatcher)
-
         viewModel = FavoriteAppsViewModel(
             fetchDeveloperAppsUseCase = fetchUseCase,
             observeFavoritesUseCase = observeFavoritesUseCase,

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/FakeDeveloperAppsRepository.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/FakeDeveloperAppsRepository.kt
@@ -1,0 +1,22 @@
+package com.d4rk.android.apps.apptoolkit.app.apps.list
+
+import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
+import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.repository.DeveloperAppsRepository
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.RootError
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Fake implementation of [DeveloperAppsRepository] that returns a predefined flow.
+ * It can optionally throw an exception when [fetchDeveloperApps] is called.
+ */
+class FakeDeveloperAppsRepository(
+    private val flow: Flow<DataState<List<AppInfo>, RootError>>,
+    private val fetchThrows: Throwable? = null,
+) : DeveloperAppsRepository {
+    override fun fetchDeveloperApps(): Flow<DataState<List<AppInfo>, RootError>> {
+        fetchThrows?.let { throw it }
+        return flow
+    }
+}
+

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModelBase.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModelBase.kt
@@ -5,17 +5,15 @@ import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.ui.UiHomeScreen
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.usecases.FetchDeveloperAppsUseCase
 import com.d4rk.android.apps.apptoolkit.app.apps.list.ui.AppsListViewModel
-import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.repository.FavoritesRepository
 import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases.ObserveFavoritesUseCase
 import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases.ToggleFavoriteUseCase
+import com.d4rk.android.apps.apptoolkit.app.apps.favorites.FakeFavoritesRepository
+import com.d4rk.android.apps.apptoolkit.app.apps.list.FakeDeveloperAppsRepository
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.RootError
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.google.common.truth.Truth.assertThat
-import io.mockk.coEvery
-import io.mockk.every
-import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.CoroutineDispatcher
@@ -24,16 +22,12 @@ import kotlinx.coroutines.cancel
 import androidx.lifecycle.viewModelScope
 import org.junit.jupiter.api.AfterEach
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableStateFlow
 import org.junit.jupiter.api.Assertions.assertTrue
 
 @OptIn(ExperimentalCoroutinesApi::class)
 open class TestAppsListViewModelBase {
 
     protected lateinit var viewModel: AppsListViewModel
-    private lateinit var fetchUseCase: FetchDeveloperAppsUseCase
-    private lateinit var favoritesRepository: FavoritesRepository
-
     protected fun setup(
         fetchFlow: Flow<DataState<List<AppInfo>, RootError>>,
         initialFavorites: Set<String> = emptySet(),
@@ -43,35 +37,11 @@ open class TestAppsListViewModelBase {
         dispatcher: CoroutineDispatcher = Dispatchers.Main,
     ) {
         println("\uD83E\uDDEA [SETUP] Initial favorites: $initialFavorites")
-        fetchUseCase = mockk()
-        favoritesRepository = mockk(relaxed = true)
-        val favFlow = favoritesFlow ?: MutableStateFlow(initialFavorites)
-        every { favoritesRepository.observeFavorites() } returns favFlow
-
-        if (toggleError != null) {
-            coEvery { favoritesRepository.toggleFavorite(any()) } throws toggleError
-        } else if (favFlow is MutableStateFlow<Set<String>>) {
-            coEvery { favoritesRepository.toggleFavorite(any()) } coAnswers {
-                val pkg = it.invocation.args[0] as String
-                println("\uD83D\uDD04 [REPO MOCK] toggleFavorite($pkg)")
-                val current = favFlow.value.toMutableSet()
-                if (!current.add(pkg)) {
-                    current.remove(pkg)
-                }
-                favFlow.value = current
-            }
-        } else {
-            coEvery { favoritesRepository.toggleFavorite(any()) } returns Unit
-        }
-        if (fetchThrows != null) {
-            coEvery { fetchUseCase.invoke() } throws fetchThrows
-        } else {
-            coEvery { fetchUseCase.invoke() } returns fetchFlow
-        }
-
+        val developerAppsRepository = FakeDeveloperAppsRepository(fetchFlow, fetchThrows)
+        val fetchUseCase = FetchDeveloperAppsUseCase(developerAppsRepository)
+        val favoritesRepository = FakeFavoritesRepository(initialFavorites, favoritesFlow, toggleError)
         val observeFavoritesUseCase = ObserveFavoritesUseCase(favoritesRepository)
         val toggleFavoriteUseCase = ToggleFavoriteUseCase(favoritesRepository, dispatcher)
-
         viewModel = AppsListViewModel(fetchUseCase, observeFavoritesUseCase, toggleFavoriteUseCase)
         println("\u2705 [SETUP] ViewModel initialized")
     }


### PR DESCRIPTION
## Summary
- implement FakeFavoritesRepository and FakeDeveloperAppsRepository
- update viewmodel tests to use in-memory fakes instead of MockK

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68adca5a2ab0832da1aaee9fea905130