### PR TITLE
Fix test mocks and dispatchers

### DIFF
--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/ads/data/TestDefaultAdsSettingsRepository.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/ads/data/TestDefaultAdsSettingsRepository.kt
@@ -29,10 +29,10 @@ class TestDefaultAdsSettingsRepository {
 
     private fun createRepository(
         dataStore: CommonDataStore,
-        isDebugBuild: Boolean = false,
+        debugBuild: Boolean = false,
     ): DefaultAdsSettingsRepository {
         val buildInfoProvider = mockk<BuildInfoProvider> {
-            every { isDebugBuild } returns isDebugBuild
+            every { isDebugBuild } returns debugBuild
         }
         return DefaultAdsSettingsRepository(
             dataStore = dataStore,
@@ -46,7 +46,7 @@ class TestDefaultAdsSettingsRepository {
         println("\uD83D\uDE80 [TEST] observeAdsEnabled emits datastore value")
         val dataStore = mockk<CommonDataStore>()
         every { dataStore.ads(default = true) } returns flowOf(false)
-        val repository = createRepository(dataStore, isDebugBuild = false)
+        val repository = createRepository(dataStore, debugBuild = false)
 
         repository.observeAdsEnabled().test {
             assertThat(awaitItem()).isFalse()
@@ -59,7 +59,7 @@ class TestDefaultAdsSettingsRepository {
         println("\uD83D\uDE80 [TEST] observeAdsEnabled emits default on error")
         val dataStore = mockk<CommonDataStore>()
         every { dataStore.ads(default = true) } returns flow { throw IOException("boom") }
-        val repository = createRepository(dataStore, isDebugBuild = false)
+        val repository = createRepository(dataStore, debugBuild = false)
 
         repository.observeAdsEnabled().test {
             assertThat(awaitItem()).isTrue()
@@ -72,7 +72,7 @@ class TestDefaultAdsSettingsRepository {
         println("\uD83D\uDE80 [TEST] observeAdsEnabled rethrows cancellation")
         val dataStore = mockk<CommonDataStore>()
         every { dataStore.ads(default = true) } returns flow { throw CancellationException("boom") }
-        val repository = createRepository(dataStore, isDebugBuild = false)
+        val repository = createRepository(dataStore, debugBuild = false)
 
         var thrown: Throwable? = null
         try {
@@ -89,7 +89,7 @@ class TestDefaultAdsSettingsRepository {
         println("\uD83D\uDE80 [TEST] setAdsEnabled returns success when persisted")
         val dataStore = mockk<CommonDataStore>()
         coEvery { dataStore.saveAds(any()) } returns Unit
-        val repository = createRepository(dataStore, isDebugBuild = false)
+        val repository = createRepository(dataStore, debugBuild = false)
 
         val result = repository.setAdsEnabled(true)
 
@@ -102,7 +102,7 @@ class TestDefaultAdsSettingsRepository {
         println("\uD83D\uDE80 [TEST] setAdsEnabled returns error on failure")
         val dataStore = mockk<CommonDataStore>()
         coEvery { dataStore.saveAds(any()) } throws IOException("boom")
-        val repository = createRepository(dataStore, isDebugBuild = false)
+        val repository = createRepository(dataStore, debugBuild = false)
 
         val result = repository.setAdsEnabled(true)
 

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupViewModelTest.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupViewModelTest.kt
@@ -4,16 +4,25 @@ import com.d4rk.android.libs.apptoolkit.app.startup.domain.actions.StartupEvent
 import com.d4rk.android.libs.apptoolkit.app.startup.domain.actions.StartupAction
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
 import com.google.common.truth.Truth.assertThat
+import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.UnconfinedDispatcherExtension
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class StartupViewModelTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val dispatcherExtension = UnconfinedDispatcherExtension()
+    }
+
     @Test
-    fun `consent event updates state`() = runTest {
+    fun `consent event updates state`() = runTest(dispatcherExtension.testDispatcher) {
         val viewModel = StartupViewModel()
         viewModel.onEvent(StartupEvent.ConsentFormLoaded)
         val state = viewModel.uiState.value
@@ -22,7 +31,7 @@ class StartupViewModelTest {
     }
 
     @Test
-    fun `continue event emits navigation action`() = runTest {
+    fun `continue event emits navigation action`() = runTest(dispatcherExtension.testDispatcher) {
         val viewModel = StartupViewModel()
         val actions = mutableListOf<StartupAction>()
         val job = launch { viewModel.actionEvent.collect { actions.add(it) } }


### PR DESCRIPTION
## Summary
- fix shadowed mock property in `TestDefaultAdsSettingsRepository`
- run `StartupViewModelTest` with unconfined test dispatcher

## Testing
- `./gradlew :apptoolkit:test`


------
https://chatgpt.com/codex/tasks/task_e_68b020e13594832d86b776aaf535f2d0