### PR TITLE
Refactor ads settings to follow architecture guidelines

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/domain/actions/AdsSettingsAction.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/domain/actions/AdsSettingsAction.kt
@@ -1,0 +1,6 @@
+package com.d4rk.android.libs.apptoolkit.app.ads.domain.actions
+
+import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.ActionEvent
+
+sealed interface AdsSettingsAction : ActionEvent
+

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/domain/actions/AdsSettingsEvent.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/domain/actions/AdsSettingsEvent.kt
@@ -1,0 +1,8 @@
+package com.d4rk.android.libs.apptoolkit.app.ads.domain.actions
+
+import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.UiEvent
+
+sealed interface AdsSettingsEvent : UiEvent {
+    data class SetAdsEnabled(val enabled: Boolean) : AdsSettingsEvent
+}
+

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/domain/model/ui/UiAdsSettingsScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/domain/model/ui/UiAdsSettingsScreen.kt
@@ -1,0 +1,6 @@
+package com.d4rk.android.libs.apptoolkit.app.ads.domain.model.ui
+
+data class UiAdsSettingsScreen(
+    val adsEnabled: Boolean = false,
+)
+

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/ui/AdsSettingsViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/ui/AdsSettingsViewModel.kt
@@ -1,30 +1,56 @@
 package com.d4rk.android.libs.apptoolkit.app.ads.ui
 
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.d4rk.android.libs.apptoolkit.app.ads.domain.actions.AdsSettingsAction
+import com.d4rk.android.libs.apptoolkit.app.ads.domain.actions.AdsSettingsEvent
+import com.d4rk.android.libs.apptoolkit.app.ads.domain.model.ui.UiAdsSettingsScreen
 import com.d4rk.android.libs.apptoolkit.app.ads.domain.repository.AdsSettingsRepository
-import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.StateFlow
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.setLoading
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.updateData
+import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 
 /** ViewModel for Ads settings screen. */
 class AdsSettingsViewModel(
     private val repository: AdsSettingsRepository,
-) : ViewModel() {
+) : ScreenViewModel<UiAdsSettingsScreen, AdsSettingsEvent, AdsSettingsAction>(
+    initialState = UiStateScreen(
+        screenState = ScreenState.IsLoading(),
+        data = UiAdsSettingsScreen()
+    )
+) {
 
-    val adsEnabled: StateFlow<Boolean> = repository.observeAdsEnabled()
-        .catch { emit(repository.defaultAdsEnabled) }
-        .stateIn(
-            scope = viewModelScope,
-            started = SharingStarted.Eagerly,
-            initialValue = repository.defaultAdsEnabled,
-        )
+    init {
+        viewModelScope.launch {
+            repository.observeAdsEnabled()
+                .onStart { screenState.setLoading() }
+                .catch {
+                    screenState.updateData(newState = ScreenState.Error()) { current ->
+                        current.copy(adsEnabled = repository.defaultAdsEnabled)
+                    }
+                }
+                .collect { enabled ->
+                    screenState.updateData(newState = ScreenState.Success()) { current ->
+                        current.copy(adsEnabled = enabled)
+                    }
+                }
+        }
+    }
 
-    fun setAdsEnabled(enabled: Boolean) {
+    override fun onEvent(event: AdsSettingsEvent) {
+        when (event) {
+            is AdsSettingsEvent.SetAdsEnabled -> setAdsEnabled(event.enabled)
+        }
+    }
+
+    private fun setAdsEnabled(enabled: Boolean) {
         viewModelScope.launch {
             repository.setAdsEnabled(enabled)
         }
     }
 }
+


### PR DESCRIPTION
## Summary
- expose ads settings via UiStateScreen and ScreenViewModel pattern
- handle user toggles through AdsSettingsEvent and repository
- drive UI with ScreenStateHandler to display loading, error, and content states

## Testing
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af86864698832d8f48d392b16d9f72