### PR TITLE
Ensure onboarding coroutines are main-safe

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/data/repository/DefaultOnboardingRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/data/repository/DefaultOnboardingRepository.kt
@@ -5,8 +5,9 @@ import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.withContext
 
 /**
  * Default implementation of [OnboardingRepository] backed by [CommonDataStore].
@@ -21,7 +22,7 @@ class DefaultOnboardingRepository(
             .map { isFirstTime -> !isFirstTime }
             .flowOn(ioDispatcher)
 
-    override suspend fun setOnboardingCompleted() {
+    override suspend fun setOnboardingCompleted() = withContext(ioDispatcher) {
         dataStore.saveStartup(isFirstTime = false)
     }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingViewModel.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import java.io.IOException
 
 /**
  * ViewModel for handling onboarding state and actions.
@@ -40,8 +41,12 @@ class OnboardingViewModel(
 
     fun completeOnboarding(onFinished: () -> Unit) {
         viewModelScope.launch {
-            repository.setOnboardingCompleted()
-            onFinished()
+            try {
+                repository.setOnboardingCompleted()
+                onFinished()
+            } catch (e: IOException) {
+                _uiState.update { it.copy(isOnboardingCompleted = false) }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
- run DataStore writes on the injected IO dispatcher
- guard onboarding completion with error handling

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af6c357144832d8eda01395912c79a