### PR TITLE
Refactor cache clearing to use Kotlin Flow

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/advanced/data/CacheRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/advanced/data/CacheRepository.kt
@@ -1,6 +1,7 @@
 package com.d4rk.android.libs.apptoolkit.app.advanced.data
 
 import com.d4rk.android.libs.apptoolkit.core.domain.model.Result
+import kotlinx.coroutines.flow.Flow
 
 /**
  * Repository abstraction for cache-related operations.
@@ -9,8 +10,8 @@ interface CacheRepository {
     /**
      * Clears the application's cache directories.
      *
-     * @return [Result.Success] if all directories were deleted successfully or
+     * @return A [Flow] emitting [Result.Success] if all directories were deleted successfully or
      * [Result.Error] with the encountered [Exception].
      */
-    suspend fun clearCache(): Result<Unit>
+    fun clearCache(): Flow<Result<Unit>>
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/advanced/ui/AdvancedSettingsViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/advanced/ui/AdvancedSettingsViewModel.kt
@@ -10,6 +10,8 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.Result
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.copyData
 import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 
 class AdvancedSettingsViewModel(
@@ -27,16 +29,15 @@ class AdvancedSettingsViewModel(
 
     private fun clearCache() {
         viewModelScope.launch {
-            val result = try {
-                repository.clearCache()
-            } catch (e: Exception) {
-                Result.Error(e)
-            }
-            val message = when (result) {
-                is Result.Success -> R.string.cache_cleared_success
-                is Result.Error -> R.string.cache_cleared_error
-            }
-            screenState.copyData { copy(cacheClearMessage = message) }
+            repository.clearCache()
+                .catch { emit(Result.Error(it as Exception)) }
+                .collect { result ->
+                    val message = when (result) {
+                        is Result.Success -> R.string.cache_cleared_success
+                        is Result.Error -> R.string.cache_cleared_error
+                    }
+                    screenState.copyData { copy(cacheClearMessage = message) }
+                }
         }
     }
 

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/advanced/ui/TestAdvancedSettingsViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/advanced/ui/TestAdvancedSettingsViewModel.kt
@@ -5,11 +5,14 @@ import com.d4rk.android.libs.apptoolkit.app.advanced.data.CacheRepository
 import com.d4rk.android.libs.apptoolkit.core.domain.model.Result
 import com.d4rk.android.libs.apptoolkit.app.advanced.domain.actions.AdvancedSettingsEvent
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
-private class FakeCacheRepository(var result: Result<Unit>) : CacheRepository {
-    override suspend fun clearCache(): Result<Unit> = result
+private class FakeCacheRepository(private val result: Result<Unit>) : CacheRepository {
+    override fun clearCache(): Flow<Result<Unit>> = flowOf(result)
 }
 
 class TestAdvancedSettingsViewModel {
@@ -20,9 +23,11 @@ class TestAdvancedSettingsViewModel {
         val viewModel = AdvancedSettingsViewModel(repository = FakeCacheRepository(Result.Success(Unit)))
 
         viewModel.onEvent(AdvancedSettingsEvent.ClearCache)
+        advanceUntilIdle()
 
         assertThat(viewModel.uiState.value.data?.cacheClearMessage).isEqualTo(R.string.cache_cleared_success)
         viewModel.onEvent(AdvancedSettingsEvent.MessageShown)
+        advanceUntilIdle()
         assertThat(viewModel.uiState.value.data?.cacheClearMessage).isNull()
         println("\uD83C\uDFC1 [TEST DONE] onClearCache emits success message")
     }
@@ -33,6 +38,7 @@ class TestAdvancedSettingsViewModel {
         val viewModel = AdvancedSettingsViewModel(repository = FakeCacheRepository(Result.Error(Exception("fail"))))
 
         viewModel.onEvent(AdvancedSettingsEvent.ClearCache)
+        advanceUntilIdle()
 
         assertThat(viewModel.uiState.value.data?.cacheClearMessage).isEqualTo(R.string.cache_cleared_error)
         println("\uD83C\uDFC1 [TEST DONE] onClearCache emits error message when failure")


### PR DESCRIPTION
## Summary
- switch cache clearing repository to emit results via Kotlin Flow
- collect flow results in `AdvancedSettingsViewModel` and propagate messages
- update unit tests for flow-based APIs

## Testing
- `./gradlew apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b099832460832dbca52a43706942b6