### PR TITLE
refactor settings repository

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/SettingsModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/SettingsModule.kt
@@ -16,7 +16,7 @@ import com.d4rk.android.libs.apptoolkit.app.advanced.ui.AdvancedSettingsViewMode
 import com.d4rk.android.libs.apptoolkit.app.permissions.ui.PermissionsViewModel
 import com.d4rk.android.libs.apptoolkit.app.permissions.domain.repository.PermissionsRepository
 import com.d4rk.android.libs.apptoolkit.app.settings.general.ui.GeneralSettingsViewModel
-import com.d4rk.android.libs.apptoolkit.app.settings.general.domain.repository.DefaultGeneralSettingsRepository
+import com.d4rk.android.libs.apptoolkit.app.settings.general.data.DefaultGeneralSettingsRepository
 import com.d4rk.android.libs.apptoolkit.app.settings.general.domain.repository.GeneralSettingsRepository
 import com.d4rk.android.libs.apptoolkit.app.settings.settings.ui.SettingsViewModel
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.interfaces.SettingsProvider
@@ -56,7 +56,9 @@ val settingsModule = module {
             mainDispatcher = get(named("main")),
         )
     }
-    single<GeneralSettingsRepository> { DefaultGeneralSettingsRepository() }
+    single<GeneralSettingsRepository> {
+        DefaultGeneralSettingsRepository(dispatcher = get(named("default")))
+    }
     viewModel {
         GeneralSettingsViewModel(repository = get())
     }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/settings/general/data/DefaultGeneralSettingsRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/settings/general/data/DefaultGeneralSettingsRepository.kt
@@ -1,0 +1,27 @@
+package com.d4rk.android.libs.apptoolkit.app.settings.general.data
+
+import com.d4rk.android.libs.apptoolkit.app.settings.general.domain.repository.GeneralSettingsRepository
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
+
+/**
+ * Default implementation of [GeneralSettingsRepository].
+ *
+ * This implementation performs basic validation on the provided key and runs
+ * the work on the supplied [CoroutineDispatcher] to keep it off the main
+ * thread.
+ */
+class DefaultGeneralSettingsRepository(
+    private val dispatcher: CoroutineDispatcher,
+) : GeneralSettingsRepository {
+
+    override fun getContentKey(contentKey: String?): Flow<String> = flow {
+        if (contentKey.isNullOrBlank()) {
+            throw IllegalArgumentException("Invalid content key")
+        }
+        emit(contentKey)
+    }.flowOn(dispatcher)
+}
+

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/settings/general/domain/repository/GeneralSettingsRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/settings/general/domain/repository/GeneralSettingsRepository.kt
@@ -1,17 +1,12 @@
 package com.d4rk.android.libs.apptoolkit.app.settings.general.domain.repository
 
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOn
 
 /**
  * Repository responsible for providing the content key for the General Settings screen.
  *
- * This implementation performs a lightweight validation on the provided key and
- * executes the work on the provided [CoroutineDispatcher] to keep data
- * operations off the UI layer and allow easier testing.
+ * Implementations should validate the provided key and emit it through a
+ * [Flow]. This keeps the data operations asynchronous and testable.
  */
 interface GeneralSettingsRepository {
     /**
@@ -23,14 +18,4 @@ interface GeneralSettingsRepository {
     fun getContentKey(contentKey: String?): Flow<String>
 }
 
-class DefaultGeneralSettingsRepository(
-    private val dispatcher: CoroutineDispatcher = Dispatchers.Default
-) : GeneralSettingsRepository {
-    override fun getContentKey(contentKey: String?): Flow<String> = flow {
-        if (contentKey.isNullOrBlank()) {
-            throw IllegalArgumentException("Invalid content key")
-        }
-        emit(contentKey)
-    }.flowOn(dispatcher)
-}
 

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/settings/general/domain/repository/TestGeneralSettingsRepository.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/settings/general/domain/repository/TestGeneralSettingsRepository.kt
@@ -1,5 +1,6 @@
 package com.d4rk.android.libs.apptoolkit.app.settings.general.domain.repository
 
+import com.d4rk.android.libs.apptoolkit.app.settings.general.data.DefaultGeneralSettingsRepository
 import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.UnconfinedDispatcherExtension
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.flow.first

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/TestGeneralSettingsViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/TestGeneralSettingsViewModel.kt
@@ -5,7 +5,7 @@ import com.d4rk.android.libs.apptoolkit.app.settings.general.domain.actions.Gene
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
 import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.UnconfinedDispatcherExtension
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
-import com.d4rk.android.libs.apptoolkit.app.settings.general.domain.repository.DefaultGeneralSettingsRepository
+import com.d4rk.android.libs.apptoolkit.app.settings.general.data.DefaultGeneralSettingsRepository
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test


### PR DESCRIPTION
## Summary
- move DefaultGeneralSettingsRepository to data layer
- inject dispatcher into DefaultGeneralSettingsRepository
- bind GeneralSettingsRepository to new implementation in SettingsModule

## Testing
- `./gradlew apptoolkit:test` *(fails: SDK location not found)*


------
https://chatgpt.com/codex/tasks/task_e_68b08b253f14832d984bde9364450d44