### PR TITLE
Refactor general settings repository to suspend function

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/settings/general/domain/repository/GeneralSettingsRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/settings/general/domain/repository/GeneralSettingsRepository.kt
@@ -2,33 +2,32 @@ package com.d4rk.android.libs.apptoolkit.app.settings.general.domain.repository
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.withContext
 
 /**
  * Repository responsible for providing the content key for the General Settings screen.
  *
  * This implementation performs a lightweight validation on the provided key and
- * exposes it as a cold [Flow]. Using a repository keeps data operations off the
- * UI layer and allows injection of a [CoroutineDispatcher] for easier testing.
+ * executes the work on the provided [CoroutineDispatcher] to keep data
+ * operations off the UI layer and allow easier testing.
  */
 interface GeneralSettingsRepository {
     /**
-     * Returns a [Flow] that emits a valid content key. If the provided key is
-     * null or blank, the flow throws an [IllegalArgumentException].
+     * Returns a valid content key. If the provided key is null or blank, the
+     * function throws an [IllegalArgumentException]. This function is marked as
+     * [suspend] to ensure callers handle it from within a coroutine.
      */
-    fun getContentKeyStream(contentKey: String?): Flow<String>
+    suspend fun getContentKey(contentKey: String?): String
 }
 
 class DefaultGeneralSettingsRepository(
     private val dispatcher: CoroutineDispatcher = Dispatchers.Default
 ) : GeneralSettingsRepository {
-    override fun getContentKeyStream(contentKey: String?): Flow<String> = flow {
+    override suspend fun getContentKey(contentKey: String?): String = withContext(dispatcher) {
         if (contentKey.isNullOrBlank()) {
             throw IllegalArgumentException("Invalid content key")
         }
-        emit(contentKey)
-    }.flowOn(dispatcher)
+        contentKey
+    }
 }
 

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/GeneralSettingsViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/GeneralSettingsViewModel.kt
@@ -16,8 +16,6 @@ import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
 import com.d4rk.android.libs.apptoolkit.app.settings.general.domain.repository.GeneralSettingsRepository
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 
 class GeneralSettingsViewModel(
@@ -37,26 +35,26 @@ class GeneralSettingsViewModel(
     private fun loadContent(contentKey: String?) {
         loadJob?.cancel()
         loadJob = viewModelScope.launch {
-            repository.getContentKeyStream(contentKey)
-                .onStart { screenState.setLoading() }
-                .catch {
-                    screenState.setErrors(
-                        errors = listOf(
-                            UiSnackbar(
-                                message = UiTextHelper.StringResource(
-                                    resourceId = R.string.error_invalid_content_key
-                                )
+            screenState.setLoading()
+            val key : String = try {
+                repository.getContentKey(contentKey)
+            } catch (e : Exception) {
+                screenState.setErrors(
+                    errors = listOf(
+                        UiSnackbar(
+                            message = UiTextHelper.StringResource(
+                                resourceId = R.string.error_invalid_content_key
                             )
                         )
                     )
-                    screenState.updateState(newValues = ScreenState.NoData())
-                }
-                .collect { key ->
-                    screenState.setErrors(errors = emptyList())
-                    screenState.updateData(newState = ScreenState.Success()) { current: UiGeneralSettingsScreen ->
-                        current.copy(contentKey = key)
-                    }
-                }
+                )
+                screenState.updateState(newValues = ScreenState.NoData())
+                return@launch
+            }
+            screenState.setErrors(errors = emptyList())
+            screenState.updateData(newState = ScreenState.Success()) { current : UiGeneralSettingsScreen ->
+                current.copy(contentKey = key)
+            }
         }
     }
 }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/settings/general/domain/repository/TestGeneralSettingsRepository.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/settings/general/domain/repository/TestGeneralSettingsRepository.kt
@@ -2,7 +2,6 @@ package com.d4rk.android.libs.apptoolkit.app.settings.general.domain.repository
 
 import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.UnconfinedDispatcherExtension
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -17,25 +16,25 @@ class TestGeneralSettingsRepository {
     }
 
     @Test
-    fun `getContentKeyStream emits provided key`() = runTest(dispatcherExtension.testDispatcher) {
+    fun `getContentKey returns provided key`() = runTest(dispatcherExtension.testDispatcher) {
         val repository = DefaultGeneralSettingsRepository(dispatcherExtension.testDispatcher)
-        val result = repository.getContentKeyStream("valid").first()
+        val result = repository.getContentKey("valid")
         assertThat(result).isEqualTo("valid")
     }
 
     @Test
-    fun `getContentKeyStream throws on null key`() = runTest(dispatcherExtension.testDispatcher) {
+    fun `getContentKey throws on null key`() = runTest(dispatcherExtension.testDispatcher) {
         val repository = DefaultGeneralSettingsRepository(dispatcherExtension.testDispatcher)
         assertThrows<IllegalArgumentException> {
-            repository.getContentKeyStream(null).first()
+            repository.getContentKey(null)
         }
     }
 
     @Test
-    fun `getContentKeyStream throws on blank key`() = runTest(dispatcherExtension.testDispatcher) {
+    fun `getContentKey throws on blank key`() = runTest(dispatcherExtension.testDispatcher) {
         val repository = DefaultGeneralSettingsRepository(dispatcherExtension.testDispatcher)
         assertThrows<IllegalArgumentException> {
-            repository.getContentKeyStream("").first()
+            repository.getContentKey("")
         }
     }
 }


### PR DESCRIPTION
## Summary
- refactor GeneralSettingsRepository to use a suspend function with injected dispatcher
- update GeneralSettingsViewModel to call repository within a coroutine and handle errors with try/catch
- adjust unit tests for new suspend API

## Testing
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af82835af0832db41b9976dce43c2a