### PR TITLE
Refactor onboarding to follow architecture guidelines

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/data/repository/DefaultOnboardingRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/data/repository/DefaultOnboardingRepository.kt
@@ -1,0 +1,16 @@
+package com.d4rk.android.libs.apptoolkit.app.onboarding.data.repository
+
+import com.d4rk.android.libs.apptoolkit.app.onboarding.domain.repository.OnboardingRepository
+import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
+
+/**
+ * Default implementation of [OnboardingRepository] backed by [CommonDataStore].
+ */
+class DefaultOnboardingRepository(
+    private val dataStore: CommonDataStore
+) : OnboardingRepository {
+
+    override suspend fun setOnboardingCompleted() {
+        dataStore.saveStartup(isFirstTime = false)
+    }
+}

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/domain/repository/OnboardingRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/domain/repository/OnboardingRepository.kt
@@ -1,0 +1,8 @@
+package com.d4rk.android.libs.apptoolkit.app.onboarding.domain.repository
+
+/**
+ * Abstraction for onboarding-related data operations.
+ */
+interface OnboardingRepository {
+    suspend fun setOnboardingCompleted()
+}

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingActivity.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingActivity.kt
@@ -8,6 +8,8 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
 import com.d4rk.android.libs.apptoolkit.app.theme.style.AppTheme
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.ConsentFormHelper
 import com.google.android.ump.ConsentInformation
