### PR TITLE
Use Result wrapper for ads settings operations

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/data/DefaultAdsSettingsRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/data/DefaultAdsSettingsRepository.kt
@@ -2,10 +2,11 @@ package com.d4rk.android.libs.apptoolkit.app.ads.data
 
 import com.d4rk.android.libs.apptoolkit.app.ads.domain.repository.AdsSettingsRepository
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoProvider
+import com.d4rk.android.libs.apptoolkit.core.domain.model.Result
 import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flowOn
@@ -30,7 +31,13 @@ class DefaultAdsSettingsRepository(
             }
             .flowOn(ioDispatcher)
 
-    override suspend fun setAdsEnabled(enabled: Boolean) = withContext(ioDispatcher) {
-        dataStore.saveAds(isChecked = enabled)
+    override suspend fun setAdsEnabled(enabled: Boolean): Result<Unit> = withContext(ioDispatcher) {
+        try {
+            dataStore.saveAds(isChecked = enabled)
+            Result.Success(Unit)
+        } catch (e: Exception) {
+            if (e is CancellationException) throw e
+            Result.Error(e)
+        }
     }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/domain/repository/AdsSettingsRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/domain/repository/AdsSettingsRepository.kt
@@ -1,6 +1,7 @@
 package com.d4rk.android.libs.apptoolkit.app.ads.domain.repository
 
 import kotlinx.coroutines.flow.Flow
+import com.d4rk.android.libs.apptoolkit.core.domain.model.Result
 
 /**
  * Repository that exposes and persists the ads display preference.
@@ -13,5 +14,5 @@ interface AdsSettingsRepository {
     fun observeAdsEnabled(): Flow<Boolean>
 
     /** Persist the ads enabled preference. */
-    suspend fun setAdsEnabled(enabled: Boolean)
+    suspend fun setAdsEnabled(enabled: Boolean): Result<Unit>
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/ui/AdsSettingsViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/ui/AdsSettingsViewModel.kt
@@ -5,6 +5,7 @@ import com.d4rk.android.libs.apptoolkit.app.ads.domain.actions.AdsSettingsAction
 import com.d4rk.android.libs.apptoolkit.app.ads.domain.actions.AdsSettingsEvent
 import com.d4rk.android.libs.apptoolkit.app.ads.domain.model.ui.UiAdsSettingsScreen
 import com.d4rk.android.libs.apptoolkit.app.ads.domain.repository.AdsSettingsRepository
+import com.d4rk.android.libs.apptoolkit.core.domain.model.Result
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.setLoading
@@ -14,7 +15,6 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
-import java.io.IOException
 
 /** ViewModel for Ads settings screen. */
 class AdsSettingsViewModel(
@@ -52,10 +52,9 @@ class AdsSettingsViewModel(
 
     private fun setAdsEnabled(enabled: Boolean) {
         viewModelScope.launch {
-            try {
-                repository.setAdsEnabled(enabled)
-            } catch (e: IOException) {
-                screenState.updateData(newState = ScreenState.Error()) { current ->
+            when (repository.setAdsEnabled(enabled)) {
+                is Result.Success -> Unit
+                is Result.Error -> screenState.updateData(newState = ScreenState.Error()) { current ->
                     current.copy(adsEnabled = !enabled)
                 }
             }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/domain/model/Result.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/domain/model/Result.kt
@@ -1,0 +1,9 @@
+package com.d4rk.android.libs.apptoolkit.core.domain.model
+
+/**
+ * Simple wrapper for operation results.
+ */
+sealed class Result<out T> {
+    data class Success<out R>(val data: R) : Result<R>()
+    data class Error(val exception: Exception) : Result<Nothing>()
+}

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/ads/data/TestDefaultAdsSettingsRepository.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/ads/data/TestDefaultAdsSettingsRepository.kt
@@ -4,6 +4,7 @@ import app.cash.turbine.test
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoProvider
 import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.UnconfinedDispatcherExtension
 import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
+import com.d4rk.android.libs.apptoolkit.core.domain.model.Result
 import com.google.common.truth.Truth.assertThat
 import io.mockk.every
 import io.mockk.coEvery
@@ -84,14 +85,28 @@ class TestDefaultAdsSettingsRepository {
     }
 
     @Test
-    fun `setAdsEnabled persists preference`() = runTest(dispatcherExtension.testDispatcher) {
-        println("\uD83D\uDE80 [TEST] setAdsEnabled persists preference")
+    fun `setAdsEnabled returns success when persisted`() = runTest(dispatcherExtension.testDispatcher) {
+        println("\uD83D\uDE80 [TEST] setAdsEnabled returns success when persisted")
         val dataStore = mockk<CommonDataStore>()
         coEvery { dataStore.saveAds(any()) } returns Unit
         val repository = createRepository(dataStore, isDebugBuild = false)
 
-        repository.setAdsEnabled(true)
+        val result = repository.setAdsEnabled(true)
 
+        assertThat(result).isInstanceOf(Result.Success::class.java)
+        coVerify { dataStore.saveAds(isChecked = true) }
+    }
+
+    @Test
+    fun `setAdsEnabled returns error on failure`() = runTest(dispatcherExtension.testDispatcher) {
+        println("\uD83D\uDE80 [TEST] setAdsEnabled returns error on failure")
+        val dataStore = mockk<CommonDataStore>()
+        coEvery { dataStore.saveAds(any()) } throws IOException("boom")
+        val repository = createRepository(dataStore, isDebugBuild = false)
+
+        val result = repository.setAdsEnabled(true)
+
+        assertThat(result).isInstanceOf(Result.Error::class.java)
         coVerify { dataStore.saveAds(isChecked = true) }
     }
 }


### PR DESCRIPTION
## Summary
- add generic `Result` type
- wrap ads settings persistence with `Result` for structured error handling
- update ViewModel and tests to use `Result`

## Testing
- `./gradlew -q :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68affed01968832d946a6cce43288ea8