### PR TITLE
Improve about repository coroutine handling

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/data/DefaultAboutRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/data/DefaultAboutRepository.kt
@@ -18,11 +18,13 @@ class DefaultAboutRepository(
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : AboutRepository {
 
-    override suspend fun getAboutInfo(): UiAboutScreen = withContext(ioDispatcher) {
-        UiAboutScreen(
-            appVersion = configProvider.appVersion,
-            appVersionCode = configProvider.appVersionCode,
-            deviceInfo = deviceProvider.deviceInfo,
-        )
+    override suspend fun getAboutInfo(): Result<UiAboutScreen> = withContext(ioDispatcher) {
+        runCatching {
+            UiAboutScreen(
+                appVersion = configProvider.appVersion,
+                appVersionCode = configProvider.appVersionCode,
+                deviceInfo = deviceProvider.deviceInfo,
+            )
+        }
     }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/domain/repository/AboutRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/domain/repository/AboutRepository.kt
@@ -8,6 +8,9 @@ import com.d4rk.android.libs.apptoolkit.app.about.domain.model.ui.UiAboutScreen
 interface AboutRepository {
     /**
      * Fetch information displayed on the about screen.
+     *
+     * @return A [Result] containing [UiAboutScreen] data or a failure when the
+     *         information could not be retrieved.
      */
-    suspend fun getAboutInfo(): UiAboutScreen
+    suspend fun getAboutInfo(): Result<UiAboutScreen>
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/ui/AboutViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/ui/AboutViewModel.kt
@@ -35,21 +35,23 @@ open class AboutViewModel(
 
     private fun loadAboutInfo() {
         viewModelScope.launch {
-            try {
-                val info = repository.getAboutInfo()
-                screenState.successData { info }
-            } catch (cancellation: CancellationException) {
-                throw cancellation
-            } catch (error: Exception) {
-                screenState.showSnackbar(
-                    snackbar = UiSnackbar(
-                        message = UiTextHelper.StringResource(resourceId = R.string.snack_device_info_failed),
-                        isError = true,
-                        timeStamp = System.nanoTime(),
-                        type = ScreenMessageType.SNACKBAR,
-                    ),
-                )
-            }
+            repository.getAboutInfo()
+                .onSuccess { info ->
+                    screenState.successData { info }
+                }
+                .onFailure { error ->
+                    if (error is CancellationException) {
+                        throw error
+                    }
+                    screenState.showSnackbar(
+                        snackbar = UiSnackbar(
+                            message = UiTextHelper.StringResource(resourceId = R.string.snack_device_info_failed),
+                            isError = true,
+                            timeStamp = System.nanoTime(),
+                            type = ScreenMessageType.SNACKBAR,
+                        ),
+                    )
+                }
         }
     }
 


### PR DESCRIPTION
## Summary
- make AboutRepository return a Result for better error propagation
- wrap DefaultAboutRepository IO work in runCatching and return Result
- handle Result in AboutViewModel and test failure path

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afec46cf14832d8f7748f63280dd92