@@ -15,8 +17,15 @@ import com.google.android.ump.UserMessagingPlatform
 
 class OnboardingActivity : ComponentActivity() {
 
+    private val lifecycleObserver = object : DefaultLifecycleObserver {
+        override fun onResume(owner: LifecycleOwner) {
+            checkUserConsent()
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        lifecycle.addObserver(lifecycleObserver)
         enableEdgeToEdge()
         setContent {
             AppTheme {
@@ -24,20 +33,14 @@ class OnboardingActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize(),
                     color = MaterialTheme.colorScheme.background
                 ) {
-                    OnboardingScreen(activity = this@OnboardingActivity)
+                    OnboardingScreen()
                 }
             }
         }
     }
 
-    override fun onResume() {
-        super.onResume()
-        checkUserConsent()
-        // Recheck permissions when returning to this activity
-    }
-
     private fun checkUserConsent() {
         val consentInfo: ConsentInformation = UserMessagingPlatform.getConsentInformation(this)
-        ConsentFormHelper.showConsentFormIfRequired(activity = this , consentInfo = consentInfo)
+        ConsentFormHelper.showConsentFormIfRequired(activity = this, consentInfo = consentInfo)
     }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingUiState.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingUiState.kt
@@ -1,0 +1,8 @@
+package com.d4rk.android.libs.apptoolkit.app.onboarding.ui
+
+/**
+ * UI state for [OnboardingViewModel].
+ */
+data class OnboardingUiState(
+    val currentTabIndex: Int = 0
+)

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingViewModel.kt
@@ -1,31 +1,46 @@
 package com.d4rk.android.libs.apptoolkit.app.onboarding.ui
 
-import android.content.Context
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.setValue
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
 import androidx.lifecycle.viewModelScope
-import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
-import kotlinx.coroutines.Dispatchers
+import com.d4rk.android.libs.apptoolkit.app.onboarding.domain.repository.OnboardingRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
-class OnboardingViewModel : ViewModel() {
-    var currentTabIndex by mutableIntStateOf(0)
-        private set
+/**
+ * ViewModel for handling onboarding state and actions.
+ *
+ * Exposes [uiState] as a [StateFlow] following unidirectional data flow
+ * and delegates data operations to an [OnboardingRepository].
+ */
+class OnboardingViewModel(
+    private val repository: OnboardingRepository
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow(OnboardingUiState())
+    val uiState: StateFlow<OnboardingUiState> = _uiState.asStateFlow()
 
     fun updateCurrentTab(index: Int) {
-        currentTabIndex = index
+        _uiState.update { it.copy(currentTabIndex = index) }
     }
 
-    fun completeOnboarding(context: Context, onFinished: () -> Unit) {
+    fun completeOnboarding(onFinished: () -> Unit) {
         viewModelScope.launch {
-            withContext(Dispatchers.IO) {
-                CommonDataStore.getInstance(context).saveStartup(isFirstTime = false)
-            }
+            repository.setOnboardingCompleted()
             onFinished()
         }
     }
-}
 
+    companion object {
+        fun provideFactory(repository: OnboardingRepository): ViewModelProvider.Factory =
+            object : ViewModelProvider.Factory {
+                @Suppress("UNCHECKED_CAST")
+                override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                    return OnboardingViewModel(repository) as T
+                }
+            }
+    }
+}

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/TestOnboardingViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/TestOnboardingViewModel.kt
@@ -1,49 +1,66 @@
 package com.d4rk.android.libs.apptoolkit.app.onboarding.ui
 
+import com.d4rk.android.libs.apptoolkit.app.onboarding.domain.repository.OnboardingRepository
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
+
+private class FakeOnboardingRepository : OnboardingRepository {
+    var completed = false
+    override suspend fun setOnboardingCompleted() {
+        completed = true
+    }
+}
 
 class TestOnboardingViewModel {
 
     @Test
     fun `current tab index mutates as expected`() {
         println("🚀 [TEST] current tab index mutates as expected")
-        val viewModel = OnboardingViewModel()
+        val viewModel = OnboardingViewModel(repository = FakeOnboardingRepository())
 
         // Default value
-        assertThat(viewModel.currentTabIndex).isEqualTo(0)
+        assertThat(viewModel.uiState.value.currentTabIndex).isEqualTo(0)
 
         // Changing the index updates the state
-        viewModel.currentTabIndex = 1
-        assertThat(viewModel.currentTabIndex).isEqualTo(1)
+        viewModel.updateCurrentTab(1)
+        assertThat(viewModel.uiState.value.currentTabIndex).isEqualTo(1)
 
         // Negative values are also accepted
-        viewModel.currentTabIndex = -1
-        assertThat(viewModel.currentTabIndex).isEqualTo(-1)
+        viewModel.updateCurrentTab(-1)
+        assertThat(viewModel.uiState.value.currentTabIndex).isEqualTo(-1)
 
         // Extremely large values do not break the model
-        viewModel.currentTabIndex = Int.MAX_VALUE
-        assertThat(viewModel.currentTabIndex).isEqualTo(Int.MAX_VALUE)
+        viewModel.updateCurrentTab(Int.MAX_VALUE)
+        assertThat(viewModel.uiState.value.currentTabIndex).isEqualTo(Int.MAX_VALUE)
 
         // Reset back to default
-        viewModel.currentTabIndex = 0
-        assertThat(viewModel.currentTabIndex).isEqualTo(0)
+        viewModel.updateCurrentTab(0)
+        assertThat(viewModel.uiState.value.currentTabIndex).isEqualTo(0)
         println("🏁 [TEST DONE] current tab index mutates as expected")
     }
 
     @Test
     fun `repeated index changes remain stable`() {
         println("🚀 [TEST] repeated index changes remain stable")
-        val viewModel = OnboardingViewModel()
+        val viewModel = OnboardingViewModel(repository = FakeOnboardingRepository())
 
         repeat(5) { index ->
-            viewModel.currentTabIndex = index
+            viewModel.updateCurrentTab(index)
         }
 
-        assertThat(viewModel.currentTabIndex).isEqualTo(4)
+        assertThat(viewModel.uiState.value.currentTabIndex).isEqualTo(4)
 
-        viewModel.currentTabIndex = 0
-        assertThat(viewModel.currentTabIndex).isEqualTo(0)
+        viewModel.updateCurrentTab(0)
+        assertThat(viewModel.uiState.value.currentTabIndex).isEqualTo(0)
         println("🏁 [TEST DONE] repeated index changes remain stable")
+    }
+
+    @Test
+    fun `complete onboarding calls repository`() = runTest {
+        val repository = FakeOnboardingRepository()
+        val viewModel = OnboardingViewModel(repository = repository)
+        viewModel.completeOnboarding {}
+        assertThat(repository.completed).isTrue()
     }
 }


### PR DESCRIPTION
## Summary
- add OnboardingRepository abstraction with default CommonDataStore implementation
- expose onboarding screen state with StateFlow and inject repository into ViewModel
- collect lifecycle-aware state in OnboardingScreen and remove Activity parameter
- observe activity lifecycle with DefaultLifecycleObserver for consent check
- update tests for new ViewModel API

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af693028e8832dbc6d931ee6023abd