### PR TITLE
Refactor permissions module to avoid Context in ViewModel

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/settings/settings/utils/providers/PermissionsSettingsProvider.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/settings/settings/utils/providers/PermissionsSettingsProvider.kt
@@ -9,8 +9,13 @@ import com.d4rk.android.libs.apptoolkit.app.settings.settings.domain.model.Setti
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
 
-class PermissionsSettingsProvider : PermissionsProvider {
-    override fun providePermissionsConfig(context: Context): Flow<SettingsConfig> {
+/**
+ * Default implementation of [PermissionsProvider] that builds the permissions
+ * configuration using string resources from the provided [Context].
+ */
+class PermissionsSettingsProvider(private val context: Context) : PermissionsProvider {
+
+    override fun providePermissionsConfig(): Flow<SettingsConfig> {
         return flowOf(
             SettingsConfig(
                 title = context.getString(R.string.permissions) , categories = listOf(

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/SettingsModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/SettingsModule.kt
@@ -43,7 +43,7 @@ val settingsModule = module {
         GeneralSettingsViewModel()
     }
 
-    single<PermissionsProvider> { PermissionsSettingsProvider() }
+    single<PermissionsProvider> { PermissionsSettingsProvider(context = get()) }
     viewModel {
         PermissionsViewModel(
             settingsProvider = get(),

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/permissions/domain/actions/PermissionsEvent.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/permissions/domain/actions/PermissionsEvent.kt
@@ -1,8 +1,17 @@
 package com.d4rk.android.libs.apptoolkit.app.permissions.domain.actions
 
-import android.content.Context
 import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.UiEvent
 
+/**
+ * Events that [PermissionsViewModel] can react to.
+ *
+ * Keeping events free of any Android framework dependencies ensures the
+ * ViewModel remains agnostic of the Android lifecycle as recommended by the
+ * Android architecture guidelines.
+ */
 sealed interface PermissionsEvent : UiEvent {
-    data class Load(val context : Context) : PermissionsEvent
+    /**
+     * Requests that the ViewModel loads the permissions configuration.
+     */
+    data object Load : PermissionsEvent
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/permissions/ui/PermissionsActivity.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/permissions/ui/PermissionsActivity.kt
@@ -16,7 +16,7 @@ class PermissionsActivity : AppCompatActivity() {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
 
-        viewModel.onEvent(PermissionsEvent.Load(context = this))
+        viewModel.onEvent(PermissionsEvent.Load)
 
         setContent {
             AppTheme {

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/permissions/ui/PermissionsScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/permissions/ui/PermissionsScreen.kt
@@ -42,7 +42,7 @@ fun PermissionsScreen(viewModel : PermissionsViewModel) {
         ScreenStateHandler(screenState = screenState , onLoading = { LoadingScreen() } , onEmpty = {
             NoDataScreen(
                 icon = Icons.Outlined.Settings , showRetry = true , onRetry = {
-                    viewModel.onEvent(PermissionsEvent.Load(context = context))
+                    viewModel.onEvent(PermissionsEvent.Load)
                 })
         } , onSuccess = { settingsConfig ->
             PermissionsContent(paddingValues , settingsConfig)

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/permissions/ui/PermissionsViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/permissions/ui/PermissionsViewModel.kt
@@ -1,6 +1,5 @@
 package com.d4rk.android.libs.apptoolkit.app.permissions.ui
 
-import android.content.Context
 import androidx.lifecycle.viewModelScope
 import com.d4rk.android.libs.apptoolkit.app.permissions.domain.actions.PermissionsAction
 import com.d4rk.android.libs.apptoolkit.app.permissions.domain.actions.PermissionsEvent
@@ -16,10 +15,10 @@ import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.launch
 
 
 class PermissionsViewModel(
@@ -32,13 +31,13 @@ class PermissionsViewModel(
 
     override fun onEvent(event : PermissionsEvent) {
         when (event) {
-            is PermissionsEvent.Load -> loadPermissions(context = event.context)
+            PermissionsEvent.Load -> loadPermissions()
         }
     }
 
-    private fun loadPermissions(context: Context) {
+    private fun loadPermissions() {
         viewModelScope.launch {
-            settingsProvider.providePermissionsConfig(context)
+            settingsProvider.providePermissionsConfig()
                 .flowOn(dispatcher)
                 .catch { error ->
                     screenState.setErrors(

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/permissions/utils/interfaces/PermissionsProvider.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/permissions/utils/interfaces/PermissionsProvider.kt
@@ -1,9 +1,14 @@
 package com.d4rk.android.libs.apptoolkit.app.permissions.utils.interfaces
 
-import android.content.Context
 import com.d4rk.android.libs.apptoolkit.app.settings.settings.domain.model.SettingsConfig
 import kotlinx.coroutines.flow.Flow
 
+/**
+ * Abstraction for providing the permissions configuration to the UI layer.
+ *
+ * Implementations should be free of Android framework dependencies so the
+ * ViewModel can obtain the configuration without requiring a [Context].
+ */
 interface PermissionsProvider {
-    fun providePermissionsConfig(context: Context): Flow<SettingsConfig>
+    fun providePermissionsConfig(): Flow<SettingsConfig>
 }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/permissions/ui/TestPermissionsViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/permissions/ui/TestPermissionsViewModel.kt
@@ -15,7 +15,6 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
-import android.content.Context
 import org.junit.jupiter.api.extension.RegisterExtension
 import org.junit.jupiter.api.Test
 import kotlin.OptIn
@@ -35,9 +34,9 @@ class TestPermissionsViewModel {
     private fun setup(config: SettingsConfig? = null, error: Throwable? = null, dispatcher: TestDispatcher) {
         provider = mockk()
         if (error != null) {
-            every { provider.providePermissionsConfig(any()) } returns flow { throw error }
+            every { provider.providePermissionsConfig() } returns flow { throw error }
         } else {
-            every { provider.providePermissionsConfig(any()) } returns flowOf(config!!)
+            every { provider.providePermissionsConfig() } returns flowOf(config!!)
         }
         viewModel = PermissionsViewModel(provider, dispatcher)
     }
@@ -45,10 +44,9 @@ class TestPermissionsViewModel {
     @Test
     fun `load permissions success`() = runTest(dispatcherExtension.testDispatcher) {
         val config = SettingsConfig(title = "P", categories = listOf(SettingsCategory(title = "c", preferences = emptyList())))
-        val context = mockk<Context>(relaxed = true)
         setup(config = config, dispatcher = dispatcherExtension.testDispatcher)
 
-        viewModel.onEvent(PermissionsEvent.Load(context))
+        viewModel.onEvent(PermissionsEvent.Load)
         advanceUntilIdle()
 
         assertThat(viewModel.uiState.value.data?.title).isEqualTo("P")
@@ -57,10 +55,9 @@ class TestPermissionsViewModel {
 
     @Test
     fun `load permissions error`() = runTest(dispatcherExtension.testDispatcher) {
-        val context = mockk<Context>(relaxed = true)
         setup(error = RuntimeException("fail"), dispatcher = dispatcherExtension.testDispatcher)
 
-        viewModel.onEvent(PermissionsEvent.Load(context))
+        viewModel.onEvent(PermissionsEvent.Load)
         advanceUntilIdle()
 
         assertThat(viewModel.uiState.value.screenState).isInstanceOf(ScreenState.Error::class.java)


### PR DESCRIPTION
## Summary
- decouple permissions ViewModel from Android framework by removing Context from events
- inject Context into PermissionsSettingsProvider and adjust DI setup
- update tests and UI to use new Load event

## Testing
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af6edcb264832d82dc4820facbb474