### PR TITLE
refactor: use Flow builder for permissions config

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/settings/settings/utils/providers/PermissionsSettingsRepository.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/settings/settings/utils/providers/PermissionsSettingsRepository.kt
@@ -6,74 +6,81 @@ import com.d4rk.android.libs.apptoolkit.app.permissions.data.PermissionsReposito
 import com.d4rk.android.libs.apptoolkit.app.settings.settings.domain.model.SettingsCategory
 import com.d4rk.android.libs.apptoolkit.app.settings.settings.domain.model.SettingsConfig
 import com.d4rk.android.libs.apptoolkit.app.settings.settings.domain.model.SettingsPreference
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
 
 /**
  * Default implementation of [PermissionsRepository] that builds the permissions
  * configuration using string resources from the provided [Context].
  */
-class PermissionsSettingsRepository(private val context: Context) : PermissionsRepository {
+class PermissionsSettingsRepository(
+    private val context: Context,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : PermissionsRepository {
 
-    override fun getPermissionsConfig(): Flow<SettingsConfig> {
-        return flowOf(
-            SettingsConfig(
-                title = context.getString(R.string.permissions),
-                categories = listOf(
-                    SettingsCategory(
-                        title = context.getString(R.string.normal),
-                        preferences = listOf(
-                            SettingsPreference(
-                                title = context.getString(R.string.access_network_state),
-                                summary = context.getString(R.string.summary_preference_permissions_access_network_state),
-                            ),
-                            SettingsPreference(
-                                title = context.getString(R.string.ad_id),
-                                summary = context.getString(R.string.summary_preference_permissions_ad_id),
-                            ),
-                            SettingsPreference(
-                                title = context.getString(R.string.billing),
-                                summary = context.getString(R.string.summary_preference_permissions_billing),
-                            ),
-                            SettingsPreference(
-                                title = context.getString(R.string.check_license),
-                                summary = context.getString(R.string.summary_preference_permissions_check_license),
-                            ),
-                            SettingsPreference(
-                                title = context.getString(R.string.foreground_service),
-                                summary = context.getString(R.string.summary_preference_permissions_foreground_service),
-                            ),
-                            SettingsPreference(
-                                title = context.getString(R.string.internet),
-                                summary = context.getString(R.string.summary_preference_permissions_internet),
-                            ),
-                            SettingsPreference(
-                                title = context.getString(R.string.wake_lock),
-                                summary = context.getString(R.string.summary_preference_permissions_wake_lock),
-                            ),
-                        ),
-                    ),
-                    SettingsCategory(
-                        title = context.getString(R.string.runtime),
-                        preferences = listOf(
-                            SettingsPreference(
-                                title = context.getString(R.string.post_notifications),
-                                summary = context.getString(R.string.summary_preference_permissions_post_notifications),
+    override fun getPermissionsConfig(): Flow<SettingsConfig> =
+        flow {
+            emit(
+                SettingsConfig(
+                    title = context.getString(R.string.permissions),
+                    categories = listOf(
+                        SettingsCategory(
+                            title = context.getString(R.string.normal),
+                            preferences = listOf(
+                                SettingsPreference(
+                                    title = context.getString(R.string.access_network_state),
+                                    summary = context.getString(R.string.summary_preference_permissions_access_network_state),
+                                ),
+                                SettingsPreference(
+                                    title = context.getString(R.string.ad_id),
+                                    summary = context.getString(R.string.summary_preference_permissions_ad_id),
+                                ),
+                                SettingsPreference(
+                                    title = context.getString(R.string.billing),
+                                    summary = context.getString(R.string.summary_preference_permissions_billing),
+                                ),
+                                SettingsPreference(
+                                    title = context.getString(R.string.check_license),
+                                    summary = context.getString(R.string.summary_preference_permissions_check_license),
+                                ),
+                                SettingsPreference(
+                                    title = context.getString(R.string.foreground_service),
+                                    summary = context.getString(R.string.summary_preference_permissions_foreground_service),
+                                ),
+                                SettingsPreference(
+                                    title = context.getString(R.string.internet),
+                                    summary = context.getString(R.string.summary_preference_permissions_internet),
+                                ),
+                                SettingsPreference(
+                                    title = context.getString(R.string.wake_lock),
+                                    summary = context.getString(R.string.summary_preference_permissions_wake_lock),
+                                ),
                             ),
                         ),
-                    ),
-                    SettingsCategory(
-                        title = context.getString(R.string.special),
-                        preferences = listOf(
-                            SettingsPreference(
-                                title = context.getString(R.string.access_notification_policy),
-                                summary = context.getString(R.string.summary_preference_permissions_access_notification_policy),
+                        SettingsCategory(
+                            title = context.getString(R.string.runtime),
+                            preferences = listOf(
+                                SettingsPreference(
+                                    title = context.getString(R.string.post_notifications),
+                                    summary = context.getString(R.string.summary_preference_permissions_post_notifications),
+                                ),
+                            ),
+                        ),
+                        SettingsCategory(
+                            title = context.getString(R.string.special),
+                            preferences = listOf(
+                                SettingsPreference(
+                                    title = context.getString(R.string.access_notification_policy),
+                                    summary = context.getString(R.string.summary_preference_permissions_access_notification_policy),
+                                ),
                             ),
                         ),
                     ),
                 ),
-            ),
-        )
-    }
+            )
+        }.flowOn(dispatcher)
 }
 

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/SettingsModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/SettingsModule.kt
@@ -43,11 +43,10 @@ val settingsModule = module {
         GeneralSettingsViewModel()
     }
 
-    single<PermissionsRepository> { PermissionsSettingsRepository(context = get()) }
+    single<PermissionsRepository> { PermissionsSettingsRepository(context = get(), dispatcher = get(named("io"))) }
     viewModel {
         PermissionsViewModel(
             permissionsRepository = get(),
-            dispatcher = get(named("io"))
         )
     }
 

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/permissions/ui/PermissionsViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/permissions/ui/PermissionsViewModel.kt
@@ -13,17 +13,13 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.successData
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.updateState
 import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.launch
 
 
 /** ViewModel responsible for exposing the permissions configuration to the UI layer. */
 class PermissionsViewModel(
     private val permissionsRepository: PermissionsRepository,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) :
     ScreenViewModel<SettingsConfig, PermissionsEvent, PermissionsAction>(
         initialState = UiStateScreen(data = SettingsConfig(title = "", categories = emptyList()))
@@ -38,7 +34,6 @@ class PermissionsViewModel(
     private fun loadPermissions() {
         viewModelScope.launch {
             permissionsRepository.getPermissionsConfig()
-                .flowOn(dispatcher)
                 .catch { error ->
                     screenState.setErrors(
                         listOf(

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/permissions/ui/TestPermissionsViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/permissions/ui/TestPermissionsViewModel.kt
@@ -12,7 +12,6 @@ import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.extension.RegisterExtension
@@ -31,20 +30,20 @@ class TestPermissionsViewModel {
     private lateinit var viewModel: PermissionsViewModel
     private lateinit var repository: PermissionsRepository
 
-    private fun setup(config: SettingsConfig? = null, error: Throwable? = null, dispatcher: TestDispatcher) {
+    private fun setup(config: SettingsConfig? = null, error: Throwable? = null) {
         repository = mockk()
         if (error != null) {
             every { repository.getPermissionsConfig() } returns flow { throw error }
         } else {
             every { repository.getPermissionsConfig() } returns flowOf(config!!)
         }
-        viewModel = PermissionsViewModel(repository, dispatcher)
+        viewModel = PermissionsViewModel(repository)
     }
 
     @Test
     fun `load permissions success`() = runTest(dispatcherExtension.testDispatcher) {
         val config = SettingsConfig(title = "P", categories = listOf(SettingsCategory(title = "c", preferences = emptyList())))
-        setup(config = config, dispatcher = dispatcherExtension.testDispatcher)
+        setup(config = config)
 
         viewModel.onEvent(PermissionsEvent.Load)
         advanceUntilIdle()
@@ -55,7 +54,7 @@ class TestPermissionsViewModel {
 
     @Test
     fun `load permissions error`() = runTest(dispatcherExtension.testDispatcher) {
-        setup(error = RuntimeException("fail"), dispatcher = dispatcherExtension.testDispatcher)
+        setup(error = RuntimeException("fail"))
 
         viewModel.onEvent(PermissionsEvent.Load)
         advanceUntilIdle()


### PR DESCRIPTION
## Summary
- use flow builder and io dispatcher in PermissionsSettingsRepository
- simplify PermissionsViewModel by collecting repository flow on main
- update Koin module and tests for new repository and ViewModel signatures

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af719d705c832d975f9beb753f984f