### PR TITLE
Refine advanced cache clearing with coroutines

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/advanced/data/CacheRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/advanced/data/CacheRepository.kt
@@ -1,5 +1,7 @@
 package com.d4rk.android.libs.apptoolkit.app.advanced.data
 
+import com.d4rk.android.libs.apptoolkit.core.domain.model.Result
+
 /**
  * Repository abstraction for cache-related operations.
  */
@@ -7,7 +9,8 @@ interface CacheRepository {
     /**
      * Clears the application's cache directories.
      *
-     * @return `true` if all directories were deleted successfully, `false` otherwise.
+     * @return [Result.Success] if all directories were deleted successfully or
+     * [Result.Error] with the encountered [Exception].
      */
-    suspend fun clearCache(): Boolean
+    suspend fun clearCache(): Result<Unit>
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/advanced/ui/AdvancedSettingsViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/advanced/ui/AdvancedSettingsViewModel.kt
@@ -6,6 +6,7 @@ import com.d4rk.android.libs.apptoolkit.app.advanced.data.CacheRepository
 import com.d4rk.android.libs.apptoolkit.app.advanced.domain.actions.AdvancedSettingsAction
 import com.d4rk.android.libs.apptoolkit.app.advanced.domain.actions.AdvancedSettingsEvent
 import com.d4rk.android.libs.apptoolkit.app.advanced.domain.model.ui.UiAdvancedSettingsScreen
+import com.d4rk.android.libs.apptoolkit.core.domain.model.Result
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.copyData
 import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
@@ -26,11 +27,14 @@ class AdvancedSettingsViewModel(
 
     private fun clearCache() {
         viewModelScope.launch {
-            val success = repository.clearCache()
-            val message = if (success) {
-                R.string.cache_cleared_success
-            } else {
-                R.string.cache_cleared_error
+            val result = try {
+                repository.clearCache()
+            } catch (e: Exception) {
+                Result.Error(e)
+            }
+            val message = when (result) {
+                is Result.Success -> R.string.cache_cleared_success
+                is Result.Error -> R.string.cache_cleared_error
             }
             screenState.copyData { copy(cacheClearMessage = message) }
         }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/advanced/data/TestDefaultCacheRepository.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/advanced/data/TestDefaultCacheRepository.kt
@@ -1,11 +1,12 @@
 package com.d4rk.android.libs.apptoolkit.app.advanced.data
 
 import android.content.Context
+import com.d4rk.android.libs.apptoolkit.core.domain.model.Result
+import com.google.common.truth.Truth.assertThat
 import io.mockk.every
 import io.mockk.mockk
 import kotlin.io.path.createTempDirectory
 import kotlin.test.assertFalse
-import kotlin.test.assertTrue
 import kotlin.test.assertFailsWith
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
@@ -27,7 +28,7 @@ class TestDefaultCacheRepository {
         val repository = DefaultCacheRepository(context)
         val result = repository.clearCache()
 
-        assertTrue(result)
+        assertThat(result).isInstanceOf(Result.Success::class.java)
         assertFalse(dir1.exists())
         assertFalse(dir2.exists())
         assertFalse(dir3.exists())
@@ -51,7 +52,7 @@ class TestDefaultCacheRepository {
         val repository = DefaultCacheRepository(context)
         val result = repository.clearCache()
 
-        assertFalse(result)
+        assertThat(result).isInstanceOf(Result.Error::class.java)
         assertFalse(dir1.exists())
         assertFalse(dir3.exists())
         println("\uD83C\uDFC1 [TEST DONE] clearCache returns false when deletion fails")
@@ -83,7 +84,7 @@ class TestDefaultCacheRepository {
         val repository = DefaultCacheRepository(context)
         val result = repository.clearCache()
 
-        assertTrue(result)
+        assertThat(result).isInstanceOf(Result.Success::class.java)
         println("\uD83C\uDFC1 [TEST DONE] clearCache handles missing directories")
     }
 

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/advanced/ui/TestAdvancedSettingsViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/advanced/ui/TestAdvancedSettingsViewModel.kt
@@ -2,13 +2,14 @@ package com.d4rk.android.libs.apptoolkit.app.advanced.ui
 
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.advanced.data.CacheRepository
+import com.d4rk.android.libs.apptoolkit.core.domain.model.Result
 import com.d4rk.android.libs.apptoolkit.app.advanced.domain.actions.AdvancedSettingsEvent
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
-private class FakeCacheRepository(var result: Boolean) : CacheRepository {
-    override suspend fun clearCache(): Boolean = result
+private class FakeCacheRepository(var result: Result<Unit>) : CacheRepository {
+    override suspend fun clearCache(): Result<Unit> = result
 }
 
 class TestAdvancedSettingsViewModel {
@@ -16,7 +17,7 @@ class TestAdvancedSettingsViewModel {
     @Test
     fun `onClearCache emits success message`() = runTest {
         println("\uD83D\uDE80 [TEST] onClearCache emits success message")
-        val viewModel = AdvancedSettingsViewModel(repository = FakeCacheRepository(true))
+        val viewModel = AdvancedSettingsViewModel(repository = FakeCacheRepository(Result.Success(Unit)))
 
         viewModel.onEvent(AdvancedSettingsEvent.ClearCache)
 
@@ -29,7 +30,7 @@ class TestAdvancedSettingsViewModel {
     @Test
     fun `onClearCache emits error message when failure`() = runTest {
         println("\uD83D\uDE80 [TEST] onClearCache emits error message when failure")
-        val viewModel = AdvancedSettingsViewModel(repository = FakeCacheRepository(false))
+        val viewModel = AdvancedSettingsViewModel(repository = FakeCacheRepository(Result.Error(Exception("fail"))))
 
         viewModel.onEvent(AdvancedSettingsEvent.ClearCache)
 


### PR DESCRIPTION
## Summary
- return `Result` from cache clearing repository
- handle cache clear results and exceptions in `AdvancedSettingsViewModel`
- update tests for new cache clearing contract

## Testing
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0988defec832d86f52e3145fdcace