### PR TITLE
feat(onboarding): add flow for onboarding completion

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/data/repository/DefaultOnboardingRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/data/repository/DefaultOnboardingRepository.kt
@@ -2,13 +2,24 @@ package com.d4rk.android.libs.apptoolkit.app.onboarding.data.repository
 
 import com.d4rk.android.libs.apptoolkit.app.onboarding.domain.repository.OnboardingRepository
 import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.flowOn
 
 /**
  * Default implementation of [OnboardingRepository] backed by [CommonDataStore].
  */
 class DefaultOnboardingRepository(
-    private val dataStore: CommonDataStore
+    private val dataStore: CommonDataStore,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : OnboardingRepository {
+
+    override fun observeOnboardingCompletion(): Flow<Boolean> =
+        dataStore.startup
+            .map { isFirstTime -> !isFirstTime }
+            .flowOn(ioDispatcher)
 
     override suspend fun setOnboardingCompleted() {
         dataStore.saveStartup(isFirstTime = false)

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/domain/repository/OnboardingRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/domain/repository/OnboardingRepository.kt
@@ -1,8 +1,11 @@
 package com.d4rk.android.libs.apptoolkit.app.onboarding.domain.repository
 
+import kotlinx.coroutines.flow.Flow
+
 /**
  * Abstraction for onboarding-related data operations.
  */
 interface OnboardingRepository {
+    fun observeOnboardingCompletion(): Flow<Boolean>
     suspend fun setOnboardingCompleted()
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingUiState.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingUiState.kt
@@ -4,5 +4,6 @@ package com.d4rk.android.libs.apptoolkit.app.onboarding.ui
  * UI state for [OnboardingViewModel].
  */
 data class OnboardingUiState(
-    val currentTabIndex: Int = 0
+    val currentTabIndex: Int = 0,
+    val isOnboardingCompleted: Boolean = false
 )

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingViewModel.kt
@@ -7,6 +7,7 @@ import com.d4rk.android.libs.apptoolkit.app.onboarding.domain.repository.Onboard
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
@@ -22,6 +23,16 @@ class OnboardingViewModel(
 
     private val _uiState = MutableStateFlow(OnboardingUiState())
     val uiState: StateFlow<OnboardingUiState> = _uiState.asStateFlow()
+
+    init {
+        viewModelScope.launch {
+            repository.observeOnboardingCompletion()
+                .catch { emit(false) }
+                .collect { completed ->
+                    _uiState.update { it.copy(isOnboardingCompleted = completed) }
+                }
+        }
+    }
 
     fun updateCurrentTab(index: Int) {
         _uiState.update { it.copy(currentTabIndex = index) }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/TestOnboardingViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/TestOnboardingViewModel.kt
@@ -2,20 +2,30 @@ package com.d4rk.android.libs.apptoolkit.app.onboarding.ui
 
 import com.d4rk.android.libs.apptoolkit.app.onboarding.domain.repository.OnboardingRepository
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 private class FakeOnboardingRepository : OnboardingRepository {
     var completed = false
+    private val completion = MutableStateFlow(false)
+
+    override fun observeOnboardingCompletion(): Flow<Boolean> = completion
+
     override suspend fun setOnboardingCompleted() {
         completed = true
+        completion.value = true
     }
 }
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class TestOnboardingViewModel {
 
     @Test
-    fun `current tab index mutates as expected`() {
+    fun `current tab index mutates as expected`() = runTest {
         println("🚀 [TEST] current tab index mutates as expected")
         val viewModel = OnboardingViewModel(repository = FakeOnboardingRepository())
 
@@ -41,7 +51,7 @@ class TestOnboardingViewModel {
     }
 
     @Test
-    fun `repeated index changes remain stable`() {
+    fun `repeated index changes remain stable`() = runTest {
         println("🚀 [TEST] repeated index changes remain stable")
         val viewModel = OnboardingViewModel(repository = FakeOnboardingRepository())
 
@@ -61,6 +71,8 @@ class TestOnboardingViewModel {
         val repository = FakeOnboardingRepository()
         val viewModel = OnboardingViewModel(repository = repository)
         viewModel.completeOnboarding {}
+        advanceUntilIdle()
         assertThat(repository.completed).isTrue()
+        assertThat(viewModel.uiState.value.isOnboardingCompleted).isTrue()
     }
 }


### PR DESCRIPTION
## Summary
- expose onboarding completion as a Flow
- collect completion flow in ViewModel and update UI state
- test ViewModel with flow-based repository

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af6ae84650832dabf1eadc228f3f95