### PR TITLE
refactor: use repository for general settings

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/SettingsModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/SettingsModule.kt
@@ -11,6 +11,8 @@ import com.d4rk.android.libs.apptoolkit.app.about.ui.AboutViewModel
 import com.d4rk.android.libs.apptoolkit.app.permissions.ui.PermissionsViewModel
 import com.d4rk.android.libs.apptoolkit.app.permissions.data.PermissionsRepository
 import com.d4rk.android.libs.apptoolkit.app.settings.general.ui.GeneralSettingsViewModel
+import com.d4rk.android.libs.apptoolkit.app.settings.general.domain.repository.DefaultGeneralSettingsRepository
+import com.d4rk.android.libs.apptoolkit.app.settings.general.domain.repository.GeneralSettingsRepository
 import com.d4rk.android.libs.apptoolkit.app.settings.settings.ui.SettingsViewModel
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.interfaces.SettingsProvider
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.AboutSettingsProvider
@@ -39,8 +41,9 @@ val settingsModule = module {
     single<PrivacySettingsProvider> { AppPrivacySettingsProvider(context = get()) }
     single<BuildInfoProvider> { AppBuildInfoProvider(context = get()) }
     single<GeneralSettingsContentProvider> { GeneralSettingsContentProvider(deviceProvider = get() , advancedProvider = get() , displayProvider = get() , privacyProvider = get() , configProvider = get()) }
+    single<GeneralSettingsRepository> { DefaultGeneralSettingsRepository() }
     viewModel {
-        GeneralSettingsViewModel()
+        GeneralSettingsViewModel(repository = get())
     }
 
     single<PermissionsRepository> { PermissionsSettingsRepository(context = get(), dispatcher = get(named("io"))) }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/settings/general/domain/repository/GeneralSettingsRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/settings/general/domain/repository/GeneralSettingsRepository.kt
@@ -1,0 +1,34 @@
+package com.d4rk.android.libs.apptoolkit.app.settings.general.domain.repository
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+
+/**
+ * Repository responsible for providing the content key for the General Settings screen.
+ *
+ * This implementation performs a lightweight validation on the provided key and
+ * emits it as a [Flow]. Using a repository keeps data operations off the UI layer
+ * and allows injection of a [CoroutineDispatcher] for easier testing.
+ */
+interface GeneralSettingsRepository {
+    /**
+     * Returns a [Flow] that emits a valid content key. If the provided key is null
+     * or blank, the flow throws an [IllegalArgumentException].
+     */
+    fun loadContent(contentKey: String?): Flow<String>
+}
+
+class DefaultGeneralSettingsRepository(
+    private val dispatcher: CoroutineDispatcher = Dispatchers.Default
+) : GeneralSettingsRepository {
+    override fun loadContent(contentKey: String?): Flow<String> = flow {
+        if (contentKey.isNullOrBlank()) {
+            throw IllegalArgumentException("Invalid content key")
+        }
+        emit(contentKey)
+    }.flowOn(dispatcher)
+}
+

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/TestGeneralSettingsViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/TestGeneralSettingsViewModel.kt
@@ -5,6 +5,7 @@ import com.d4rk.android.libs.apptoolkit.app.settings.general.domain.actions.Gene
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
 import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.UnconfinedDispatcherExtension
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
+import com.d4rk.android.libs.apptoolkit.app.settings.general.domain.repository.DefaultGeneralSettingsRepository
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
@@ -21,7 +22,9 @@ class TestGeneralSettingsViewModel {
     @Test
     fun `load content success`() = runTest(dispatcherExtension.testDispatcher) {
         println("🚀 [TEST] load content success")
-        val viewModel = GeneralSettingsViewModel()
+        val viewModel = GeneralSettingsViewModel(
+            repository = DefaultGeneralSettingsRepository(dispatcherExtension.testDispatcher)
+        )
         viewModel.onEvent(GeneralSettingsEvent.Load("key"))
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
         val state = viewModel.uiState.value
@@ -33,7 +36,9 @@ class TestGeneralSettingsViewModel {
     @Test
     fun `load content invalid`() = runTest(dispatcherExtension.testDispatcher) {
         println("🚀 [TEST] load content invalid")
-        val viewModel = GeneralSettingsViewModel()
+        val viewModel = GeneralSettingsViewModel(
+            repository = DefaultGeneralSettingsRepository(dispatcherExtension.testDispatcher)
+        )
         viewModel.onEvent(GeneralSettingsEvent.Load(null))
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
         val state = viewModel.uiState.value
@@ -46,7 +51,9 @@ class TestGeneralSettingsViewModel {
     @Test
     fun `load content blank`() = runTest(dispatcherExtension.testDispatcher) {
         println("🚀 [TEST] load content blank")
-        val viewModel = GeneralSettingsViewModel()
+        val viewModel = GeneralSettingsViewModel(
+            repository = DefaultGeneralSettingsRepository(dispatcherExtension.testDispatcher)
+        )
         viewModel.onEvent(GeneralSettingsEvent.Load(""))
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
         val state = viewModel.uiState.value
@@ -59,7 +66,9 @@ class TestGeneralSettingsViewModel {
     @Test
     fun `multiple load calls update key`() = runTest(dispatcherExtension.testDispatcher) {
         println("🚀 [TEST] multiple load calls update key")
-        val viewModel = GeneralSettingsViewModel()
+        val viewModel = GeneralSettingsViewModel(
+            repository = DefaultGeneralSettingsRepository(dispatcherExtension.testDispatcher)
+        )
         viewModel.onEvent(GeneralSettingsEvent.Load("one"))
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
         var state = viewModel.uiState.value
@@ -75,7 +84,9 @@ class TestGeneralSettingsViewModel {
     @Test
     fun `errors cleared after successful load`() = runTest(dispatcherExtension.testDispatcher) {
         println("🚀 [TEST] errors cleared after successful load")
-        val viewModel = GeneralSettingsViewModel()
+        val viewModel = GeneralSettingsViewModel(
+            repository = DefaultGeneralSettingsRepository(dispatcherExtension.testDispatcher)
+        )
         viewModel.onEvent(GeneralSettingsEvent.Load(""))
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
         var state = viewModel.uiState.value
@@ -92,7 +103,9 @@ class TestGeneralSettingsViewModel {
     @Test
     fun `content persists across config changes`() = runTest(dispatcherExtension.testDispatcher) {
         println("🚀 [TEST] content persists across config changes")
-        val viewModel = GeneralSettingsViewModel()
+        val viewModel = GeneralSettingsViewModel(
+            repository = DefaultGeneralSettingsRepository(dispatcherExtension.testDispatcher)
+        )
         viewModel.onEvent(GeneralSettingsEvent.Load("rotate"))
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
         val stateBefore = viewModel.uiState.value
@@ -106,7 +119,9 @@ class TestGeneralSettingsViewModel {
     @Test
     fun `reload with same key retains state`() = runTest(dispatcherExtension.testDispatcher) {
         println("🚀 [TEST] reload with same key retains state")
-        val viewModel = GeneralSettingsViewModel()
+        val viewModel = GeneralSettingsViewModel(
+            repository = DefaultGeneralSettingsRepository(dispatcherExtension.testDispatcher)
+        )
         viewModel.onEvent(GeneralSettingsEvent.Load("keep"))
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
         val stateBefore = viewModel.uiState.value
@@ -121,7 +136,9 @@ class TestGeneralSettingsViewModel {
     @Test
     fun `load extremely long content key`() = runTest(dispatcherExtension.testDispatcher) {
         println("🚀 [TEST] load extremely long content key")
-        val viewModel = GeneralSettingsViewModel()
+        val viewModel = GeneralSettingsViewModel(
+            repository = DefaultGeneralSettingsRepository(dispatcherExtension.testDispatcher)
+        )
         val longKey = "a".repeat(1000)
         viewModel.onEvent(GeneralSettingsEvent.Load(longKey))
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
@@ -134,7 +151,9 @@ class TestGeneralSettingsViewModel {
     @Test
     fun `load content key with special characters`() = runTest(dispatcherExtension.testDispatcher) {
         println("🚀 [TEST] load content key with special characters")
-        val viewModel = GeneralSettingsViewModel()
+        val viewModel = GeneralSettingsViewModel(
+            repository = DefaultGeneralSettingsRepository(dispatcherExtension.testDispatcher)
+        )
         val key = "!@#$%^&*()_+漢字"
         viewModel.onEvent(GeneralSettingsEvent.Load(key))
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
@@ -147,7 +166,9 @@ class TestGeneralSettingsViewModel {
     @Test
     fun `concurrent load events yield latest state`() = runTest(dispatcherExtension.testDispatcher) {
         println("🚀 [TEST] concurrent load events yield latest state")
-        val viewModel = GeneralSettingsViewModel()
+        val viewModel = GeneralSettingsViewModel(
+            repository = DefaultGeneralSettingsRepository(dispatcherExtension.testDispatcher)
+        )
         viewModel.onEvent(GeneralSettingsEvent.Load("first"))
         viewModel.onEvent(GeneralSettingsEvent.Load("second"))
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()


### PR DESCRIPTION
## Summary
- introduce `GeneralSettingsRepository` with coroutine Flow for validating and emitting content key
- refactor `GeneralSettingsViewModel` to consume repository flow with structured concurrency and error handling
- wire repository via Koin and update tests

## Testing
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af74f7f5d0832dae33bd753e484d06