### PR TITLE
Use repository and coroutines for About screen

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/SettingsModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/SettingsModule.kt
@@ -7,6 +7,8 @@ import com.d4rk.android.apps.apptoolkit.app.settings.settings.utils.providers.Ap
 import com.d4rk.android.apps.apptoolkit.app.settings.settings.utils.providers.AppPrivacySettingsProvider
 import com.d4rk.android.apps.apptoolkit.app.settings.settings.utils.providers.AppSettingsProvider
 import com.d4rk.android.apps.apptoolkit.app.settings.settings.utils.providers.PermissionsSettingsRepository
+import com.d4rk.android.libs.apptoolkit.app.about.data.DefaultAboutRepository
+import com.d4rk.android.libs.apptoolkit.app.about.domain.repository.AboutRepository
 import com.d4rk.android.libs.apptoolkit.app.about.ui.AboutViewModel
 import com.d4rk.android.libs.apptoolkit.app.permissions.ui.PermissionsViewModel
 import com.d4rk.android.libs.apptoolkit.app.permissions.data.PermissionsRepository
@@ -41,6 +43,13 @@ val settingsModule = module {
     single<PrivacySettingsProvider> { AppPrivacySettingsProvider(context = get()) }
     single<BuildInfoProvider> { AppBuildInfoProvider(context = get()) }
     single<GeneralSettingsContentProvider> { GeneralSettingsContentProvider(advancedProvider = get() , displayProvider = get() , privacyProvider = get() , configProvider = get()) }
+    single<AboutRepository> {
+        DefaultAboutRepository(
+            deviceProvider = get(),
+            configProvider = get(),
+            ioDispatcher = get(named("io")),
+        )
+    }
     single<GeneralSettingsRepository> { DefaultGeneralSettingsRepository() }
     viewModel {
         GeneralSettingsViewModel(repository = get())
@@ -55,9 +64,7 @@ val settingsModule = module {
 
     viewModel {
         AboutViewModel(
-            deviceProvider = get(),
-            configProvider = get(),
-            dispatcher = get(named("default")),
+            repository = get(),
         )
     }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/data/DefaultAboutRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/data/DefaultAboutRepository.kt
@@ -1,0 +1,28 @@
+package com.d4rk.android.libs.apptoolkit.app.about.data
+
+import com.d4rk.android.libs.apptoolkit.app.about.domain.model.ui.UiAboutScreen
+import com.d4rk.android.libs.apptoolkit.app.about.domain.repository.AboutRepository
+import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.AboutSettingsProvider
+import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoProvider
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+
+/**
+ * Default implementation of [AboutRepository] that gathers device and build
+ * information on an I/O dispatcher.
+ */
+class DefaultAboutRepository(
+    private val deviceProvider: AboutSettingsProvider,
+    private val configProvider: BuildInfoProvider,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : AboutRepository {
+
+    override suspend fun getAboutInfo(): UiAboutScreen = withContext(ioDispatcher) {
+        UiAboutScreen(
+            appVersion = configProvider.appVersion,
+            appVersionCode = configProvider.appVersionCode,
+            deviceInfo = deviceProvider.deviceInfo,
+        )
+    }
+}

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/domain/repository/AboutRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/domain/repository/AboutRepository.kt
@@ -1,0 +1,13 @@
+package com.d4rk.android.libs.apptoolkit.app.about.domain.repository
+
+import com.d4rk.android.libs.apptoolkit.app.about.domain.model.ui.UiAboutScreen
+
+/**
+ * Repository responsible for providing data for the about screen.
+ */
+interface AboutRepository {
+    /**
+     * Fetch information displayed on the about screen.
+     */
+    suspend fun getAboutInfo(): UiAboutScreen
+}

--- a/apptoolkit/src/main/res/values/strings.xml
+++ b/apptoolkit/src/main/res/values/strings.xml
@@ -261,6 +261,7 @@
     <string name="android_version">Android Version:</string>
     <string name="api_level">API Level:</string>
     <string name="snack_device_info_copied">Device info copied to clipboard</string>
+    <string name="snack_device_info_failed">Unable to load device info</string>
 
     <string name="help_and_feedback">Help &amp; feedback</string>
     <string name="help">Help</string>

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/about/ui/TestAboutViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/about/ui/TestAboutViewModel.kt
@@ -2,6 +2,7 @@ package com.d4rk.android.libs.apptoolkit.app.about.ui
 
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.about.domain.model.actions.AboutEvents
+import com.d4rk.android.libs.apptoolkit.app.about.data.DefaultAboutRepository
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.AboutSettingsProvider
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoProvider
 import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.UnconfinedDispatcherExtension
@@ -32,9 +33,11 @@ class TestAboutViewModel {
 
     private fun createViewModel(): AboutViewModel =
         AboutViewModel(
-            deviceProvider = deviceProvider,
-            configProvider = buildInfoProvider,
-            dispatcher = dispatcherExtension.testDispatcher,
+            repository = DefaultAboutRepository(
+                deviceProvider = deviceProvider,
+                configProvider = buildInfoProvider,
+                ioDispatcher = dispatcherExtension.testDispatcher,
+            ),
         )
 
     @Test


### PR DESCRIPTION
## Summary
- Introduce AboutRepository with DefaultAboutRepository using IO dispatcher
- Update AboutViewModel to fetch via repository and handle errors with snackbar
- Wire repository through Koin settings module and add failure string resource

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af8dd28f4c832dae2e84fc9f33c80a