### PR TITLE
refactor: use flowOn for about info

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/data/DefaultAboutRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/data/DefaultAboutRepository.kt
@@ -10,6 +10,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.withContext
 
 /**
@@ -26,15 +27,14 @@ class DefaultAboutRepository(
 
     override fun getAboutInfoStream(): Flow<UiAboutScreen> =
         flow {
-            val info = withContext(ioDispatcher) {
+            emit(
                 UiAboutScreen(
                     appVersion = configProvider.appVersion,
                     appVersionCode = configProvider.appVersionCode,
                     deviceInfo = deviceProvider.deviceInfo,
                 )
-            }
-            emit(info)
-        }
+            )
+        }.flowOn(ioDispatcher)
 
     override suspend fun copyDeviceInfo(label: String, deviceInfo: String) {
         withContext(mainDispatcher) {


### PR DESCRIPTION
## Summary
- refactor about repository to build flow without switching context and apply flowOn for IO operations

## Testing
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aff431b770832d848f7d5dccac5fe7