### PR TITLE
Use lifecycle observers for startup actions

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainActivity.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainActivity.kt
@@ -12,6 +12,8 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import androidx.lifecycle.lifecycleScope
 import com.d4rk.android.apps.apptoolkit.core.data.datastore.DataStore
 import com.d4rk.android.libs.apptoolkit.app.main.utils.InAppUpdateHelper
@@ -42,21 +44,22 @@ class MainActivity : AppCompatActivity() {
     private var updateResultLauncher: ActivityResultLauncher<IntentSenderRequest> =
         registerForActivityResult(contract = ActivityResultContracts.StartIntentSenderForResult()) {}
     private var keepSplashVisible: Boolean = true
+    private val lifecycleObserver = object : DefaultLifecycleObserver {
+        override fun onStart(owner: LifecycleOwner) {
+            checkForUpdates()
+            checkUserConsent()
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val splashScreen = installSplashScreen()
         splashScreen.setKeepOnScreenCondition { keepSplashVisible }
         enableEdgeToEdge()
+        lifecycle.addObserver(lifecycleObserver)
         initializeDependencies()
         handleStartup()
         checkInAppReview()
-    }
-
-    override fun onResume() {
-        super.onResume()
-        checkForUpdates()
-        checkUserConsent()
     }
 
     private fun initializeDependencies() {

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingActivity.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingActivity.kt
@@ -4,20 +4,40 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
+import androidx.activity.result.ActivityResultLauncher
+import androidx.activity.result.IntentSenderRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
 import com.d4rk.android.libs.apptoolkit.app.theme.style.AppTheme
+import com.d4rk.android.libs.apptoolkit.app.main.utils.InAppUpdateHelper
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.ConsentFormHelper
 import com.google.android.ump.ConsentInformation
 import com.google.android.ump.UserMessagingPlatform
+import com.google.android.play.core.appupdate.AppUpdateManagerFactory
+import kotlinx.coroutines.launch
 
 class OnboardingActivity : ComponentActivity() {
+
+    private var updateResultLauncher: ActivityResultLauncher<IntentSenderRequest> =
+        registerForActivityResult(contract = ActivityResultContracts.StartIntentSenderForResult()) {}
+    private val lifecycleObserver = object : DefaultLifecycleObserver {
+        override fun onStart(owner: LifecycleOwner) {
+            checkForUpdates()
+            checkUserConsent()
+            checkPermissions()
+        }
+    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
+        lifecycle.addObserver(lifecycleObserver)
         setContent {
             AppTheme {
                 Surface(
@@ -30,14 +50,21 @@ class OnboardingActivity : ComponentActivity() {
         }
     }
 
-    override fun onResume() {
-        super.onResume()
-        checkUserConsent()
-        // Recheck permissions when returning to this activity
-    }
-
     private fun checkUserConsent() {
         val consentInfo: ConsentInformation = UserMessagingPlatform.getConsentInformation(this)
         ConsentFormHelper.showConsentFormIfRequired(activity = this , consentInfo = consentInfo)
+    }
+
+    private fun checkForUpdates() {
+        lifecycleScope.launch {
+            InAppUpdateHelper.performUpdate(
+                appUpdateManager = AppUpdateManagerFactory.create(this@OnboardingActivity),
+                updateResultLauncher = updateResultLauncher,
+            )
+        }
+    }
+
+    private fun checkPermissions() {
+        // Recheck permissions when returning to this activity
     }
 }


### PR DESCRIPTION
## Summary
- remove activity `onResume` overrides
- trigger startup checks using a `DefaultLifecycleObserver`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ae26059460832d991e6e3c60db7503