### PR TITLE
Refactor apps list feature to follow architecture guidelines

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/actions/HomeAction.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/actions/HomeAction.kt
@@ -3,3 +3,4 @@ package com.d4rk.android.apps.apptoolkit.app.apps.list.domain.actions
 import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.ActionEvent
 
 sealed interface HomeAction : ActionEvent
+

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListViewModel.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListViewModel.kt
@@ -1,107 +1,86 @@
 package com.d4rk.android.apps.apptoolkit.app.apps.list.ui
 
 import androidx.lifecycle.viewModelScope
+import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases.ObserveFavoritesUseCase
+import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases.ToggleFavoriteUseCase
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.actions.HomeAction
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.actions.HomeEvent
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.ui.UiHomeScreen
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.usecases.FetchDeveloperAppsUseCase
-import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases.ObserveFavoritesUseCase
-import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases.ToggleFavoriteUseCase
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.RootError
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
-import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiSnackbar
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.showSnackbar
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.updateData
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.updateState
 import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.ScreenMessageType
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
-import kotlinx.coroutines.CoroutineStart
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.collect
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class AppsListViewModel(
-    private val fetchDeveloperAppsUseCase : FetchDeveloperAppsUseCase,
+    private val fetchDeveloperAppsUseCase: FetchDeveloperAppsUseCase,
     private val observeFavoritesUseCase: ObserveFavoritesUseCase,
     private val toggleFavoriteUseCase: ToggleFavoriteUseCase,
-) : ScreenViewModel<UiHomeScreen , HomeEvent , HomeAction>(
-    initialState = UiStateScreen(screenState = ScreenState.IsLoading() , data = UiHomeScreen())
+) : ScreenViewModel<UiHomeScreen, HomeEvent, HomeAction>(
+    initialState = UiStateScreen(screenState = ScreenState.IsLoading(), data = UiHomeScreen())
 ) {
 
-    private val _favorites = MutableStateFlow<Set<String>>(emptySet())
-    private val favoritesLoaded = MutableStateFlow(false)
+    private val fetchAppsTrigger = MutableSharedFlow<Unit>(replay = 1)
 
-    val favorites = _favorites.stateIn(
-        scope = viewModelScope,
-        started = SharingStarted.Eagerly,
-        initialValue = emptySet()
-    )
+    val favorites = observeFavoritesUseCase()
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = emptySet()
+        )
 
     init {
-        viewModelScope.launch(start = CoroutineStart.UNDISPATCHED) {
-            runCatching {
-                observeFavoritesUseCase()
-                    .onEach {
-                        favoritesLoaded.value = true
-                        _favorites.value = it
-                    }
-                    .collect()
-            }
-        }
-
-        viewModelScope.launch(start = CoroutineStart.UNDISPATCHED) {
-            favoritesLoaded.filter { it }.first()
-            onEvent(HomeEvent.FetchApps)
-        }
-    }
-
-    override fun onEvent(event : HomeEvent) {
-        when (event) {
-            HomeEvent.FetchApps -> fetchDeveloperApps()
-        }
-    }
-
-    private fun fetchDeveloperApps() {
-        viewModelScope.launch {
-            try {
-                fetchDeveloperAppsUseCase().collect { result: DataState<List<AppInfo>, RootError> ->
-                    when (result) {
-                        is DataState.Success -> {
-                            val apps = result.data
-                            if (apps.isEmpty()) {
-                                screenState.update { currentState ->
-                                    currentState.copy(
-                                        screenState = ScreenState.NoData(),
-                                        data = currentState.data?.copy(apps = emptyList()),
-                                    )
-                                }
-                            } else {
-                                screenState.updateData(newState = ScreenState.Success()) { currentData ->
-                                    currentData.copy(apps = apps)
-                                }
+        fetchAppsTrigger
+            .flatMapLatest { fetchDeveloperAppsUseCase() }
+            .onEach { result ->
+                when (result) {
+                    is DataState.Success -> {
+                        val apps = result.data
+                        if (apps.isEmpty()) {
+                            screenState.update { current ->
+                                current.copy(
+                                    screenState = ScreenState.NoData(),
+                                    data = UiHomeScreen(apps = emptyList())
+                                )
+                            }
+                        } else {
+                            screenState.updateData(newState = ScreenState.Success()) { currentData ->
+                                currentData.copy(apps = apps)
                             }
                         }
-
-                        is DataState.Error -> showLoadAppsError()
-
-                        is DataState.Loading -> {
-                            screenState.updateState(ScreenState.IsLoading())
-                        }
                     }
+
+                    is DataState.Error -> showLoadAppsError()
+
+                    is DataState.Loading -> screenState.updateState(ScreenState.IsLoading())
                 }
-            } catch (error: Throwable) {
-                showLoadAppsError()
             }
+            .catch { showLoadAppsError() }
+            .launchIn(viewModelScope)
+
+        fetchAppsTrigger.tryEmit(Unit)
+    }
+
+    override fun onEvent(event: HomeEvent) {
+        when (event) {
+            HomeEvent.FetchApps -> fetchAppsTrigger.tryEmit(Unit)
         }
     }
 
@@ -119,14 +98,13 @@ class AppsListViewModel(
 
     fun toggleFavorite(packageName: String) {
         viewModelScope.launch {
-            runCatching {
-                toggleFavoriteUseCase(packageName)
-            }.onFailure { error ->
-                error.printStackTrace()
-                screenState.update { currentState ->
-                    currentState.copy(screenState = ScreenState.Error())
+            runCatching { toggleFavoriteUseCase(packageName) }
+                .onFailure { error ->
+                    error.printStackTrace()
+                    screenState.update { currentState ->
+                        currentState.copy(screenState = ScreenState.Error())
+                    }
                 }
-            }
         }
     }
 }


### PR DESCRIPTION
## Summary
- refactor apps list ViewModel to use flow triggers and stateIn for favorites
- clean up action definition

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b00d3aa858832d9dbf85e5eab1efe0