### PR TITLE
Refactor startup flow to use ScreenStateHandler

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppToolkitModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppToolkitModule.kt
@@ -14,6 +14,7 @@ import com.d4rk.android.libs.apptoolkit.core.di.GithubToken
 import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.AppDispatchers
 import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.AppDispatchersImpl
 import com.d4rk.android.libs.apptoolkit.app.startup.utils.interfaces.providers.StartupProvider
+import com.d4rk.android.libs.apptoolkit.app.startup.ui.StartupViewModel
 import com.d4rk.android.libs.apptoolkit.app.support.billing.BillingRepository
 import com.d4rk.android.libs.apptoolkit.app.support.ui.SupportViewModel
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.github.GithubConstants
@@ -35,6 +36,7 @@ val appToolkitModule : Module = module {
     viewModel {
         SupportViewModel(billingRepository = get())
     }
+    viewModel { StartupViewModel() }
 
     single<AppDispatchers> { AppDispatchersImpl() }
     single<DeviceInfoProvider> { DeviceInfoProviderImpl(get(), get()) }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/startup/domain/actions/StartupAction.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/startup/domain/actions/StartupAction.kt
@@ -1,0 +1,7 @@
+package com.d4rk.android.libs.apptoolkit.app.startup.domain.actions
+
+import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.ActionEvent
+
+sealed interface StartupAction : ActionEvent {
+    data object NavigateNext : StartupAction
+}

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/startup/domain/actions/StartupEvent.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/startup/domain/actions/StartupEvent.kt
@@ -1,0 +1,8 @@
+package com.d4rk.android.libs.apptoolkit.app.startup.domain.actions
+
+import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.UiEvent
+
+sealed interface StartupEvent : UiEvent {
+    data object ConsentFormLoaded : StartupEvent
+    data object Continue : StartupEvent
+}

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/startup/domain/model/ui/UiStartupScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/startup/domain/model/ui/UiStartupScreen.kt
@@ -1,0 +1,5 @@
+package com.d4rk.android.libs.apptoolkit.app.startup.domain.model.ui
+
+data class UiStartupScreen(
+    val consentFormLoaded : Boolean = false
+)

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupActivity.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupActivity.kt
@@ -7,52 +7,63 @@ import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.getValue
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.d4rk.android.libs.apptoolkit.app.startup.domain.actions.StartupAction
+import com.d4rk.android.libs.apptoolkit.app.startup.domain.actions.StartupEvent
 import com.d4rk.android.libs.apptoolkit.app.startup.utils.interfaces.providers.StartupProvider
 import com.d4rk.android.libs.apptoolkit.app.theme.style.AppTheme
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.ConsentFormHelper
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.IntentsHelper
 import com.google.android.ump.ConsentInformation
 import com.google.android.ump.UserMessagingPlatform
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 import org.koin.android.ext.android.inject
+import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class StartupActivity : AppCompatActivity() {
-    private val provider: StartupProvider by inject()
-    private val _consentFormLoaded = MutableStateFlow(false)
-    val consentFormLoaded: StateFlow<Boolean> = _consentFormLoaded.asStateFlow()
-    private val permissionLauncher: ActivityResultLauncher<Array<String>> =
+    private val provider : StartupProvider by inject()
+    private val viewModel : StartupViewModel by viewModel()
+    private val permissionLauncher : ActivityResultLauncher<Array<String>> =
         registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { }
 
     override fun onCreate(savedInstanceState : Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
 
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.actionEvent.collect { action : StartupAction ->
+                    when (action) {
+                        StartupAction.NavigateNext -> navigateToNext()
+                    }
+                }
+            }
+        }
+
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.RESUMED) {
+                if (provider.requiredPermissions.isNotEmpty()) {
+                    permissionLauncher.launch(provider.requiredPermissions)
+                }
+                checkUserConsent()
+            }
+        }
+
         setContent {
             AppTheme {
-                val consentFormLoadedState by consentFormLoaded.collectAsStateWithLifecycle()
+                val screenState by viewModel.uiState.collectAsStateWithLifecycle()
                 StartupScreen(
-                    consentFormLoaded = consentFormLoadedState,
-                    onContinueClick = { navigateToNext() }
+                    screenState = screenState,
+                    onContinueClick = { viewModel.onEvent(StartupEvent.Continue) }
                 )
             }
         }
     }
 
