### PR TITLE
Refactor general settings data flow

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/settings/general/domain/repository/GeneralSettingsRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/settings/general/domain/repository/GeneralSettingsRepository.kt
@@ -2,7 +2,9 @@ package com.d4rk.android.libs.apptoolkit.app.settings.general.domain.repository
 
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
 
 /**
  * Repository responsible for providing the content key for the General Settings screen.
@@ -13,21 +15,22 @@ import kotlinx.coroutines.withContext
  */
 interface GeneralSettingsRepository {
     /**
-     * Returns a valid content key. If the provided key is null or blank, the
-     * function throws an [IllegalArgumentException]. This function is marked as
-     * [suspend] to ensure callers handle it from within a coroutine.
+     * Returns a [Flow] that emits a valid content key. If the provided key is
+     * null or blank, the flow throws an [IllegalArgumentException] when
+     * collected. Using a [Flow] allows the repository to expose asynchronous
+     * data streams in line with recommended architecture guidelines.
      */
-    suspend fun getContentKey(contentKey: String?): String
+    fun getContentKey(contentKey: String?): Flow<String>
 }
 
 class DefaultGeneralSettingsRepository(
     private val dispatcher: CoroutineDispatcher = Dispatchers.Default
 ) : GeneralSettingsRepository {
-    override suspend fun getContentKey(contentKey: String?): String = withContext(dispatcher) {
+    override fun getContentKey(contentKey: String?): Flow<String> = flow {
         if (contentKey.isNullOrBlank()) {
             throw IllegalArgumentException("Invalid content key")
         }
-        contentKey
-    }
+        emit(contentKey)
+    }.flowOn(dispatcher)
 }
 

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/settings/general/domain/repository/TestGeneralSettingsRepository.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/settings/general/domain/repository/TestGeneralSettingsRepository.kt
@@ -2,6 +2,7 @@ package com.d4rk.android.libs.apptoolkit.app.settings.general.domain.repository
 
 import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.UnconfinedDispatcherExtension
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
@@ -18,7 +19,7 @@ class TestGeneralSettingsRepository {
     @Test
     fun `getContentKey returns provided key`() = runTest(dispatcherExtension.testDispatcher) {
         val repository = DefaultGeneralSettingsRepository(dispatcherExtension.testDispatcher)
-        val result = repository.getContentKey("valid")
+        val result = repository.getContentKey("valid").first()
         assertThat(result).isEqualTo("valid")
     }
 
@@ -26,7 +27,7 @@ class TestGeneralSettingsRepository {
     fun `getContentKey throws on null key`() = runTest(dispatcherExtension.testDispatcher) {
         val repository = DefaultGeneralSettingsRepository(dispatcherExtension.testDispatcher)
         assertThrows<IllegalArgumentException> {
-            repository.getContentKey(null)
+            repository.getContentKey(null).first()
         }
     }
 
@@ -34,7 +35,7 @@ class TestGeneralSettingsRepository {
     fun `getContentKey throws on blank key`() = runTest(dispatcherExtension.testDispatcher) {
         val repository = DefaultGeneralSettingsRepository(dispatcherExtension.testDispatcher)
         assertThrows<IllegalArgumentException> {
-            repository.getContentKey("")
+            repository.getContentKey("").first()
         }
     }
 }


### PR DESCRIPTION
## Summary
- refactor general settings repository to emit content key via Flow
- update view model to collect from Flow with onStart and catch
- adapt unit tests for Flow-based repository

## Testing
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af84387fac832da5b812fa88141c97