### PR TITLE
feat: use ScreenStateHandler in about settings

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/ui/AboutSettingsList.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/ui/AboutSettingsList.kt
@@ -20,6 +20,9 @@ import com.d4rk.android.libs.apptoolkit.app.about.domain.actions.AboutEvent
 import com.d4rk.android.libs.apptoolkit.app.about.domain.model.ui.UiAboutScreen
 import com.d4rk.android.libs.apptoolkit.app.licenses.LicensesActivity
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
+import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.LoadingScreen
+import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.NoDataScreen
+import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.ScreenStateHandler
 import com.d4rk.android.libs.apptoolkit.core.ui.components.preferences.PreferenceCategoryItem
 import com.d4rk.android.libs.apptoolkit.core.ui.components.preferences.SettingsPreferenceItem
 import com.d4rk.android.libs.apptoolkit.core.ui.components.snackbar.DefaultSnackbarHandler
@@ -36,47 +39,50 @@ fun AboutSettingsList(paddingValues: PaddingValues = PaddingValues(), snackbarHo
     val viewModel: AboutViewModel = koinViewModel()
     val screenState: UiStateScreen<UiAboutScreen> by viewModel.uiState.collectAsStateWithLifecycle()
     val deviceInfo: String = stringResource(id = R.string.device_info)
-    LazyColumn(modifier = Modifier.fillMaxHeight() , contentPadding = paddingValues) {
-        item {
-            PreferenceCategoryItem(title = stringResource(id = R.string.app_info))
-            SmallVerticalSpacer()
-            Column(
-                modifier = Modifier
-                        .padding(horizontal = SizeConstants.LargeSize)
-                        .clip(shape = RoundedCornerShape(size = SizeConstants.LargeSize))
-            ) {
-                SettingsPreferenceItem(title = stringResource(id = R.string.app_full_name), summary = stringResource(id = R.string.copyright))
-                ExtraTinyVerticalSpacer()
-                SettingsPreferenceItem(
-                    title = stringResource(id = R.string.app_build_version),
-                    summary = "${screenState.data?.appVersion} (${screenState.data?.appVersionCode})",
-                )
-                ExtraTinyVerticalSpacer()
-                SettingsPreferenceItem(title = stringResource(id = R.string.oss_license_title), summary = stringResource(id = R.string.summary_preference_settings_oss)) {
-                    IntentsHelper.openActivity(context = context, activityClass = LicensesActivity::class.java)
-                }
-            }
-        }
 
-        item {
-            PreferenceCategoryItem(title = deviceInfo)
-            SmallVerticalSpacer()
-            Column(
-                modifier = Modifier
-                        .padding(horizontal = SizeConstants.LargeSize)
-                        .clip(shape = RoundedCornerShape(size = SizeConstants.LargeSize))
-            ) {
-                SettingsPreferenceItem(title = deviceInfo, summary = screenState.data?.deviceInfo ?: "") {
-                    ClipboardHelper.copyTextToClipboard(
-                        context = context,
-                        label = deviceInfo,
-                        text = screenState.data?.deviceInfo ?: "",
-                        onShowSnackbar = { viewModel.onEvent(event = AboutEvent.CopyDeviceInfo) },
+    ScreenStateHandler(screenState = screenState, onLoading = { LoadingScreen() }, onEmpty = { NoDataScreen() }, onSuccess = { data: UiAboutScreen ->
+        LazyColumn(modifier = Modifier.fillMaxHeight() , contentPadding = paddingValues) {
+            item {
+                PreferenceCategoryItem(title = stringResource(id = R.string.app_info))
+                SmallVerticalSpacer()
+                Column(
+                    modifier = Modifier
+                            .padding(horizontal = SizeConstants.LargeSize)
+                            .clip(shape = RoundedCornerShape(size = SizeConstants.LargeSize))
+                ) {
+                    SettingsPreferenceItem(title = stringResource(id = R.string.app_full_name), summary = stringResource(id = R.string.copyright))
+                    ExtraTinyVerticalSpacer()
+                    SettingsPreferenceItem(
+                        title = stringResource(id = R.string.app_build_version),
+                        summary = "${data.appVersion} (${data.appVersionCode})",
                     )
+                    ExtraTinyVerticalSpacer()
+                    SettingsPreferenceItem(title = stringResource(id = R.string.oss_license_title), summary = stringResource(id = R.string.summary_preference_settings_oss)) {
+                        IntentsHelper.openActivity(context = context, activityClass = LicensesActivity::class.java)
+                    }
+                }
+            }
+
+            item {
+                PreferenceCategoryItem(title = deviceInfo)
+                SmallVerticalSpacer()
+                Column(
+                    modifier = Modifier
+                            .padding(horizontal = SizeConstants.LargeSize)
+                            .clip(shape = RoundedCornerShape(size = SizeConstants.LargeSize))
+                ) {
+                    SettingsPreferenceItem(title = deviceInfo, summary = data.deviceInfo) {
+                        ClipboardHelper.copyTextToClipboard(
+                            context = context,
+                            label = deviceInfo,
+                            text = data.deviceInfo,
+                            onShowSnackbar = { viewModel.onEvent(event = AboutEvent.CopyDeviceInfo) },
+                        )
+                    }
                 }
             }
         }
-    }
+    })
 
     DefaultSnackbarHandler(screenState = screenState, snackbarHostState = snackbarHostState, getDismissEvent = { AboutEvent.DismissSnackbar }, onEvent = { viewModel.onEvent(it) })
 }


### PR DESCRIPTION
## Summary
- handle loading and empty states in AboutSettingsList with ScreenStateHandler

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afea1b1cb4832dbff1de095ae1a9ed