### PR TITLE
Use ScreenStateHandler in Advanced Settings

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/advanced/domain/actions/AdvancedSettingsAction.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/advanced/domain/actions/AdvancedSettingsAction.kt
@@ -1,0 +1,5 @@
+package com.d4rk.android.libs.apptoolkit.app.advanced.domain.actions
+
+import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.ActionEvent
+
+sealed interface AdvancedSettingsAction : ActionEvent

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/advanced/domain/actions/AdvancedSettingsEvent.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/advanced/domain/actions/AdvancedSettingsEvent.kt
@@ -1,0 +1,8 @@
+package com.d4rk.android.libs.apptoolkit.app.advanced.domain.actions
+
+import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.UiEvent
+
+sealed interface AdvancedSettingsEvent : UiEvent {
+    data object ClearCache : AdvancedSettingsEvent
+    data object MessageShown : AdvancedSettingsEvent
+}

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/advanced/domain/model/ui/UiAdvancedSettingsScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/advanced/domain/model/ui/UiAdvancedSettingsScreen.kt
@@ -1,10 +1,10 @@
-package com.d4rk.android.libs.apptoolkit.app.advanced.ui
+package com.d4rk.android.libs.apptoolkit.app.advanced.domain.model.ui
 
 /**
  * Represents the state for [AdvancedSettingsViewModel].
  *
  * @param cacheClearMessage optional string resource id to show after clearing cache
  */
