### PR TITLE
Refactor ads settings to use Flow-based architecture

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AdsModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AdsModule.kt
@@ -1,13 +1,31 @@
 package com.d4rk.android.apps.apptoolkit.core.di.modules
 
 import com.d4rk.android.apps.apptoolkit.core.utils.constants.ads.AdsConstants
+import com.d4rk.android.libs.apptoolkit.app.ads.data.DefaultAdsSettingsRepository
+import com.d4rk.android.libs.apptoolkit.app.ads.domain.repository.AdsSettingsRepository
+import com.d4rk.android.libs.apptoolkit.app.ads.ui.AdsSettingsViewModel
+import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoProvider
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
+import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
 import com.google.android.gms.ads.AdSize
 import org.koin.core.module.Module
+import org.koin.core.module.dsl.viewModel
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 val adsModule : Module = module {
+
+    single<AdsSettingsRepository> {
+        DefaultAdsSettingsRepository(
+            dataStore = CommonDataStore.getInstance(get()),
+            buildInfoProvider = get<BuildInfoProvider>(),
+            ioDispatcher = get(named("io"))
+        )
+    }
+
+    viewModel {
+        AdsSettingsViewModel(repository = get())
+    }
 
     single<AdsConfig> {
         AdsConfig(bannerAdUnitId = AdsConstants.BANNER_AD_UNIT_ID , adSize = AdSize.BANNER)

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/data/DefaultAdsSettingsRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/data/DefaultAdsSettingsRepository.kt
@@ -1,0 +1,30 @@
+package com.d4rk.android.libs.apptoolkit.app.ads.data
+
+import com.d4rk.android.libs.apptoolkit.app.ads.domain.repository.AdsSettingsRepository
+import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoProvider
+import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.withContext
+
+/**
+ * Default implementation of [AdsSettingsRepository] backed by [CommonDataStore].
+ */
+class DefaultAdsSettingsRepository(
+    private val dataStore: CommonDataStore,
+    buildInfoProvider: BuildInfoProvider,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : AdsSettingsRepository {
+
+    override val defaultAdsEnabled: Boolean = !buildInfoProvider.isDebugBuild
+
+    override fun observeAdsEnabled(): Flow<Boolean> =
+        dataStore.ads(default = defaultAdsEnabled)
+            .flowOn(ioDispatcher)
+
+    override suspend fun setAdsEnabled(enabled: Boolean) = withContext(ioDispatcher) {
+        dataStore.saveAds(isChecked = enabled)
+    }
+}

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/domain/repository/AdsSettingsRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/domain/repository/AdsSettingsRepository.kt
@@ -1,0 +1,17 @@
+package com.d4rk.android.libs.apptoolkit.app.ads.domain.repository
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Repository that exposes and persists the ads display preference.
+ */
+interface AdsSettingsRepository {
+    /** Default value used when the preference has not been set. */
+    val defaultAdsEnabled: Boolean
+
+    /** Observe whether ads are enabled. */
+    fun observeAdsEnabled(): Flow<Boolean>
+
+    /** Persist the ads enabled preference. */
+    suspend fun setAdsEnabled(enabled: Boolean)
+}

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/ui/AdsSettingsActivity.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/ui/AdsSettingsActivity.kt
@@ -4,18 +4,18 @@ import android.os.Bundle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.appcompat.app.AppCompatActivity
-import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoProvider
 import com.d4rk.android.libs.apptoolkit.app.theme.style.AppTheme
-import org.koin.android.ext.android.inject
+import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class AdsSettingsActivity : AppCompatActivity() {
-    private val buildInfoProvider : BuildInfoProvider by inject()
+    private val viewModel: AdsSettingsViewModel by viewModel()
+
     override fun onCreate(savedInstanceState : Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {
             AppTheme {
-                AdsSettingsScreen(activity = this@AdsSettingsActivity , buildInfoProvider = buildInfoProvider)
+                AdsSettingsScreen(activity = this@AdsSettingsActivity, viewModel = viewModel)
             }
         }
     }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/ui/AdsSettingsScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/ui/AdsSettingsScreen.kt
@@ -1,7 +1,6 @@
 package com.d4rk.android.libs.apptoolkit.app.ads.ui
 
 import android.app.Activity
-import android.content.Context
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.fillMaxSize
@@ -11,15 +10,11 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import com.d4rk.android.libs.apptoolkit.R
-import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoProvider
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.sections.InfoMessageSection
 import com.d4rk.android.libs.apptoolkit.core.ui.components.navigation.LargeTopAppBarWithScaffold
 import com.d4rk.android.libs.apptoolkit.core.ui.components.preferences.PreferenceItem
@@ -27,24 +22,13 @@ import com.d4rk.android.libs.apptoolkit.core.ui.components.preferences.SwitchCar
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.links.AppLinks
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.ConsentFormHelper
-import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
 import com.google.android.ump.ConsentInformation
 import com.google.android.ump.UserMessagingPlatform
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun AdsSettingsScreen(activity : Activity , buildInfoProvider : BuildInfoProvider) {
-    val context : Context = LocalContext.current
-    val appContext = context.applicationContext
-    val coroutineScope : CoroutineScope = rememberCoroutineScope()
-    val dataStore = remember(appContext) { CommonDataStore.getInstance(appContext) }
-
-    val defaultAds = !buildInfoProvider.isDebugBuild
-    val adsEnabled by dataStore
-        .ads(default = defaultAds)
-        .collectAsStateWithLifecycle(initialValue = defaultAds)
+fun AdsSettingsScreen(activity: Activity, viewModel: AdsSettingsViewModel) {
+    val adsEnabled by viewModel.adsEnabled.collectAsStateWithLifecycle()
 
     LargeTopAppBarWithScaffold(
         title = stringResource(id = R.string.ads) , onBackClicked = { activity.finish() }) { paddingValues : PaddingValues ->
@@ -55,11 +39,10 @@ fun AdsSettingsScreen(activity : Activity , buildInfoProvider : BuildInfoProvide
         ) {
             item {
                 SwitchCardItem(
-                    title = stringResource(id = R.string.display_ads) , switchState = rememberUpdatedState(newValue = adsEnabled)
-                ) { isChecked : Boolean ->
-                    coroutineScope.launch {
-                        dataStore.saveAds(isChecked = isChecked)
-                    }
+                    title = stringResource(id = R.string.display_ads),
+                    switchState = rememberUpdatedState(newValue = adsEnabled)
+                ) { isChecked: Boolean ->
+                    viewModel.setAdsEnabled(isChecked)
                 }
             }
 

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/ui/AdsSettingsViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/ui/AdsSettingsViewModel.kt
@@ -1,0 +1,30 @@
+package com.d4rk.android.libs.apptoolkit.app.ads.ui
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.d4rk.android.libs.apptoolkit.app.ads.domain.repository.AdsSettingsRepository
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+/** ViewModel for Ads settings screen. */
+class AdsSettingsViewModel(
+    private val repository: AdsSettingsRepository,
+) : ViewModel() {
+
+    val adsEnabled: StateFlow<Boolean> = repository.observeAdsEnabled()
+        .catch { emit(repository.defaultAdsEnabled) }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.Eagerly,
+            initialValue = repository.defaultAdsEnabled,
+        )
+
+    fun setAdsEnabled(enabled: Boolean) {
+        viewModelScope.launch {
+            repository.setAdsEnabled(enabled)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add AdsSettingsRepository and ViewModel to manage ad preference with Kotlin Flows
- Replace direct DataStore usage in AdsSettings UI with ViewModel and repository
- Register repository and ViewModel in AdsModule for DI

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af84b16390832d96e4da72af5c9a0c