### PR TITLE
Add repository tests and align general settings data flow naming

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/settings/general/domain/repository/GeneralSettingsRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/settings/general/domain/repository/GeneralSettingsRepository.kt
@@ -10,21 +10,21 @@ import kotlinx.coroutines.flow.flowOn
  * Repository responsible for providing the content key for the General Settings screen.
  *
  * This implementation performs a lightweight validation on the provided key and
- * emits it as a [Flow]. Using a repository keeps data operations off the UI layer
- * and allows injection of a [CoroutineDispatcher] for easier testing.
+ * exposes it as a cold [Flow]. Using a repository keeps data operations off the
+ * UI layer and allows injection of a [CoroutineDispatcher] for easier testing.
  */
 interface GeneralSettingsRepository {
     /**
-     * Returns a [Flow] that emits a valid content key. If the provided key is null
-     * or blank, the flow throws an [IllegalArgumentException].
+     * Returns a [Flow] that emits a valid content key. If the provided key is
+     * null or blank, the flow throws an [IllegalArgumentException].
      */
-    fun loadContent(contentKey: String?): Flow<String>
+    fun getContentKeyStream(contentKey: String?): Flow<String>
 }
 
 class DefaultGeneralSettingsRepository(
     private val dispatcher: CoroutineDispatcher = Dispatchers.Default
 ) : GeneralSettingsRepository {
-    override fun loadContent(contentKey: String?): Flow<String> = flow {
+    override fun getContentKeyStream(contentKey: String?): Flow<String> = flow {
         if (contentKey.isNullOrBlank()) {
             throw IllegalArgumentException("Invalid content key")
         }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/GeneralSettingsViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/GeneralSettingsViewModel.kt
@@ -37,7 +37,7 @@ class GeneralSettingsViewModel(
     private fun loadContent(contentKey: String?) {
         loadJob?.cancel()
         loadJob = viewModelScope.launch {
-            repository.loadContent(contentKey)
+            repository.getContentKeyStream(contentKey)
                 .onStart { screenState.setLoading() }
                 .catch {
                     screenState.setErrors(

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/settings/general/domain/repository/TestGeneralSettingsRepository.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/settings/general/domain/repository/TestGeneralSettingsRepository.kt
@@ -1,0 +1,41 @@
+package com.d4rk.android.libs.apptoolkit.app.settings.general.domain.repository
+
+import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.UnconfinedDispatcherExtension
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.junit.jupiter.api.extension.RegisterExtension
+
+class TestGeneralSettingsRepository {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val dispatcherExtension = UnconfinedDispatcherExtension()
+    }
+
+    @Test
+    fun `getContentKeyStream emits provided key`() = runTest(dispatcherExtension.testDispatcher) {
+        val repository = DefaultGeneralSettingsRepository(dispatcherExtension.testDispatcher)
+        val result = repository.getContentKeyStream("valid").first()
+        assertThat(result).isEqualTo("valid")
+    }
+
+    @Test
+    fun `getContentKeyStream throws on null key`() = runTest(dispatcherExtension.testDispatcher) {
+        val repository = DefaultGeneralSettingsRepository(dispatcherExtension.testDispatcher)
+        assertThrows<IllegalArgumentException> {
+            repository.getContentKeyStream(null).first()
+        }
+    }
+
+    @Test
+    fun `getContentKeyStream throws on blank key`() = runTest(dispatcherExtension.testDispatcher) {
+        val repository = DefaultGeneralSettingsRepository(dispatcherExtension.testDispatcher)
+        assertThrows<IllegalArgumentException> {
+            repository.getContentKeyStream("").first()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Rename general settings repository stream function to `getContentKeyStream` for clearer flow naming
- Update view model to use the new repository method
- Add unit tests for `DefaultGeneralSettingsRepository`

## Testing
- `./gradlew apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af819e1950832d9e3e548d15939fb4