### PR TITLE
Use injected dispatchers in issue reporter repository

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppToolkitModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppToolkitModule.kt
@@ -38,7 +38,7 @@ val appToolkitModule : Module = module {
 
     single<AppDispatchers> { AppDispatchersImpl() }
     single<DeviceInfoProvider> { DeviceInfoProviderImpl(get(), get()) }
-    single<IssueReporterRepository> { DefaultIssueReporterRepository(get()) }
+    single<IssueReporterRepository> { DefaultIssueReporterRepository(get(), get()) }
     single { SendIssueReportUseCase(get(), get()) }
 
     val githubTokenQualifier = qualifier<GithubToken>()


### PR DESCRIPTION
## Summary
- run issue reporter network calls on an injected IO dispatcher to keep the main thread unblocked
- provide dispatchers when wiring the repository in Koin
- adjust repository unit tests to use test dispatchers

## Testing
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af640ceba4832db4cb787529fbdae6