### PR TITLE
Inject dispatchers into DeviceInfoProvider for main safety

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppToolkitModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppToolkitModule.kt
@@ -36,7 +36,7 @@ val appToolkitModule : Module = module {
     }
 
     single<AppDispatchers> { AppDispatchersImpl() }
-    single<DeviceInfoProvider> { DeviceInfoProviderImpl(get()) }
+    single<DeviceInfoProvider> { DeviceInfoProviderImpl(get(), get()) }
     single { IssueReporterRepository(get()) }
     single { SendIssueReportUseCase(get(), get()) }
 

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/domain/providers/DeviceInfoProvider.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/domain/providers/DeviceInfoProvider.kt
@@ -2,7 +2,9 @@ package com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.providers
 
 import android.app.Application
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo
+import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.AppDispatchers
 import javax.inject.Inject
+import kotlinx.coroutines.withContext
 
 interface DeviceInfoProvider {
     suspend fun capture(): DeviceInfo
@@ -10,6 +12,9 @@ interface DeviceInfoProvider {
 
 class DeviceInfoProviderImpl @Inject constructor(
     private val app: Application,
+    private val dispatchers: AppDispatchers,
 ) : DeviceInfoProvider {
-    override suspend fun capture(): DeviceInfo = DeviceInfo.create(app)
+    override suspend fun capture(): DeviceInfo = withContext(dispatchers.io) {
+        DeviceInfo.create(app)
+    }
 }


### PR DESCRIPTION
## Summary
- Inject `AppDispatchers` into `DeviceInfoProviderImpl`
- Capture device info on the IO dispatcher to keep suspend function main-safe
- Wire `DeviceInfoProviderImpl` with dispatchers in DI module

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af16101fc8832d86f9fb712acbf8b8