### PR TITLE
Refactor about data flow to use Flow

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/data/DefaultAboutRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/data/DefaultAboutRepository.kt
@@ -6,7 +6,9 @@ import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.AboutSettin
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoProvider
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
 
 /**
  * Default implementation of [AboutRepository] that gathers device and build
@@ -18,13 +20,14 @@ class DefaultAboutRepository(
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : AboutRepository {
 
-    override suspend fun getAboutInfo(): Result<UiAboutScreen> = withContext(ioDispatcher) {
-        runCatching {
-            UiAboutScreen(
-                appVersion = configProvider.appVersion,
-                appVersionCode = configProvider.appVersionCode,
-                deviceInfo = deviceProvider.deviceInfo,
+    override fun getAboutInfoStream(): Flow<UiAboutScreen> =
+        flow {
+            emit(
+                UiAboutScreen(
+                    appVersion = configProvider.appVersion,
+                    appVersionCode = configProvider.appVersionCode,
+                    deviceInfo = deviceProvider.deviceInfo,
+                )
             )
-        }
-    }
+        }.flowOn(ioDispatcher)
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/domain/repository/AboutRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/domain/repository/AboutRepository.kt
@@ -1,16 +1,16 @@
 package com.d4rk.android.libs.apptoolkit.app.about.domain.repository
 
 import com.d4rk.android.libs.apptoolkit.app.about.domain.model.ui.UiAboutScreen
+import kotlinx.coroutines.flow.Flow
 
 /**
  * Repository responsible for providing data for the about screen.
  */
 interface AboutRepository {
     /**
-     * Fetch information displayed on the about screen.
+     * Stream information displayed on the about screen.
      *
-     * @return A [Result] containing [UiAboutScreen] data or a failure when the
-     *         information could not be retrieved.
+     * @return A [Flow] emitting [UiAboutScreen] data.
      */
-    suspend fun getAboutInfo(): Result<UiAboutScreen>
+    fun getAboutInfoStream(): Flow<UiAboutScreen>
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/ui/AboutViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/ui/AboutViewModel.kt
@@ -15,6 +15,8 @@ import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.ScreenMessageType
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
 import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 
 open class AboutViewModel(
@@ -35,11 +37,8 @@ open class AboutViewModel(
 
     private fun loadAboutInfo() {
         viewModelScope.launch {
-            repository.getAboutInfo()
-                .onSuccess { info ->
-                    screenState.successData { info }
-                }
-                .onFailure { error ->
+            repository.getAboutInfoStream()
+                .catch { error ->
                     if (error is CancellationException) {
                         throw error
                     }
@@ -51,6 +50,9 @@ open class AboutViewModel(
                             type = ScreenMessageType.SNACKBAR,
                         ),
                     )
+                }
+                .collect { info ->
+                    screenState.successData { info }
                 }
         }
     }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/about/ui/TestAboutViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/about/ui/TestAboutViewModel.kt
@@ -10,6 +10,8 @@ import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoPr
 import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.UnconfinedDispatcherExtension
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
@@ -45,8 +47,9 @@ class TestAboutViewModel {
     private fun createFailingViewModel(): AboutViewModel =
         AboutViewModel(
             repository = object : AboutRepository {
-                override suspend fun getAboutInfo(): Result<UiAboutScreen> =
-                    Result.failure(Exception("fail"))
+                override fun getAboutInfoStream(): Flow<UiAboutScreen> = flow {
+                    throw Exception("fail")
+                }
             },
         )
 


### PR DESCRIPTION
## Summary
- expose About repository data as Flow via getAboutInfoStream
- collect about info Flow in AboutViewModel with error handling
- adjust AboutViewModel tests for Flow-based repository

## Testing
- `./gradlew apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68afed684938832dbadd48c64b551ccf