### PR TITLE
Align developer apps flow with architecture guidelines

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsViewModel.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsViewModel.kt
@@ -5,9 +5,11 @@ import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.actions.Favori
 import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.actions.FavoriteAppsEvent
 import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases.ObserveFavoritesUseCase
 import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases.ToggleFavoriteUseCase
+import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.ui.UiHomeScreen
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.usecases.FetchDeveloperAppsUseCase
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.RootError
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState.*
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
@@ -21,6 +23,7 @@ import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
@@ -72,7 +75,10 @@ class FavoriteAppsViewModel(
     private fun loadFavorites() {
         viewModelScope.launch(start = CoroutineStart.UNDISPATCHED) {
             combine(
-                flow = fetchDeveloperAppsUseCase(),
+                flow = flow {
+                    emit(DataState.Loading<List<AppInfo>, RootError>())
+                    emit(fetchDeveloperAppsUseCase())
+                },
                 flow2 = favorites
             ) { dataState, favsSet ->
                 dataState to favsSet

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/repository/DeveloperAppsRepository.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/repository/DeveloperAppsRepository.kt
@@ -1,11 +1,7 @@
 package com.d4rk.android.apps.apptoolkit.app.apps.list.domain.repository
 
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
-import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
-import com.d4rk.android.libs.apptoolkit.core.domain.model.network.RootError
-import kotlinx.coroutines.flow.Flow
-
 interface DeveloperAppsRepository {
-    fun fetchDeveloperApps(): Flow<DataState<List<AppInfo>, RootError>>
+    suspend fun fetchDeveloperApps(): List<AppInfo>
 }
 

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModel.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModel.kt
@@ -2,11 +2,8 @@ package com.d4rk.android.apps.apptoolkit.app.apps.favorites
 
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
 import com.d4rk.android.apps.apptoolkit.app.core.utils.dispatchers.StandardDispatcherExtension
-import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
-import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Error
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
@@ -24,12 +21,8 @@ class TestFavoriteAppsViewModel : TestFavoriteAppsViewModelBase() {
     fun `toggle favorite throws after load`() = runTest(dispatcherExtension.testDispatcher) {
         println("\uD83D\uDE80 [TEST] toggle favorite throws after load")
         val apps = listOf(AppInfo("App", "pkg", "url"))
-        val flow = flow {
-            emit(DataState.Loading<List<AppInfo>, Error>())
-            emit(DataState.Success<List<AppInfo>, Error>(apps))
-        }
         setup(
-            fetchFlow = flow,
+            fetchApps = apps,
             initialFavorites = emptySet(),
             toggleError = RuntimeException("fail"),
             dispatcher = dispatcherExtension.testDispatcher

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModelBase.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModelBase.kt
@@ -7,8 +7,6 @@ import com.d4rk.android.apps.apptoolkit.app.apps.favorites.ui.FavoriteAppsViewMo
 import com.d4rk.android.apps.apptoolkit.app.apps.list.FakeDeveloperAppsRepository
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.usecases.FetchDeveloperAppsUseCase
-import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
-import com.d4rk.android.libs.apptoolkit.core.domain.model.network.RootError
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -21,14 +19,14 @@ open class TestFavoriteAppsViewModelBase {
 
     protected lateinit var viewModel: FavoriteAppsViewModel
     protected fun setup(
-        fetchFlow: Flow<DataState<List<AppInfo>, RootError>>,
+        fetchApps: List<AppInfo>,
         initialFavorites: Set<String> = emptySet(),
         favoritesFlow: Flow<Set<String>>? = null,
         toggleError: Throwable? = null,
         dispatcher: CoroutineDispatcher = Dispatchers.Main
     ) {
         println("\uD83E\uDDEA [SETUP] Initial favorites: $initialFavorites")
-        val developerAppsRepository = FakeDeveloperAppsRepository(fetchFlow)
+        val developerAppsRepository = FakeDeveloperAppsRepository(fetchApps)
         val fetchUseCase = FetchDeveloperAppsUseCase(developerAppsRepository)
         val favoritesRepository = FakeFavoritesRepository(initialFavorites, favoritesFlow, toggleError)
         val observeFavoritesUseCase = ObserveFavoritesUseCase(favoritesRepository)

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/FakeDeveloperAppsRepository.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/FakeDeveloperAppsRepository.kt
@@ -2,21 +2,18 @@ package com.d4rk.android.apps.apptoolkit.app.apps.list
 
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.repository.DeveloperAppsRepository
-import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
-import com.d4rk.android.libs.apptoolkit.core.domain.model.network.RootError
-import kotlinx.coroutines.flow.Flow
 
 /**
- * Fake implementation of [DeveloperAppsRepository] that returns a predefined flow.
+ * Fake implementation of [DeveloperAppsRepository] that returns a predefined list.
  * It can optionally throw an exception when [fetchDeveloperApps] is called.
  */
 class FakeDeveloperAppsRepository(
-    private val flow: Flow<DataState<List<AppInfo>, RootError>>,
+    private val apps: List<AppInfo>,
     private val fetchThrows: Throwable? = null,
 ) : DeveloperAppsRepository {
-    override fun fetchDeveloperApps(): Flow<DataState<List<AppInfo>, RootError>> {
+    override suspend fun fetchDeveloperApps(): List<AppInfo> {
         fetchThrows?.let { throw it }
-        return flow
+        return apps
     }
 }
 

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModel.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModel.kt
@@ -2,9 +2,6 @@ package com.d4rk.android.apps.apptoolkit.app.apps.list
 
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
 import com.d4rk.android.apps.apptoolkit.app.core.utils.dispatchers.StandardDispatcherExtension
-import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
-import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Error
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
@@ -20,20 +17,14 @@ class TestAppsListViewModel : TestAppsListViewModelBase() {
     @Test
     fun `fetch apps - large list`() = runTest(dispatcherExtension.testDispatcher) {
         val apps = (1..10_000).map { AppInfo("App$it", "pkg$it", "url$it") }
-        val flow = flow {
-            emit(DataState.Loading<List<AppInfo>, Error>())
-            emit(DataState.Success<List<AppInfo>, Error>(apps))
-        }
-        setup(fetchFlow = flow, dispatcher = dispatcherExtension.testDispatcher)
+        setup(fetchApps = apps, dispatcher = dispatcherExtension.testDispatcher)
         viewModel.uiState.testSuccess(expectedSize = apps.size)
     }
 
     @Test
     fun `toggle favorite updates state`() = runTest(dispatcherExtension.testDispatcher) {
-        val flow = flow {
-            emit(DataState.Success<List<AppInfo>, Error>(listOf(AppInfo("App", "pkg", "url"))))
-        }
-        setup(fetchFlow = flow, dispatcher = dispatcherExtension.testDispatcher)
+        val apps = listOf(AppInfo("App", "pkg", "url"))
+        setup(fetchApps = apps, dispatcher = dispatcherExtension.testDispatcher)
         toggleAndAssert(packageName = "pkg", expected = true)
         toggleAndAssert(packageName = "pkg", expected = false)
     }

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModelBase.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModelBase.kt
@@ -9,8 +9,6 @@ import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.ui.UiHomeScreen
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.usecases.FetchDeveloperAppsUseCase
 import com.d4rk.android.apps.apptoolkit.app.apps.list.ui.AppsListViewModel
-import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
-import com.d4rk.android.libs.apptoolkit.core.domain.model.network.RootError
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.google.common.truth.Truth.assertThat
@@ -27,7 +25,7 @@ open class TestAppsListViewModelBase {
 
     protected lateinit var viewModel: AppsListViewModel
     protected fun setup(
-        fetchFlow: Flow<DataState<List<AppInfo>, RootError>>,
+        fetchApps: List<AppInfo>,
         initialFavorites: Set<String> = emptySet(),
         favoritesFlow: Flow<Set<String>>? = null,
         toggleError: Throwable? = null,
@@ -35,7 +33,7 @@ open class TestAppsListViewModelBase {
         dispatcher: CoroutineDispatcher = Dispatchers.Main,
     ) {
         println("\uD83E\uDDEA [SETUP] Initial favorites: $initialFavorites")
-        val developerAppsRepository = FakeDeveloperAppsRepository(fetchFlow, fetchThrows)
+        val developerAppsRepository = FakeDeveloperAppsRepository(fetchApps, fetchThrows)
         val fetchUseCase = FetchDeveloperAppsUseCase(developerAppsRepository)
         val favoritesRepository = FakeFavoritesRepository(initialFavorites, favoritesFlow, toggleError)
         val observeFavoritesUseCase = ObserveFavoritesUseCase(favoritesRepository)

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/data/repository/DeveloperAppsRepositoryImplTest.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/data/repository/DeveloperAppsRepositoryImplTest.kt
@@ -4,9 +4,6 @@ import com.d4rk.android.apps.apptoolkit.app.apps.list.data.model.api.ApiResponse
 import com.d4rk.android.apps.apptoolkit.app.apps.list.data.model.api.AppDataWrapper
 import com.d4rk.android.apps.apptoolkit.app.apps.list.data.model.api.AppInfoDto
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
-import com.d4rk.android.apps.apptoolkit.core.domain.model.network.Errors
-import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
-import com.d4rk.android.libs.apptoolkit.core.domain.model.network.RootError
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -16,20 +13,18 @@ import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.headersOf
 import io.ktor.serialization.kotlinx.json.json
-import kotlinx.coroutines.flow.drop
-import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import kotlinx.serialization.json.Json
 import org.junit.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
+import kotlin.test.assertIs
+import java.net.SocketTimeoutException
 
 class DeveloperAppsRepositoryImplTest {
 
     @Test
-    fun `fetchDeveloperApps emits loading then success`() = runTest {
+    fun `fetchDeveloperApps returns apps list`() = runTest {
         val testDispatcher = StandardTestDispatcher(testScheduler)
         val apps = listOf(AppInfo("App", "pkg", "icon"))
         val response = ApiResponse(AppDataWrapper(apps.map { AppInfoDto(it.name, it.packageName, it.iconUrl) }))
@@ -45,19 +40,12 @@ class DeveloperAppsRepositoryImplTest {
         }
         val repository = DeveloperAppsRepositoryImpl(client, testDispatcher)
 
-        val flow = repository.fetchDeveloperApps()
-        val loading = flow.first()
-        assertTrue(loading is DataState.Loading)
-
-        val results = flow.drop(1).toList()
-        assertEquals(1, results.size)
-        val success = results[0]
-        assertTrue(success is DataState.Success)
-        assertEquals(apps, success.data)
+        val result = repository.fetchDeveloperApps()
+        assertEquals(apps, result)
     }
 
     @Test
-    fun `fetchDeveloperApps emits loading then error`() = runTest {
+    fun `fetchDeveloperApps throws on error`() = runTest {
         val testDispatcher = StandardTestDispatcher(testScheduler)
         val client = HttpClient(MockEngine { request ->
             respond(
@@ -70,15 +58,9 @@ class DeveloperAppsRepositoryImplTest {
         }
         val repository = DeveloperAppsRepositoryImpl(client, testDispatcher)
 
-        val flow = repository.fetchDeveloperApps()
-        val loading = flow.first()
-        assertTrue(loading is DataState.Loading)
-
-        val results = flow.drop(1).toList()
-        assertEquals(1, results.size)
-        val errorState = results[0]
-        assertTrue(errorState is DataState.Error)
-        assertEquals(Errors.Network.REQUEST_TIMEOUT, errorState.error)
+        val result = runCatching { repository.fetchDeveloperApps() }
+        val exception = result.exceptionOrNull()
+        assertIs<SocketTimeoutException>(exception)
     }
 }
 


### PR DESCRIPTION
## Summary
- execute network call via suspend repository method and map results in use case
- build developer apps streams in view models using flow builders
- wrap favorites observation in a flow to call suspend use case safely

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b01d86982c832d8ea093402de6ee52