### PR TITLE
Update about module tests for suspend repository

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/domain/repository/AboutRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/domain/repository/AboutRepository.kt
@@ -1,16 +1,15 @@
 package com.d4rk.android.libs.apptoolkit.app.about.domain.repository
 
 import com.d4rk.android.libs.apptoolkit.app.about.domain.model.ui.UiAboutScreen
-import kotlinx.coroutines.flow.Flow
 
 /**
  * Repository responsible for providing data for the about screen.
  */
 interface AboutRepository {
     /**
-     * Stream information displayed on the about screen.
+     * Retrieve information displayed on the about screen.
      *
-     * @return A [Flow] emitting [UiAboutScreen] data.
+     * @return A [UiAboutScreen] data object.
      */
     suspend fun getAboutInfoStream(): UiAboutScreen
 

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/about/ui/TestAboutViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/about/ui/TestAboutViewModel.kt
@@ -9,8 +9,6 @@ import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoPr
 import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.UnconfinedDispatcherExtension
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
@@ -37,15 +35,12 @@ class TestAboutViewModel {
     private fun createViewModel(): AboutViewModel =
         AboutViewModel(
             repository = object : AboutRepository {
-                override fun getAboutInfoStream(): Flow<UiAboutScreen> = flow {
-                    emit(
-                        UiAboutScreen(
-                            appVersion = buildInfoProvider.appVersion,
-                            appVersionCode = buildInfoProvider.appVersionCode,
-                            deviceInfo = deviceProvider.deviceInfo,
-                        )
+                override suspend fun getAboutInfoStream(): UiAboutScreen =
+                    UiAboutScreen(
+                        appVersion = buildInfoProvider.appVersion,
+                        appVersionCode = buildInfoProvider.appVersionCode,
+                        deviceInfo = deviceProvider.deviceInfo,
                     )
-                }
 
                 override suspend fun copyDeviceInfo(label: String, deviceInfo: String) { /* no-op */ }
             },
@@ -54,7 +49,7 @@ class TestAboutViewModel {
     private fun createFailingViewModel(): AboutViewModel =
         AboutViewModel(
             repository = object : AboutRepository {
-                override fun getAboutInfoStream(): Flow<UiAboutScreen> = flow {
+                override suspend fun getAboutInfoStream(): UiAboutScreen {
                     throw Exception("fail")
                 }
 


### PR DESCRIPTION
## Summary
- update AboutRepository docs to reflect suspend function
- refactor AboutViewModel tests to use suspend-based repository instead of flows

## Testing
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aff67a1410832d8afaac92ef27f155