-data class AdvancedSettingsUiState(
+data class UiAdvancedSettingsScreen(
     val cacheClearMessage: Int? = null,
 )

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/advanced/ui/AdvancedSettingsList.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/advanced/ui/AdvancedSettingsList.kt
@@ -18,6 +18,8 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.ui.IssueReporterActivity
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.AdvancedSettingsProvider
+import com.d4rk.android.libs.apptoolkit.app.advanced.domain.actions.AdvancedSettingsEvent
+import com.d4rk.android.libs.apptoolkit.app.advanced.domain.model.ui.UiAdvancedSettingsScreen
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.LoadingScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.NoDataScreen
@@ -36,12 +38,12 @@ fun AdvancedSettingsList(
     viewModel: AdvancedSettingsViewModel = koinViewModel(),
 ) {
     val context: Context = LocalContext.current
-    val screenState: UiStateScreen<AdvancedSettingsUiState> = viewModel.uiState.collectAsStateWithLifecycle().value
+    val screenState: UiStateScreen<UiAdvancedSettingsScreen> = viewModel.uiState.collectAsStateWithLifecycle().value
 
     LaunchedEffect(screenState.data?.cacheClearMessage) {
         screenState.data?.cacheClearMessage?.let { messageRes ->
             Toast.makeText(context, context.getString(messageRes), Toast.LENGTH_SHORT).show()
-            viewModel.onMessageShown()
+            viewModel.onEvent(AdvancedSettingsEvent.MessageShown)
         }
     }
 
@@ -82,7 +84,7 @@ fun AdvancedSettingsList(
                         SettingsPreferenceItem(
                             title = stringResource(id = R.string.clear_cache),
                             summary = stringResource(id = R.string.summary_preference_settings_clear_cache),
-                            onClick = { viewModel.onClearCache() },
+                            onClick = { viewModel.onEvent(AdvancedSettingsEvent.ClearCache) },
                         )
                     }
                 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/advanced/ui/AdvancedSettingsList.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/advanced/ui/AdvancedSettingsList.kt
@@ -18,6 +18,10 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.ui.IssueReporterActivity
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.AdvancedSettingsProvider
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
+import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.LoadingScreen
+import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.NoDataScreen
+import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.ScreenStateHandler
 import com.d4rk.android.libs.apptoolkit.core.ui.components.preferences.PreferenceCategoryItem
 import com.d4rk.android.libs.apptoolkit.core.ui.components.preferences.SettingsPreferenceItem
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.SmallVerticalSpacer
@@ -32,50 +36,57 @@ fun AdvancedSettingsList(
     viewModel: AdvancedSettingsViewModel = koinViewModel(),
 ) {
     val context: Context = LocalContext.current
-    val uiState: AdvancedSettingsUiState = viewModel.uiState.collectAsStateWithLifecycle().value
+    val screenState: UiStateScreen<AdvancedSettingsUiState> = viewModel.uiState.collectAsStateWithLifecycle().value
 
-    LaunchedEffect(uiState.cacheClearMessage) {
-        uiState.cacheClearMessage?.let { messageRes ->
+    LaunchedEffect(screenState.data?.cacheClearMessage) {
+        screenState.data?.cacheClearMessage?.let { messageRes ->
             Toast.makeText(context, context.getString(messageRes), Toast.LENGTH_SHORT).show()
             viewModel.onMessageShown()
         }
     }
 
-    LazyColumn(contentPadding = paddingValues, modifier = Modifier.fillMaxHeight()) {
-        item {
-            PreferenceCategoryItem(title = stringResource(id = R.string.error_reporting))
-            SmallVerticalSpacer()
-            Column(
-                modifier = Modifier
-                    .padding(horizontal = SizeConstants.LargeSize)
-                    .clip(shape = RoundedCornerShape(size = SizeConstants.LargeSize))
-            ) {
-                SettingsPreferenceItem(
-                    title = stringResource(id = R.string.bug_report),
-                    summary = stringResource(id = R.string.summary_preference_settings_bug_report),
-                    onClick = {
-                        IntentsHelper.openActivity(
-                            context = context,
-                            activityClass = IssueReporterActivity::class.java,
+    ScreenStateHandler(
+        screenState = screenState,
+        onLoading = { LoadingScreen() },
+        onEmpty = { NoDataScreen() },
+        onSuccess = {
+            LazyColumn(contentPadding = paddingValues, modifier = Modifier.fillMaxHeight()) {
+                item {
+                    PreferenceCategoryItem(title = stringResource(id = R.string.error_reporting))
+                    SmallVerticalSpacer()
+                    Column(
+                        modifier = Modifier
+                            .padding(horizontal = SizeConstants.LargeSize)
+                            .clip(shape = RoundedCornerShape(size = SizeConstants.LargeSize))
+                    ) {
+                        SettingsPreferenceItem(
+                            title = stringResource(id = R.string.bug_report),
+                            summary = stringResource(id = R.string.summary_preference_settings_bug_report),
+                            onClick = {
+                                IntentsHelper.openActivity(
+                                    context = context,
+                                    activityClass = IssueReporterActivity::class.java,
+                                )
+                            },
                         )
-                    },
-                )
+                    }
+                }
+                item {
+                    PreferenceCategoryItem(title = stringResource(id = R.string.cache_management))
+                    SmallVerticalSpacer()
+                    Column(
+                        modifier = Modifier
+                            .padding(horizontal = SizeConstants.LargeSize)
+                            .clip(shape = RoundedCornerShape(size = SizeConstants.LargeSize))
+                    ) {
+                        SettingsPreferenceItem(
+                            title = stringResource(id = R.string.clear_cache),
+                            summary = stringResource(id = R.string.summary_preference_settings_clear_cache),
+                            onClick = { viewModel.onClearCache() },
+                        )
+                    }
+                }
             }
-        }
-        item {
-            PreferenceCategoryItem(title = stringResource(id = R.string.cache_management))
-            SmallVerticalSpacer()
-            Column(
-                modifier = Modifier
-                    .padding(horizontal = SizeConstants.LargeSize)
-                    .clip(shape = RoundedCornerShape(size = SizeConstants.LargeSize))
-            ) {
-                SettingsPreferenceItem(
-                    title = stringResource(id = R.string.clear_cache),
-                    summary = stringResource(id = R.string.summary_preference_settings_clear_cache),
-                    onClick = { viewModel.onClearCache() },
-                )
-            }
-        }
-    }
+        },
+    )
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/advanced/ui/AdvancedSettingsViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/advanced/ui/AdvancedSettingsViewModel.kt
@@ -1,30 +1,30 @@
 package com.d4rk.android.libs.apptoolkit.app.advanced.ui
 
-import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.advanced.data.CacheRepository
-import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
+import com.d4rk.android.libs.apptoolkit.app.advanced.domain.actions.AdvancedSettingsAction
+import com.d4rk.android.libs.apptoolkit.app.advanced.domain.actions.AdvancedSettingsEvent
+import com.d4rk.android.libs.apptoolkit.app.advanced.domain.model.ui.UiAdvancedSettingsScreen
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.copyData
-import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
+import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
 import kotlinx.coroutines.launch
 
 class AdvancedSettingsViewModel(
     private val repository: CacheRepository,
-) : ViewModel() {
+) : ScreenViewModel<UiAdvancedSettingsScreen, AdvancedSettingsEvent, AdvancedSettingsAction>(
+    initialState = UiStateScreen(data = UiAdvancedSettingsScreen()),
+) {
 
-    private val _uiState = MutableStateFlow(
-        UiStateScreen(
-            screenState = ScreenState.Success(),
-            data = AdvancedSettingsUiState(),
-        ),
-    )
-    val uiState: StateFlow<UiStateScreen<AdvancedSettingsUiState>> = _uiState.asStateFlow()
+    override fun onEvent(event: AdvancedSettingsEvent) {
+        when (event) {
+            AdvancedSettingsEvent.ClearCache -> clearCache()
+            AdvancedSettingsEvent.MessageShown -> onMessageShown()
+        }
+    }
 
-    fun onClearCache() {
+    private fun clearCache() {
         viewModelScope.launch {
             val success = repository.clearCache()
             val message = if (success) {
@@ -32,11 +32,11 @@ class AdvancedSettingsViewModel(
             } else {
                 R.string.cache_cleared_error
             }
-            _uiState.copyData { copy(cacheClearMessage = message) }
+            screenState.copyData { copy(cacheClearMessage = message) }
         }
     }
 
-    fun onMessageShown() {
-        _uiState.copyData { copy(cacheClearMessage = null) }
+    private fun onMessageShown() {
+        screenState.copyData { copy(cacheClearMessage = null) }
     }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/advanced/ui/AdvancedSettingsViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/advanced/ui/AdvancedSettingsViewModel.kt
@@ -4,18 +4,25 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.advanced.data.CacheRepository
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.copyData
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class AdvancedSettingsViewModel(
     private val repository: CacheRepository,
 ) : ViewModel() {
 
-    private val _uiState = MutableStateFlow(AdvancedSettingsUiState())
-    val uiState: StateFlow<AdvancedSettingsUiState> = _uiState.asStateFlow()
+    private val _uiState = MutableStateFlow(
+        UiStateScreen(
+            screenState = ScreenState.Success(),
+            data = AdvancedSettingsUiState(),
+        ),
+    )
+    val uiState: StateFlow<UiStateScreen<AdvancedSettingsUiState>> = _uiState.asStateFlow()
 
     fun onClearCache() {
         viewModelScope.launch {
@@ -25,11 +32,11 @@ class AdvancedSettingsViewModel(
             } else {
                 R.string.cache_cleared_error
             }
-            _uiState.update { it.copy(cacheClearMessage = message) }
+            _uiState.copyData { copy(cacheClearMessage = message) }
         }
     }
 
     fun onMessageShown() {
-        _uiState.update { it.copy(cacheClearMessage = null) }
+        _uiState.copyData { copy(cacheClearMessage = null) }
     }
 }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/advanced/ui/TestAdvancedSettingsViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/advanced/ui/TestAdvancedSettingsViewModel.kt
@@ -2,6 +2,7 @@ package com.d4rk.android.libs.apptoolkit.app.advanced.ui
 
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.advanced.data.CacheRepository
+import com.d4rk.android.libs.apptoolkit.app.advanced.domain.actions.AdvancedSettingsEvent
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -17,11 +18,11 @@ class TestAdvancedSettingsViewModel {
         println("\uD83D\uDE80 [TEST] onClearCache emits success message")
         val viewModel = AdvancedSettingsViewModel(repository = FakeCacheRepository(true))
 
-        viewModel.onClearCache()
+        viewModel.onEvent(AdvancedSettingsEvent.ClearCache)
 
-        assertThat(viewModel.uiState.value.cacheClearMessage).isEqualTo(R.string.cache_cleared_success)
-        viewModel.onMessageShown()
-        assertThat(viewModel.uiState.value.cacheClearMessage).isNull()
+        assertThat(viewModel.uiState.value.data?.cacheClearMessage).isEqualTo(R.string.cache_cleared_success)
+        viewModel.onEvent(AdvancedSettingsEvent.MessageShown)
+        assertThat(viewModel.uiState.value.data?.cacheClearMessage).isNull()
         println("\uD83C\uDFC1 [TEST DONE] onClearCache emits success message")
     }
 
@@ -30,9 +31,9 @@ class TestAdvancedSettingsViewModel {
         println("\uD83D\uDE80 [TEST] onClearCache emits error message when failure")
         val viewModel = AdvancedSettingsViewModel(repository = FakeCacheRepository(false))
 
-        viewModel.onClearCache()
+        viewModel.onEvent(AdvancedSettingsEvent.ClearCache)
 
-        assertThat(viewModel.uiState.value.cacheClearMessage).isEqualTo(R.string.cache_cleared_error)
+        assertThat(viewModel.uiState.value.data?.cacheClearMessage).isEqualTo(R.string.cache_cleared_error)
         println("\uD83C\uDFC1 [TEST DONE] onClearCache emits error message when failure")
     }
 }


### PR DESCRIPTION
## Summary
- integrate `ScreenStateHandler` into `AdvancedSettingsList` to handle loading and empty states
- refactor `AdvancedSettingsViewModel` to expose `UiStateScreen` and update cache message with `copyData`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0962f8278832d8f6745cec34cef0b