### PR TITLE
Use suspend API for billing queries

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportViewModel.kt
@@ -88,20 +88,7 @@ class SupportViewModel(
         }
 
         viewModelScope.launch {
-            billingRepository.queryProductDetails(
-                listOf(
-                    DonationProductIds.LOW_DONATION,
-                    DonationProductIds.NORMAL_DONATION,
-                    DonationProductIds.HIGH_DONATION,
-                    DonationProductIds.EXTREME_DONATION
-                )
-            )
-        }
-    }
-
-    override fun onEvent(event: SupportEvent) {
-        when (event) {
-            is SupportEvent.QueryProductDetails -> viewModelScope.launch {
+            try {
                 billingRepository.queryProductDetails(
                     listOf(
                         DonationProductIds.LOW_DONATION,
@@ -110,6 +97,47 @@ class SupportViewModel(
                         DonationProductIds.EXTREME_DONATION
                     )
                 )
+            } catch (e: Exception) {
+                screenState.updateData(newState = ScreenState.Error()) { current ->
+                    current.copy(error = e.message)
+                }
+                screenState.showSnackbar(
+                    UiSnackbar(
+                        message = UiTextHelper.DynamicString(e.message ?: ""),
+                        isError = true,
+                        timeStamp = System.currentTimeMillis(),
+                        type = ScreenMessageType.SNACKBAR
+                    )
+                )
+            }
+        }
+    }
+
+    override fun onEvent(event: SupportEvent) {
+        when (event) {
+            is SupportEvent.QueryProductDetails -> viewModelScope.launch {
+                try {
+                    billingRepository.queryProductDetails(
+                        listOf(
+                            DonationProductIds.LOW_DONATION,
+                            DonationProductIds.NORMAL_DONATION,
+                            DonationProductIds.HIGH_DONATION,
+                            DonationProductIds.EXTREME_DONATION
+                        )
+                    )
+                } catch (e: Exception) {
+                    screenState.updateData(newState = ScreenState.Error()) { current ->
+                        current.copy(error = e.message)
+                    }
+                    screenState.showSnackbar(
+                        UiSnackbar(
+                            message = UiTextHelper.DynamicString(e.message ?: ""),
+                            isError = true,
+                            timeStamp = System.currentTimeMillis(),
+                            type = ScreenMessageType.SNACKBAR
+                        )
+                    )
+                }
             }
 
             SupportEvent.DismissSnackbar -> screenState.dismissSnackbar()

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportViewModelTest.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportViewModelTest.kt
@@ -10,6 +10,7 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
 import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.UnconfinedDispatcherExtension
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
 import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -32,7 +33,7 @@ class SupportViewModelTest {
     private val billingRepository = mockk<BillingRepository>(relaxed = true) {
         every { productDetails } returns productDetailsFlow
         every { purchaseResult } returns purchaseResultFlow
-        every { queryProductDetails(any()) } returns Unit
+        coEvery { queryProductDetails(any()) } returns Unit
         every { launchPurchaseFlow(any(), any()) } returns Unit
     }
 


### PR DESCRIPTION
## Summary
- Convert billing product query to a suspend function using coroutines
- Handle repository errors in SupportViewModel with user-visible snackbar
- Adjust tests for new suspend repository API

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0012500fc832d9a41e037fb17e322