### PR TITLE
Refactor issue reporter to domain result handling

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/domain/usecases/SendIssueReportUseCase.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/domain/usecases/SendIssueReportUseCase.kt
@@ -6,13 +6,14 @@ import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.Report
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.github.GithubTarget
 import com.d4rk.android.libs.apptoolkit.core.domain.usecases.Repository
 import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.AppDispatchers
+import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.withContext
 
 class SendIssueReportUseCase(
     private val repository: IssueReporterRepository,
     private val dispatchers: AppDispatchers,
-) : Repository<SendIssueReportUseCase.Params, Result<IssueReportResult>> {
+) : Repository<SendIssueReportUseCase.Params, IssueReportResult> {
 
     data class Params(
         val report: Report,
@@ -20,14 +21,17 @@ class SendIssueReportUseCase(
         val token: String?
     )
 
-    override suspend fun invoke(param: Params): Result<IssueReportResult> =
+    override suspend fun invoke(param: Params): IssueReportResult =
         withContext(dispatchers.io) {
             try {
-                Result.success(repository.sendReport(param.report, param.target, param.token))
+                repository.sendReport(param.report, param.target, param.token)
             } catch (e: CancellationException) {
                 throw e
             } catch (e: Throwable) {
-                Result.failure(e)
+                IssueReportResult.Error(
+                    status = HttpStatusCode.InternalServerError,
+                    message = e.message ?: ""
+                )
             }
         }
 }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/domain/usecases/SendIssueReportUseCaseTest.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/domain/usecases/SendIssueReportUseCaseTest.kt
@@ -1,0 +1,60 @@
+package com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.usecases
+
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.data.IssueReporterRepository
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.IssueReportResult
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.Report
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.github.ExtraInfo
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.github.GithubTarget
+import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.AppDispatchers
+import com.google.common.truth.Truth.assertThat
+import io.ktor.http.HttpStatusCode
+import io.mockk.coEvery
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class SendIssueReportUseCaseTest {
+
+    private val dispatcher = StandardTestDispatcher()
+    private val dispatchers = object : AppDispatchers {
+        override val io = dispatcher
+        override val default = dispatcher
+        override val main = dispatcher
+    }
+
+    private val params = SendIssueReportUseCase.Params(
+        report = Report("t", "d", mockk(), ExtraInfo(), null),
+        target = GithubTarget("user", "repo"),
+        token = null
+    )
+
+    @Test
+    fun `invoke success returns success`() = runTest(dispatcher) {
+        val repository = mockk<IssueReporterRepository>()
+        coEvery { repository.sendReport(any(), any(), any()) } returns IssueReportResult.Success("url")
+
+        val useCase = SendIssueReportUseCase(repository, dispatchers)
+        val result = useCase(params)
+
+        assertThat(result).isInstanceOf(IssueReportResult.Success::class.java)
+        assertThat((result as IssueReportResult.Success).url).isEqualTo("url")
+    }
+
+    @Test
+    fun `invoke error maps exception`() = runTest(dispatcher) {
+        val repository = mockk<IssueReporterRepository>()
+        coEvery { repository.sendReport(any(), any(), any()) } throws IllegalStateException("boom")
+
+        val useCase = SendIssueReportUseCase(repository, dispatchers)
+        val result = useCase(params)
+
+        assertThat(result).isInstanceOf(IssueReportResult.Error::class.java)
+        val error = result as IssueReportResult.Error
+        assertThat(error.status).isEqualTo(HttpStatusCode.InternalServerError)
+        assertThat(error.message).isEqualTo("boom")
+    }
+}
+

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/IssueReporterViewModelTest.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/IssueReporterViewModelTest.kt
@@ -66,7 +66,7 @@ class IssueReporterViewModelTest {
         try {
             val useCase = mockk<SendIssueReportUseCase>()
             val captured = slot<SendIssueReportUseCase.Params>()
-            coEvery { useCase.invoke(capture(captured)) } returns Result.success(IssueReportResult.Success("url"))
+            coEvery { useCase.invoke(capture(captured)) } returns IssueReportResult.Success("url")
             val viewModel = IssueReporterViewModel(useCase, githubTarget, "token", deviceInfoProvider)
             backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { viewModel.uiState.collect() }
 
@@ -106,7 +106,7 @@ class IssueReporterViewModelTest {
         Dispatchers.setMain(dispatcher)
         try {
             val useCase = mockk<SendIssueReportUseCase>()
-            coEvery { useCase.invoke(any()) } returns Result.success(IssueReportResult.Error(status, ""))
+            coEvery { useCase.invoke(any()) } returns IssueReportResult.Error(status, "")
             val viewModel = IssueReporterViewModel(useCase, githubTarget, "tok", deviceInfoProvider)
             backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { viewModel.uiState.collect() }
 


### PR DESCRIPTION
## Summary
- Refactor `SendIssueReportUseCase` to return `IssueReportResult` and map exceptions to `Error`
- Simplify `IssueReporterViewModel` to consume domain results and guard concurrent sends
- Add unit tests for use case and view model to verify error mapping and state updates

## Testing
- `ANDROID_HOME=/usr/lib/android-sdk ./gradlew :apptoolkit:test` *(fails: Missing SDK components and licenses)*

------
https://chatgpt.com/codex/tasks/task_e_68af08c71db4832da3fe86886e39bfc4