### PR TITLE
Handle datastore errors with flow catch

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/data/DefaultAdsSettingsRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/data/DefaultAdsSettingsRepository.kt
@@ -6,6 +6,7 @@ import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.withContext
 
@@ -22,6 +23,7 @@ class DefaultAdsSettingsRepository(
 
     override fun observeAdsEnabled(): Flow<Boolean> =
         dataStore.ads(default = defaultAdsEnabled)
+            .catch { emit(defaultAdsEnabled) }
             .flowOn(ioDispatcher)
 
     override suspend fun setAdsEnabled(enabled: Boolean) = withContext(ioDispatcher) {

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/ads/data/TestDefaultAdsSettingsRepository.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/ads/data/TestDefaultAdsSettingsRepository.kt
@@ -1,0 +1,79 @@
+package com.d4rk.android.libs.apptoolkit.app.ads.data
+
+import app.cash.turbine.test
+import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoProvider
+import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.UnconfinedDispatcherExtension
+import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import java.io.IOException
+
+class TestDefaultAdsSettingsRepository {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val dispatcherExtension = UnconfinedDispatcherExtension()
+    }
+
+    private fun createRepository(
+        dataStore: CommonDataStore,
+        isDebugBuild: Boolean = false,
+    ): DefaultAdsSettingsRepository {
+        val buildInfoProvider = mockk<BuildInfoProvider> {
+            every { isDebugBuild } returns isDebugBuild
+        }
+        return DefaultAdsSettingsRepository(
+            dataStore = dataStore,
+            buildInfoProvider = buildInfoProvider,
+            ioDispatcher = dispatcherExtension.testDispatcher,
+        )
+    }
+
+    @Test
+    fun `observeAdsEnabled emits datastore value`() = runTest(dispatcherExtension.testDispatcher) {
+        println("\uD83D\uDE80 [TEST] observeAdsEnabled emits datastore value")
+        val dataStore = mockk<CommonDataStore>()
+        every { dataStore.ads(default = true) } returns flowOf(false)
+        val repository = createRepository(dataStore, isDebugBuild = false)
+
+        repository.observeAdsEnabled().test {
+            assertThat(awaitItem()).isFalse()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `observeAdsEnabled emits default on error`() = runTest(dispatcherExtension.testDispatcher) {
+        println("\uD83D\uDE80 [TEST] observeAdsEnabled emits default on error")
+        val dataStore = mockk<CommonDataStore>()
+        every { dataStore.ads(default = true) } returns flow { throw IOException("boom") }
+        val repository = createRepository(dataStore, isDebugBuild = false)
+
+        repository.observeAdsEnabled().test {
+            assertThat(awaitItem()).isTrue()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `setAdsEnabled persists preference`() = runTest(dispatcherExtension.testDispatcher) {
+        println("\uD83D\uDE80 [TEST] setAdsEnabled persists preference")
+        val dataStore = mockk<CommonDataStore>()
+        coEvery { dataStore.saveAds(any()) } returns Unit
+        val repository = createRepository(dataStore, isDebugBuild = false)
+
+        repository.setAdsEnabled(true)
+
+        coVerify { dataStore.saveAds(isChecked = true) }
+    }
+}
+


### PR DESCRIPTION
## Summary
- handle DataStore errors in Ads settings repository using Flow `catch`
- cover Ads settings repository with unit tests

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af8adb2cdc832d9c7e8952ba9e5051