### PR TITLE
Use ViewModel coroutine scope for onboarding completion

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingScreen.kt
@@ -38,7 +38,6 @@ import com.d4rk.android.libs.apptoolkit.app.onboarding.ui.components.OnboardingB
 import com.d4rk.android.libs.apptoolkit.app.onboarding.ui.components.pages.OnboardingDefaultPageLayout
 import com.d4rk.android.libs.apptoolkit.app.onboarding.utils.interfaces.providers.OnboardingProvider
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.hapticPagerSwipe
-import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
@@ -55,16 +54,14 @@ fun OnboardingScreen(activity : Activity) {
         initialPage = viewModel.currentTabIndex,
     ) { pages.size }
     LaunchedEffect(pagerState.currentPage) {
-        viewModel.currentTabIndex = pagerState.currentPage
+        viewModel.updateCurrentTab(pagerState.currentPage)
     }
-    val dataStore: CommonDataStore = CommonDataStore.getInstance(context = activity)
     val hapticFeedback : HapticFeedback = LocalHapticFeedback.current
     val view : View = LocalView.current
     val onSkipRequested = {
-        coroutineScope.launch {
-            dataStore.saveStartup(isFirstTime = false)
+        viewModel.completeOnboarding(context = activity) {
+            onboardingProvider.onOnboardingFinished(context = activity)
         }
-        onboardingProvider.onOnboardingFinished(context = activity)
     }
 
     Scaffold(topBar = {
@@ -99,8 +96,7 @@ fun OnboardingScreen(activity : Activity) {
                             pagerState.animateScrollToPage(pagerState.currentPage + 1)
                         }
                     } else {
-                        coroutineScope.launch {
-                            dataStore.saveStartup(isFirstTime = false)
+                        viewModel.completeOnboarding(context = activity) {
                             onboardingProvider.onOnboardingFinished(activity)
                         }
                     }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingViewModel.kt
@@ -1,10 +1,31 @@
 package com.d4rk.android.libs.apptoolkit.app.onboarding.ui
 
+import android.content.Context
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class OnboardingViewModel : ViewModel() {
     var currentTabIndex by mutableIntStateOf(0)
+        private set
+
+    fun updateCurrentTab(index: Int) {
+        currentTabIndex = index
+    }
+
+    fun completeOnboarding(context: Context, onFinished: () -> Unit) {
+        viewModelScope.launch {
+            withContext(Dispatchers.IO) {
+                CommonDataStore.getInstance(context).saveStartup(isFirstTime = false)
+            }
+            onFinished()
+        }
+    }
 }
+


### PR DESCRIPTION
## Summary
- move onboarding completion logic into `OnboardingViewModel` using `viewModelScope` and IO dispatcher
- delegate skip and finish actions from `OnboardingScreen` to the ViewModel

## Testing
- `./gradlew :apptoolkit:build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af6788ea80832d9c05fe01b74734c7