### PR TITLE
Refactor issue reporter repository for interface-based design

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppToolkitModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppToolkitModule.kt
@@ -3,6 +3,7 @@ package com.d4rk.android.apps.apptoolkit.core.di.modules
 import com.d4rk.android.apps.apptoolkit.BuildConfig
 import com.d4rk.android.apps.apptoolkit.app.startup.utils.interfaces.providers.AppStartupProvider
 import com.d4rk.android.libs.apptoolkit.app.help.domain.data.model.HelpScreenConfig
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.data.DefaultIssueReporterRepository
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.data.IssueReporterRepository
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.github.GithubTarget
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.providers.DeviceInfoProvider
@@ -37,7 +38,7 @@ val appToolkitModule : Module = module {
 
     single<AppDispatchers> { AppDispatchersImpl() }
     single<DeviceInfoProvider> { DeviceInfoProviderImpl(get(), get()) }
-    single { IssueReporterRepository(get()) }
+    single<IssueReporterRepository> { DefaultIssueReporterRepository(get()) }
     single { SendIssueReportUseCase(get(), get()) }
 
     val githubTokenQualifier = qualifier<GithubToken>()

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/data/DefaultIssueReporterRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/data/DefaultIssueReporterRepository.kt
@@ -1,0 +1,53 @@
+package com.d4rk.android.libs.apptoolkit.app.issuereporter.data
+
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.CreateIssueRequest
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.IssueReportResult
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.Report
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.github.GithubTarget
+import io.ktor.client.HttpClient
+import io.ktor.client.request.header
+import io.ktor.client.request.post
+import io.ktor.client.request.setBody
+import io.ktor.client.statement.HttpResponse
+import io.ktor.client.statement.bodyAsText
+import io.ktor.http.ContentType
+import io.ktor.http.HttpStatusCode
+import io.ktor.http.contentType
+import kotlinx.serialization.json.Json
+import kotlinx.serialization.json.jsonObject
+import kotlinx.serialization.json.jsonPrimitive
+
+/**
+ * Default implementation of [IssueReporterRepository] that posts issues to GitHub.
+ */
+class DefaultIssueReporterRepository(private val client: HttpClient) : IssueReporterRepository {
+
+    override suspend fun sendReport(
+        report: Report,
+        target: GithubTarget,
+        token: String?,
+    ): IssueReportResult {
+        val url = "https://api.github.com/repos/${'$'}{target.username}/${'$'}{target.repository}/issues"
+        val response: HttpResponse = client.post(url) {
+            contentType(ContentType.Application.Json)
+            header("Accept", "application/vnd.github+json")
+            token?.let { header("Authorization", "Bearer ${'$'}it") }
+            val issueRequest = CreateIssueRequest(
+                title = report.title,
+                body = report.getDescription(),
+                labels = listOf("bug", "from-mobile"),
+            )
+            setBody(Json.encodeToString(CreateIssueRequest.serializer(), issueRequest))
+        }
+
+        val responseBody = response.bodyAsText()
+        return if (response.status == HttpStatusCode.Created) {
+            val json = Json.parseToJsonElement(responseBody).jsonObject
+            val issueUrl = json["html_url"]?.jsonPrimitive?.content ?: ""
+            IssueReportResult.Success(issueUrl)
+        } else {
+            IssueReportResult.Error(response.status, responseBody)
+        }
+    }
+}
+

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/data/IssueReporterRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/data/IssueReporterRepository.kt
@@ -1,49 +1,17 @@
 package com.d4rk.android.libs.apptoolkit.app.issuereporter.data
 
-import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.CreateIssueRequest
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.IssueReportResult
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.Report
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.github.GithubTarget
-import io.ktor.client.HttpClient
-import io.ktor.client.request.header
-import io.ktor.client.request.post
-import io.ktor.client.request.setBody
-import io.ktor.client.statement.HttpResponse
-import io.ktor.client.statement.bodyAsText
-import io.ktor.http.ContentType
-import io.ktor.http.HttpStatusCode
-import io.ktor.http.contentType
-import kotlinx.serialization.json.Json
-import kotlinx.serialization.json.jsonObject
-import kotlinx.serialization.json.jsonPrimitive
 
-class IssueReporterRepository(private val client : HttpClient) {
-
+/**
+ * Repository contract for sending issue reports.
+ */
+interface IssueReporterRepository {
     suspend fun sendReport(
         report: Report,
         target: GithubTarget,
-        token: String? = null
-    ): IssueReportResult {
-        val url = "https://api.github.com/repos/${target.username}/${target.repository}/issues"
-        val response: HttpResponse = client.post(url) {
-            contentType(ContentType.Application.Json)
-            header("Accept", "application/vnd.github+json")
-            token?.let { header("Authorization", "Bearer $it") }
-            val issueRequest = CreateIssueRequest(
-                title = report.title,
-                body = report.getDescription(),
-                labels = listOf("bug", "from-mobile")
-            )
-            setBody(Json.encodeToString(CreateIssueRequest.serializer(), issueRequest))
-        }
-
-        val responseBody = response.bodyAsText()
-        return if (response.status == HttpStatusCode.Created) {
-            val json = Json.parseToJsonElement(responseBody).jsonObject
-            val issueUrl = json["html_url"]?.jsonPrimitive?.content ?: ""
-            IssueReportResult.Success(issueUrl)
-        } else {
-            IssueReportResult.Error(response.status, responseBody)
-        }
-    }
+        token: String? = null,
+    ): IssueReportResult
 }
+

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/data/TestIssueReporterRepository.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/data/TestIssueReporterRepository.kt
@@ -4,6 +4,7 @@ import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.IssueRepo
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.Report
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.github.ExtraInfo
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.github.GithubTarget
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.data.DefaultIssueReporterRepository
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -32,7 +33,7 @@ class TestIssueReporterRepository {
         val client = HttpClient(engine) {
             install(ContentNegotiation) { json() }
         }
-        val repository = IssueReporterRepository(client)
+        val repository: IssueReporterRepository = DefaultIssueReporterRepository(client)
         val report = Report("title", "desc", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo.create(android.app.Application()), ExtraInfo(), "me@test.com")
         val target = GithubTarget("user", "repo")
         val result = repository.sendReport(report, target, token = "token123")
@@ -48,7 +49,7 @@ class TestIssueReporterRepository {
         println("\uD83D\uDE80 [TEST] repository error")
         val engine = MockEngine { respond("fail", HttpStatusCode.BadRequest) }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
-        val repository = IssueReporterRepository(client)
+        val repository: IssueReporterRepository = DefaultIssueReporterRepository(client)
         val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo.create(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
         val result = repository.sendReport(report, target)
@@ -68,7 +69,7 @@ class TestIssueReporterRepository {
             respond("""{"html_url":"https://example.com/issue/2"}""", HttpStatusCode.Created)
         }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
-        val repository = IssueReporterRepository(client)
+        val repository: IssueReporterRepository = DefaultIssueReporterRepository(client)
         val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo.create(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
 
@@ -82,7 +83,7 @@ class TestIssueReporterRepository {
     fun `sendReport network exception`() = runTest {
         val engine = MockEngine { throw SocketTimeoutException("timeout") }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
-        val repository = IssueReporterRepository(client)
+        val repository: IssueReporterRepository = DefaultIssueReporterRepository(client)
         val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo.create(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
 
@@ -95,7 +96,7 @@ class TestIssueReporterRepository {
     fun `sendReport malformed json`() = runTest {
         val engine = MockEngine { respond("{", HttpStatusCode.Created) }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
-        val repository = IssueReporterRepository(client)
+        val repository: IssueReporterRepository = DefaultIssueReporterRepository(client)
         val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo.create(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
 
@@ -108,7 +109,7 @@ class TestIssueReporterRepository {
     fun `sendReport unsupported status`() = runTest {
         val engine = MockEngine { respond("weird", HttpStatusCode.PaymentRequired) }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
-        val repository = IssueReporterRepository(client)
+        val repository: IssueReporterRepository = DefaultIssueReporterRepository(client)
         val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo.create(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
 
@@ -127,7 +128,7 @@ class TestIssueReporterRepository {
             respond("""{"html_url":"https://ex.com/1"}""", HttpStatusCode.Created)
         }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
-        val repository = IssueReporterRepository(client)
+        val repository: IssueReporterRepository = DefaultIssueReporterRepository(client)
         val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo.create(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
 
@@ -139,7 +140,7 @@ class TestIssueReporterRepository {
     fun `sendReport handles bad gateway`() = runTest {
         val engine = MockEngine { respond("broke", HttpStatusCode.BadGateway) }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
-        val repository = IssueReporterRepository(client)
+        val repository: IssueReporterRepository = DefaultIssueReporterRepository(client)
         val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo.create(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
 
@@ -154,7 +155,7 @@ class TestIssueReporterRepository {
     fun `sendReport handles teapot`() = runTest {
         val engine = MockEngine { respond("hot", HttpStatusCode.fromValue(418)) }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
-        val repository = IssueReporterRepository(client)
+        val repository: IssueReporterRepository = DefaultIssueReporterRepository(client)
         val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo.create(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
 
@@ -169,7 +170,7 @@ class TestIssueReporterRepository {
     fun `sendReport null pointer exception`() = runTest {
         val engine = MockEngine { throw NullPointerException("boom") }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
-        val repository = IssueReporterRepository(client)
+        val repository: IssueReporterRepository = DefaultIssueReporterRepository(client)
         val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo.create(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
 
@@ -182,7 +183,7 @@ class TestIssueReporterRepository {
     fun `sendReport illegal state exception`() = runTest {
         val engine = MockEngine { throw IllegalStateException("illegal") }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
-        val repository = IssueReporterRepository(client)
+        val repository: IssueReporterRepository = DefaultIssueReporterRepository(client)
         val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo.create(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
 
@@ -195,7 +196,7 @@ class TestIssueReporterRepository {
     fun `sendReport unauthorized`() = runTest {
         val engine = MockEngine { respond("unauth", HttpStatusCode.Unauthorized) }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
-        val repository = IssueReporterRepository(client)
+        val repository: IssueReporterRepository = DefaultIssueReporterRepository(client)
         val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo.create(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
 
@@ -210,7 +211,7 @@ class TestIssueReporterRepository {
     fun `sendReport forbidden`() = runTest {
         val engine = MockEngine { respond("stop", HttpStatusCode.Forbidden) }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
-        val repository = IssueReporterRepository(client)
+        val repository: IssueReporterRepository = DefaultIssueReporterRepository(client)
         val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo.create(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
 
@@ -225,7 +226,7 @@ class TestIssueReporterRepository {
     fun `sendReport created without url`() = runTest {
         val engine = MockEngine { respond("{}", HttpStatusCode.Created) }
         val client = HttpClient(engine) { install(ContentNegotiation) { json() } }
-        val repository = IssueReporterRepository(client)
+        val repository: IssueReporterRepository = DefaultIssueReporterRepository(client)
         val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo.create(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
 


### PR DESCRIPTION
## Summary
- Introduce IssueReporterRepository interface and DefaultIssueReporterRepository implementation
- Bind IssueReporterRepository via Koin with new default implementation
- Update repository tests to use new interface

## Testing
- `./gradlew apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af17c0e6a8832dbfc9b0d4fa53b974