### PR TITLE
Refactor consent helper to coroutines

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/ui/AdsSettingsScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/ui/AdsSettingsScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Modifier
@@ -30,11 +31,13 @@ import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.ConsentFormHelper
 import com.google.android.ump.ConsentInformation
 import com.google.android.ump.UserMessagingPlatform
+import kotlinx.coroutines.launch
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AdsSettingsScreen(activity: Activity, viewModel: AdsSettingsViewModel) {
     val screenState: UiStateScreen<UiAdsSettingsScreen> by viewModel.uiState.collectAsStateWithLifecycle()
+    val coroutineScope = rememberCoroutineScope()
 
     LargeTopAppBarWithScaffold(
         title = stringResource(id = R.string.ads),
@@ -67,8 +70,11 @@ fun AdsSettingsScreen(activity: Activity, viewModel: AdsSettingsViewModel) {
                                 enabled = data.adsEnabled,
                                 summary = stringResource(id = R.string.summary_ads_personalized_ads),
                                 onClick = {
-                                    val consentInfo: ConsentInformation = UserMessagingPlatform.getConsentInformation(activity)
-                                    ConsentFormHelper.showConsentForm(activity = activity, consentInfo = consentInfo)
+                                    coroutineScope.launch {
+                                        val consentInfo: ConsentInformation =
+                                            UserMessagingPlatform.getConsentInformation(activity)
+                                        ConsentFormHelper.showConsentForm(activity = activity, consentInfo = consentInfo)
+                                    }
                                 }
                             )
                         }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupActivity.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupActivity.kt
@@ -73,13 +73,13 @@ class StartupActivity : AppCompatActivity() {
         finish()
     }
 
-    private fun checkUserConsent() {
-        val consentInfo : ConsentInformation =
+    private suspend fun checkUserConsent() {
+        val consentInfo: ConsentInformation =
             UserMessagingPlatform.getConsentInformation(this)
         ConsentFormHelper.showConsentFormIfRequired(
             activity = this,
             consentInfo = consentInfo,
-            onFormShown = { viewModel.onEvent(StartupEvent.ConsentFormLoaded) }
         )
+        viewModel.onEvent(StartupEvent.ConsentFormLoaded)
     }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/ConsentFormHelper.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/ConsentFormHelper.kt
@@ -6,71 +6,101 @@ import com.google.android.ump.ConsentForm
 import com.google.android.ump.ConsentInformation
 import com.google.android.ump.ConsentRequestParameters
 import com.google.android.ump.UserMessagingPlatform
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
 
+/**
+ * Helper functions for showing the Google UMP consent dialog.
+ *
+ * These methods expose a suspend API so callers can work with coroutines and
+ * remain on the main thread while the underlying UMP SDK performs network and
+ * I/O work on background threads.
+ */
 object ConsentFormHelper {
 
-    fun showConsentFormIfRequired(
-        activity : Activity ,
-        consentInfo : ConsentInformation ,
-        onFormShown : () -> Unit = {}
+    /**
+     * Request consent information and display the consent form if required.
+     * The function returns once the form has been displayed or it has been
+     * determined that showing the form isn't necessary.
+     */
+    suspend fun showConsentFormIfRequired(
+        activity: Activity,
+        consentInfo: ConsentInformation,
     ) {
-        val params : ConsentRequestParameters =
+        val params: ConsentRequestParameters =
             ConsentRequestParameters.Builder().setTagForUnderAgeOfConsent(false).build()
 
-        consentInfo.requestConsentInfoUpdate(activity , params , {
-            if (consentInfo.consentStatus != ConsentInformation.ConsentStatus.REQUIRED &&
-                consentInfo.consentStatus != ConsentInformation.ConsentStatus.UNKNOWN) {
-                onFormShown()
-                return@requestConsentInfoUpdate
-            }
+        suspendCancellableCoroutine { continuation ->
+            consentInfo.requestConsentInfoUpdate(activity, params, {
+                if (consentInfo.consentStatus != ConsentInformation.ConsentStatus.REQUIRED &&
+                    consentInfo.consentStatus != ConsentInformation.ConsentStatus.UNKNOWN) {
+                    if (continuation.isActive) continuation.resume(Unit)
+                    return@requestConsentInfoUpdate
+                }
 
-            runCatching {
-                UserMessagingPlatform.loadConsentForm(activity , { consentForm : ConsentForm ->
-                    runCatching {
-                        consentForm.show(activity) { onFormShown() }
-                    }.onFailure {
-                        Log.e("ConsentFormHelper", "Failed to load consent form", it)
-                        onFormShown()
-                    }
-                } , { t ->
-                    Log.e("ConsentFormHelper", "Failed to load consent form: ${t.message}")
-                    onFormShown()
-                })
-            }.onFailure {
-                Log.e("ConsentFormHelper", "Failed to load consent form", it)
-                onFormShown()
-            }
-        } , {})
+                runCatching {
+                    UserMessagingPlatform.loadConsentForm(activity, { consentForm: ConsentForm ->
+                        runCatching {
+                            consentForm.show(activity) {
+                                if (continuation.isActive) continuation.resume(Unit)
+                            }
+                        }.onFailure {
+                            Log.e("ConsentFormHelper", "Failed to load consent form", it)
+                            if (continuation.isActive) continuation.resume(Unit)
+                        }
+                    }, { t ->
+                        Log.e("ConsentFormHelper", "Failed to load consent form: ${t.message}")
+                        if (continuation.isActive) continuation.resume(Unit)
+                    })
+                }.onFailure {
+                    Log.e("ConsentFormHelper", "Failed to load consent form", it)
+                    if (continuation.isActive) continuation.resume(Unit)
+                }
+            }, {
+                if (continuation.isActive) continuation.resume(Unit)
+            })
+        }
     }
 
-    fun showConsentForm(
-        activity : Activity ,
-        consentInfo : ConsentInformation ,
-        onFormShown : () -> Unit = {}
+    /**
+     * Always show the consent form regardless of the current consent status.
+     * The function returns once the form has been displayed (or if loading the
+     * form failed).
+     */
+    suspend fun showConsentForm(
+        activity: Activity,
+        consentInfo: ConsentInformation,
     ) {
-        val params : ConsentRequestParameters =
+        val params: ConsentRequestParameters =
             ConsentRequestParameters.Builder().setTagForUnderAgeOfConsent(false).build()
 
-        consentInfo.requestConsentInfoUpdate(activity , params , {
-            if (consentInfo.consentStatus != ConsentInformation.ConsentStatus.REQUIRED &&
-                consentInfo.consentStatus != ConsentInformation.ConsentStatus.UNKNOWN) {
-                onFormShown()
-                return@requestConsentInfoUpdate
-            }
+        suspendCancellableCoroutine { continuation ->
+            consentInfo.requestConsentInfoUpdate(activity, params, {
+                if (consentInfo.consentStatus != ConsentInformation.ConsentStatus.REQUIRED &&
+                    consentInfo.consentStatus != ConsentInformation.ConsentStatus.UNKNOWN) {
+                    if (continuation.isActive) continuation.resume(Unit)
+                    return@requestConsentInfoUpdate
+                }
 
-            runCatching {
-                UserMessagingPlatform.loadConsentForm(activity , { consentForm : ConsentForm ->
-                    runCatching {
-                        consentForm.show(activity) { onFormShown() }
-                    }.onFailure {
-                        onFormShown()
-                    }
-                } , { t ->
-                    onFormShown()
-                })
-            }.onFailure {
-                onFormShown()
-            }
-        } , {})
+                runCatching {
+                    UserMessagingPlatform.loadConsentForm(activity, { consentForm: ConsentForm ->
+                        runCatching {
+                            consentForm.show(activity) {
+                                if (continuation.isActive) continuation.resume(Unit)
+                            }
+                        }.onFailure {
+                            if (continuation.isActive) continuation.resume(Unit)
+                        }
+                    }, {
+                        if (continuation.isActive) continuation.resume(Unit)
+                    })
+                }.onFailure {
+                    if (continuation.isActive) continuation.resume(Unit)
+                }
+            }, {
+                if (continuation.isActive) continuation.resume(Unit)
+            })
+        }
     }
 }
+

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestConsentFormHelper.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestConsentFormHelper.kt
@@ -5,13 +5,13 @@ import com.google.android.ump.ConsentForm
 import com.google.android.ump.ConsentInformation
 import com.google.android.ump.UserMessagingPlatform
 import io.mockk.*
-import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
 import org.junit.Test
 
 class TestConsentFormHelper {
     @Test
-    fun `showConsentForm success invokes onFormShown`() {
-        println("🚀 [TEST] showConsentForm success invokes onFormShown")
+    fun `showConsentForm success returns`() = runBlocking {
+        println("🚀 [TEST] showConsentForm success returns")
         val activity = mockk<Activity>()
         val consentInfo = mockk<ConsentInformation>()
         val consentForm = mockk<ConsentForm>()
@@ -31,15 +31,13 @@ class TestConsentFormHelper {
             onDismissed()
         }
 
-        var called = false
-        ConsentFormHelper.showConsentForm(activity, consentInfo) { called = true }
-
-        assertTrue(called)
-        println("🏁 [TEST DONE] showConsentForm success invokes onFormShown")
+        ConsentFormHelper.showConsentForm(activity, consentInfo)
+        verify { consentForm.show(activity, any()) }
+        println("🏁 [TEST DONE] showConsentForm success returns")
     }
 
     @Test
-    fun `showConsentForm handles exception from loadConsentForm`() {
+    fun `showConsentForm handles exception from loadConsentForm`() = runBlocking {
         println("🚀 [TEST] showConsentForm handles exception from loadConsentForm")
         val activity = mockk<Activity>()
         val consentInfo = mockk<ConsentInformation>()
@@ -52,14 +50,12 @@ class TestConsentFormHelper {
         mockkStatic(UserMessagingPlatform::class)
         every { UserMessagingPlatform.loadConsentForm(any(), any(), any()) } throws RuntimeException("fail")
 
-        var called = false
-        ConsentFormHelper.showConsentForm(activity, consentInfo) { called = true }
-
-        assertTrue(called)
+        ConsentFormHelper.showConsentForm(activity, consentInfo)
         println("🏁 [TEST DONE] showConsentForm handles exception from loadConsentForm")
     }
+
     @Test
-    fun `showConsentForm handles OutOfMemoryError from loadConsentForm`() {
+    fun `showConsentForm handles OutOfMemoryError from loadConsentForm`() = runBlocking {
         println("🚀 [TEST] showConsentForm handles OutOfMemoryError from loadConsentForm")
         val activity = mockk<Activity>()
         val consentInfo = mockk<ConsentInformation>()
@@ -72,10 +68,7 @@ class TestConsentFormHelper {
         mockkStatic(UserMessagingPlatform::class)
         every { UserMessagingPlatform.loadConsentForm(any(), any(), any()) } throws OutOfMemoryError("oom")
 
-        var called = false
-        ConsentFormHelper.showConsentForm(activity, consentInfo) { called = true }
-
-        assertTrue(called)
+        ConsentFormHelper.showConsentForm(activity, consentInfo)
         println("🏁 [TEST DONE] showConsentForm handles OutOfMemoryError from loadConsentForm")
     }
 }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestConsentFormHelperIfRequired.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestConsentFormHelperIfRequired.kt
@@ -6,12 +6,12 @@ import com.google.android.ump.ConsentForm
 import com.google.android.ump.ConsentInformation
 import com.google.android.ump.UserMessagingPlatform
 import io.mockk.*
-import kotlin.test.assertTrue
+import kotlinx.coroutines.runBlocking
 import org.junit.Test
 
 class TestConsentFormHelperIfRequired {
     @Test
-    fun `showConsentFormIfRequired when required loads and shows form`() {
+    fun `showConsentFormIfRequired when required loads and shows form`() = runBlocking {
         println("🚀 [TEST] showConsentFormIfRequired when required loads and shows form")
         val activity = mockk<Activity>()
         val consentInfo = mockk<ConsentInformation>()
@@ -33,17 +33,15 @@ class TestConsentFormHelperIfRequired {
             onDismissed()
         }
 
-        var called = false
-        ConsentFormHelper.showConsentFormIfRequired(activity, consentInfo) { called = true }
+        ConsentFormHelper.showConsentFormIfRequired(activity, consentInfo)
 
-        assertTrue(called)
         verify { UserMessagingPlatform.loadConsentForm(any(), any(), any()) }
         verify { consentForm.show(activity, any()) }
         println("🏁 [TEST DONE] showConsentFormIfRequired when required loads and shows form")
     }
 
     @Test
-    fun `showConsentFormIfRequired when not required skips loading`() {
+    fun `showConsentFormIfRequired when not required skips loading`() = runBlocking {
         println("🚀 [TEST] showConsentFormIfRequired when not required skips loading")
         val activity = mockk<Activity>()
         val consentInfo = mockk<ConsentInformation>()
@@ -56,16 +54,14 @@ class TestConsentFormHelperIfRequired {
 
         mockkStatic(UserMessagingPlatform::class)
 
-        var called = false
-        ConsentFormHelper.showConsentFormIfRequired(activity, consentInfo) { called = true }
+        ConsentFormHelper.showConsentFormIfRequired(activity, consentInfo)
 
-        assertTrue(called)
         verify(exactly = 0) { UserMessagingPlatform.loadConsentForm(any(), any(), any()) }
         println("🏁 [TEST DONE] showConsentFormIfRequired when not required skips loading")
     }
 
     @Test
-    fun `showConsentFormIfRequired handles load error`() {
+    fun `showConsentFormIfRequired handles load error`() = runBlocking {
         println("🚀 [TEST] showConsentFormIfRequired handles load error")
         val activity = mockk<Activity>()
         val consentInfo = mockk<ConsentInformation>()
@@ -81,10 +77,8 @@ class TestConsentFormHelperIfRequired {
         mockkStatic(Log::class)
         every { Log.e(any(), any(), any()) } returns 0
 
-        var called = false
-        ConsentFormHelper.showConsentFormIfRequired(activity, consentInfo) { called = true }
+        ConsentFormHelper.showConsentFormIfRequired(activity, consentInfo)
 
-        assertTrue(called)
         verify { Log.e(any(), any(), any()) }
         println("🏁 [TEST DONE] showConsentFormIfRequired handles load error")
     }


### PR DESCRIPTION
## Summary
- convert consent dialog helper to suspend functions for coroutine-based usage
- update startup and ads flows to call suspend helper using structured concurrency
- adjust tests for new coroutine APIs

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b000e43594832db84626a5acf6b4fb