### PR TITLE
feat(ads): handle repository errors in viewmodel

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/ui/AdsSettingsViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/ui/AdsSettingsViewModel.kt
@@ -49,7 +49,13 @@ class AdsSettingsViewModel(
 
     private fun setAdsEnabled(enabled: Boolean) {
         viewModelScope.launch {
-            repository.setAdsEnabled(enabled)
+            try {
+                repository.setAdsEnabled(enabled)
+            } catch (e: Exception) {
+                screenState.updateData(newState = ScreenState.Error()) { current ->
+                    current.copy(adsEnabled = !enabled)
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- handle repository errors when persisting ads preference

## Testing
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af891c1f50832db50d8750736f4cc8