-    override fun onResume() {
-        super.onResume()
-        if (provider.requiredPermissions.isNotEmpty()) {
-            permissionLauncher.launch(input = provider.requiredPermissions)
-        }
-
-        checkUserConsent()
-    }
-
-    fun navigateToNext() {
+    private fun navigateToNext() {
         lifecycleScope.launch {
             IntentsHelper.openActivity(context = this@StartupActivity , activityClass = provider.getNextIntent(this@StartupActivity).component?.className?.let {
                 Class.forName(it)
@@ -62,14 +73,12 @@ class StartupActivity : AppCompatActivity() {
     }
 
     private fun checkUserConsent() {
-        lifecycleScope.launch {
-            val consentInfo: ConsentInformation =
-                UserMessagingPlatform.getConsentInformation(this@StartupActivity)
-            ConsentFormHelper.showConsentFormIfRequired(
-                activity = this@StartupActivity,
-                consentInfo = consentInfo
-            )
-            _consentFormLoaded.value = true
-        }
+        val consentInfo : ConsentInformation =
+            UserMessagingPlatform.getConsentInformation(this)
+        ConsentFormHelper.showConsentFormIfRequired(
+            activity = this,
+            consentInfo = consentInfo,
+            onFormShown = { viewModel.onEvent(StartupEvent.ConsentFormLoaded) }
+        )
     }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupScreen.kt
@@ -25,7 +25,12 @@ import com.airbnb.lottie.compose.LottieCompositionSpec
 import com.airbnb.lottie.compose.LottieConstants
 import com.airbnb.lottie.compose.rememberLottieComposition
 import com.d4rk.android.libs.apptoolkit.R
+import com.d4rk.android.libs.apptoolkit.app.startup.domain.model.ui.UiStartupScreen
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.fab.AnimatedExtendedFloatingActionButton
+import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.LoadingScreen
+import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.NoDataScreen
+import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.ScreenStateHandler
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.sections.InfoMessageSection
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
 import com.d4rk.android.libs.apptoolkit.core.ui.components.navigation.TopAppBarScaffold
@@ -34,33 +39,35 @@ import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 
 @Composable
 fun StartupScreen(
-    consentFormLoaded: Boolean,
-    onContinueClick: () -> Unit
+    screenState : UiStateScreen<UiStartupScreen> ,
+    onContinueClick : () -> Unit
 ) {
-    TopAppBarScaffold(
-        title = stringResource(R.string.welcome),
-        content = { paddingValues ->
-            StartupScreenContent(paddingValues = paddingValues)
-        },
-        floatingActionButton = {
-            AnimatedExtendedFloatingActionButton(
-                visible = consentFormLoaded,
-                modifier = Modifier.bounceClick(),
-                containerColor = if (consentFormLoaded) {
-                    FloatingActionButtonDefaults.containerColor
-                } else {
-                    Gray
-                },
-                text = { Text(text = stringResource(id = R.string.agree)) },
-                onClick = onContinueClick,
-                icon = {
-                    Icon(
-                        imageVector = Icons.Outlined.CheckCircle, contentDescription = null
-                    )
-                }
-            )
-        }
-    )
+    ScreenStateHandler(screenState = screenState , onLoading = { LoadingScreen() } , onEmpty = { NoDataScreen() } , onSuccess = { data : UiStartupScreen ->
+        TopAppBarScaffold(
+            title = stringResource(R.string.welcome) ,
+            content = { paddingValues ->
+                StartupScreenContent(paddingValues = paddingValues)
+            } ,
+            floatingActionButton = {
+                AnimatedExtendedFloatingActionButton(
+                    visible = data.consentFormLoaded ,
+                    modifier = Modifier.bounceClick() ,
+                    containerColor = if (data.consentFormLoaded) {
+                        FloatingActionButtonDefaults.containerColor
+                    } else {
+                        Gray
+                    } ,
+                    text = { Text(text = stringResource(id = R.string.agree)) } ,
+                    onClick = onContinueClick ,
+                    icon = {
+                        Icon(
+                            imageVector = Icons.Outlined.CheckCircle , contentDescription = null
+                        )
+                    }
+                )
+            }
+        )
+    })
 }
 
 @Composable

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupViewModel.kt
@@ -1,0 +1,23 @@
+package com.d4rk.android.libs.apptoolkit.app.startup.ui
+
+import com.d4rk.android.libs.apptoolkit.app.startup.domain.actions.StartupAction
+import com.d4rk.android.libs.apptoolkit.app.startup.domain.actions.StartupEvent
+import com.d4rk.android.libs.apptoolkit.app.startup.domain.model.ui.UiStartupScreen
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.updateData
+import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
+
+class StartupViewModel : ScreenViewModel<UiStartupScreen , StartupEvent , StartupAction>(
+    initialState = UiStateScreen(data = UiStartupScreen())
+) {
+    override fun onEvent(event : StartupEvent) {
+        when (event) {
+            StartupEvent.ConsentFormLoaded -> screenState.updateData(
+                newState = ScreenState.Success()
+            ) { current -> current.copy(consentFormLoaded = true) }
+
+            StartupEvent.Continue -> sendAction(StartupAction.NavigateNext)
+        }
+    }
+}

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupViewModelTest.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupViewModelTest.kt
@@ -1,0 +1,34 @@
+package com.d4rk.android.libs.apptoolkit.app.startup.ui
+
+import com.d4rk.android.libs.apptoolkit.app.startup.domain.actions.StartupEvent
+import com.d4rk.android.libs.apptoolkit.app.startup.domain.actions.StartupAction
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class StartupViewModelTest {
+    @Test
+    fun `consent event updates state`() = runTest {
+        val viewModel = StartupViewModel()
+        viewModel.onEvent(StartupEvent.ConsentFormLoaded)
+        val state = viewModel.uiState.value
+        assertThat(state.screenState).isInstanceOf(ScreenState.Success::class.java)
+        assertThat(state.data?.consentFormLoaded).isTrue()
+    }
+
+    @Test
+    fun `continue event emits navigation action`() = runTest {
+        val viewModel = StartupViewModel()
+        val actions = mutableListOf<StartupAction>()
+        val job = launch { viewModel.actionEvent.collect { actions.add(it) } }
+        viewModel.onEvent(StartupEvent.Continue)
+        advanceUntilIdle()
+        assertThat(actions).containsExactly(StartupAction.NavigateNext)
+        job.cancel()
+    }
+}


### PR DESCRIPTION
## Summary
- Introduce `UiStartupScreen`, `StartupEvent`, and `StartupAction` to manage consent state and navigation
- Refactor `StartupViewModel` to `ScreenViewModel` pattern and handle events for consent and navigation
- Use `ScreenStateHandler` in `StartupScreen` and collect `StartupAction` in activity for navigation

## Testing
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af8695d4d4832d82c8f81d39233031