### PR TITLE
Refactor permissions module to use Kotlin Flow

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/settings/settings/utils/providers/PermissionsSettingsProvider.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/settings/settings/utils/providers/PermissionsSettingsProvider.kt
@@ -6,11 +6,14 @@ import com.d4rk.android.libs.apptoolkit.app.permissions.utils.interfaces.Permiss
 import com.d4rk.android.libs.apptoolkit.app.settings.settings.domain.model.SettingsCategory
 import com.d4rk.android.libs.apptoolkit.app.settings.settings.domain.model.SettingsConfig
 import com.d4rk.android.libs.apptoolkit.app.settings.settings.domain.model.SettingsPreference
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 
 class PermissionsSettingsProvider : PermissionsProvider {
-    override fun providePermissionsConfig(context : Context) : SettingsConfig {
-        return SettingsConfig(
-            title = context.getString(R.string.permissions) , categories = listOf(
+    override fun providePermissionsConfig(context: Context): Flow<SettingsConfig> {
+        return flowOf(
+            SettingsConfig(
+                title = context.getString(R.string.permissions) , categories = listOf(
                 SettingsCategory(
                     title = context.getString(R.string.normal) ,
                     preferences = listOf(
@@ -61,6 +64,6 @@ class PermissionsSettingsProvider : PermissionsProvider {
                     ) ,
                 )
             )
-        )
+        ))
     }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/permissions/utils/interfaces/PermissionsProvider.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/permissions/utils/interfaces/PermissionsProvider.kt
@@ -2,7 +2,8 @@ package com.d4rk.android.libs.apptoolkit.app.permissions.utils.interfaces
 
 import android.content.Context
 import com.d4rk.android.libs.apptoolkit.app.settings.settings.domain.model.SettingsConfig
+import kotlinx.coroutines.flow.Flow
 
 interface PermissionsProvider {
-    fun providePermissionsConfig(context : Context) : SettingsConfig
+    fun providePermissionsConfig(context: Context): Flow<SettingsConfig>
 }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/permissions/ui/TestPermissionsViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/permissions/ui/TestPermissionsViewModel.kt
@@ -7,10 +7,11 @@ import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.UnconfinedDispatc
 import com.d4rk.android.libs.apptoolkit.app.permissions.domain.actions.PermissionsEvent
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
 import com.google.common.truth.Truth.assertThat
-import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -34,9 +35,9 @@ class TestPermissionsViewModel {
     private fun setup(config: SettingsConfig? = null, error: Throwable? = null, dispatcher: TestDispatcher) {
         provider = mockk()
         if (error != null) {
-            coEvery { provider.providePermissionsConfig(any()) } throws error
+            every { provider.providePermissionsConfig(any()) } returns flow { throw error }
         } else {
-            every { provider.providePermissionsConfig(any()) } returns config!!
+            every { provider.providePermissionsConfig(any()) } returns flowOf(config!!)
         }
         viewModel = PermissionsViewModel(provider, dispatcher)
     }


### PR DESCRIPTION
## Summary
- model permissions provider as a Flow stream
- load permissions in ViewModel using Flow operators
- adjust tests for Flow-based APIs

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af6d9d5e38832d9e63e1441d58f6fb