### PR TITLE
Align about module with coroutine architecture

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/data/DefaultAboutRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/data/DefaultAboutRepository.kt
@@ -10,7 +10,6 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.withContext
 
 /**
@@ -27,14 +26,15 @@ class DefaultAboutRepository(
 
     override fun getAboutInfoStream(): Flow<UiAboutScreen> =
         flow {
-            emit(
+            val info = withContext(ioDispatcher) {
                 UiAboutScreen(
                     appVersion = configProvider.appVersion,
                     appVersionCode = configProvider.appVersionCode,
                     deviceInfo = deviceProvider.deviceInfo,
                 )
-            )
-        }.flowOn(ioDispatcher)
+            }
+            emit(info)
+        }
 
     override suspend fun copyDeviceInfo(label: String, deviceInfo: String) {
         withContext(mainDispatcher) {


### PR DESCRIPTION
## Summary
- ensure `DefaultAboutRepository` does background work on the IO dispatcher
- collect the about info flow from `viewModelScope` for structured concurrency

## Testing
- `./gradlew :apptoolkit:test` *(fails: Could not determine dependencies; missing SDK packages and licenses)*

------
https://chatgpt.com/codex/tasks/task_e_68aff260c5f0832d9cc7bf0e46ee378d