### PR TITLE
Inject external coroutine scope for BillingRepository

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppToolkitModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppToolkitModule.kt
@@ -11,13 +11,16 @@ import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.providers.Devic
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.usecases.SendIssueReportUseCase
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.ui.IssueReporterViewModel
 import com.d4rk.android.libs.apptoolkit.core.di.GithubToken
-import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.AppDispatchers
-import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.AppDispatchersImpl
 import com.d4rk.android.libs.apptoolkit.app.startup.utils.interfaces.providers.StartupProvider
 import com.d4rk.android.libs.apptoolkit.app.startup.ui.StartupViewModel
 import com.d4rk.android.libs.apptoolkit.app.support.billing.BillingRepository
 import com.d4rk.android.libs.apptoolkit.app.support.ui.SupportViewModel
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.github.GithubConstants
+import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.AppDispatchers
+import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.AppDispatchersImpl
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.viewModel
 import org.koin.core.qualifier.named
@@ -28,9 +31,11 @@ val appToolkitModule : Module = module {
     single<StartupProvider> { AppStartupProvider() }
 
     single(createdAtStart = true) {
+        val ioDispatcher = get<CoroutineDispatcher>(named("io"))
         BillingRepository.getInstance(
             context = get(),
-            ioDispatcher = get(named("io"))
+            ioDispatcher = ioDispatcher,
+            externalScope = CoroutineScope(SupervisorJob() + ioDispatcher)
         )
     }
     viewModel {

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/billing/BillingRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/billing/BillingRepository.kt
@@ -28,9 +28,10 @@ import kotlinx.coroutines.launch
 class BillingRepository private constructor(
     context: Context,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    externalScope: CoroutineScope = CoroutineScope(SupervisorJob() + ioDispatcher),
 ) : PurchasesUpdatedListener {
 
-    private val scope = CoroutineScope(SupervisorJob() + ioDispatcher)
+    private val scope = CoroutineScope(externalScope.coroutineContext + SupervisorJob() + ioDispatcher)
 
     private val _productDetails = MutableStateFlow<Map<String, ProductDetails>>(emptyMap())
     val productDetails: StateFlow<Map<String, ProductDetails>> = _productDetails.asStateFlow()
@@ -56,9 +57,10 @@ class BillingRepository private constructor(
         fun getInstance(
             context: Context,
             ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+            externalScope: CoroutineScope = CoroutineScope(SupervisorJob() + ioDispatcher),
         ): BillingRepository {
             return INSTANCE ?: synchronized(this) {
-                INSTANCE ?: BillingRepository(context.applicationContext, ioDispatcher)
+                INSTANCE ?: BillingRepository(context.applicationContext, ioDispatcher, externalScope)
                     .also { INSTANCE = it }
             }
         }


### PR DESCRIPTION
## Summary
- inject external coroutine scope and dispatcher in BillingRepository to follow coroutine best practices
- provide injected scope and dispatcher through AppToolkitModule

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af8c0dfffc832d941c1ddf1930374f