### PR TITLE
Fix GitHub token annotation and header interpolation

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/data/DefaultIssueReporterRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/data/DefaultIssueReporterRepository.kt
@@ -32,11 +32,11 @@ class DefaultIssueReporterRepository(
         target: GithubTarget,
         token: String?,
     ): IssueReportResult = withContext(dispatchers.io) {
-        val url = "https://api.github.com/repos/${'$'}{target.username}/${'$'}{target.repository}/issues"
+        val url = "https://api.github.com/repos/${target.username}/${target.repository}/issues"
         val response: HttpResponse = client.post(url) {
             contentType(ContentType.Application.Json)
             header("Accept", "application/vnd.github+json")
-            token?.let { header("Authorization", "Bearer ${'$'}it") }
+            token?.let { header("Authorization", "Bearer $it") }
             val issueRequest = CreateIssueRequest(
                 title = report.title,
                 body = report.getDescription(),

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/IssueReporterViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/IssueReporterViewModel.kt
@@ -31,7 +31,7 @@ import kotlinx.coroutines.launch
 class IssueReporterViewModel(
     private val sendIssueReport: SendIssueReportUseCase,
     private val githubTarget: GithubTarget,
-    @GithubToken private val githubToken: String,
+    @param:GithubToken private val githubToken: String,
     private val deviceInfoProvider: DeviceInfoProvider,
 ) : ScreenViewModel<UiIssueReporterScreen, IssueReporterEvent, IssueReporterAction>(
     initialState = UiStateScreen(


### PR DESCRIPTION
## Summary
- annotate constructor token parameter with @param:GithubToken to suppress Kotlin defaulting warning
- fix GitHub issue reporter to build URL and Authorization header with proper string interpolation

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af66621dd8832dadf195e8826fff5f