### PR TITLE
Improve issue reporter error handling and configuration

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/data/DefaultIssueReporterRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/data/DefaultIssueReporterRepository.kt
@@ -1,10 +1,10 @@
 package com.d4rk.android.libs.apptoolkit.app.issuereporter.data
 
-import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.repository.IssueReporterRepository
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.CreateIssueRequest
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.IssueReportResult
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.Report
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.github.GithubTarget
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.repository.IssueReporterRepository
 import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.AppDispatchers
 import io.ktor.client.HttpClient
 import io.ktor.client.request.header
@@ -15,10 +15,12 @@ import io.ktor.client.statement.bodyAsText
 import io.ktor.http.ContentType
 import io.ktor.http.HttpStatusCode
 import io.ktor.http.contentType
+import io.ktor.utils.io.errors.IOException
 import kotlinx.coroutines.withContext
 import kotlinx.serialization.json.Json
 import kotlinx.serialization.json.jsonObject
 import kotlinx.serialization.json.jsonPrimitive
+import kotlinx.serialization.SerializationException
 
 /**
  * Default implementation of [IssueReporterRepository] that posts issues to GitHub.
@@ -26,6 +28,7 @@ import kotlinx.serialization.json.jsonPrimitive
 class DefaultIssueReporterRepository(
     private val client: HttpClient,
     private val dispatchers: AppDispatchers,
+    private val baseUrl: String = "https://api.github.com",
 ) : IssueReporterRepository {
 
     override suspend fun sendReport(
@@ -33,26 +36,39 @@ class DefaultIssueReporterRepository(
         target: GithubTarget,
         token: String?,
     ): IssueReportResult = withContext(dispatchers.io) {
-        val url = "https://api.github.com/repos/${target.username}/${target.repository}/issues"
-        val response: HttpResponse = client.post(url) {
-            contentType(ContentType.Application.Json)
-            header("Accept", "application/vnd.github+json")
-            token?.let { header("Authorization", "Bearer $it") }
-            val issueRequest = CreateIssueRequest(
-                title = report.title,
-                body = report.getDescription(),
-                labels = listOf("bug", "from-mobile"),
-            )
-            setBody(Json.encodeToString(CreateIssueRequest.serializer(), issueRequest))
-        }
+        val url = "$baseUrl/repos/${target.username}/${target.repository}/issues"
+        try {
+            val response: HttpResponse = client.post(url) {
+                contentType(ContentType.Application.Json)
+                header("Accept", "application/vnd.github+json")
+                token?.let { header("Authorization", "Bearer $it") }
+                val issueRequest = CreateIssueRequest(
+                    title = report.title,
+                    body = report.getDescription(),
+                    labels = listOf("bug", "from-mobile"),
+                )
+                setBody(Json.encodeToString(CreateIssueRequest.serializer(), issueRequest))
+            }
 
-        val responseBody = response.bodyAsText()
-        if (response.status == HttpStatusCode.Created) {
-            val json = Json.parseToJsonElement(responseBody).jsonObject
-            val issueUrl = json["html_url"]?.jsonPrimitive?.content ?: ""
-            IssueReportResult.Success(issueUrl)
-        } else {
-            IssueReportResult.Error(response.status, responseBody)
+            val responseBody = response.bodyAsText()
+            if (response.status == HttpStatusCode.Created) {
+                val json = Json.parseToJsonElement(responseBody).jsonObject
+                val issueUrl = json["html_url"]?.jsonPrimitive?.content ?: ""
+                IssueReportResult.Success(issueUrl)
+            } else {
+                mapError(response.status, responseBody)
+            }
+        } catch (e: IOException) {
+            IssueReportResult.Error.Network(e.message ?: "")
+        } catch (e: SerializationException) {
+            IssueReportResult.Error.Serialization(e.message ?: "")
         }
+    }
+
+    private fun mapError(status: HttpStatusCode, body: String): IssueReportResult.Error = when (status) {
+        HttpStatusCode.BadRequest -> IssueReportResult.Error.BadRequest(body)
+        HttpStatusCode.Unauthorized -> IssueReportResult.Error.Unauthorized(body)
+        HttpStatusCode.Forbidden -> IssueReportResult.Error.Forbidden(body)
+        else -> IssueReportResult.Error.Unknown(status, body)
     }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/domain/model/IssueReportResult.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/domain/model/IssueReportResult.kt
@@ -4,5 +4,27 @@ import io.ktor.http.HttpStatusCode
 
 sealed interface IssueReportResult {
     data class Success(val url: String) : IssueReportResult
-    data class Error(val status: HttpStatusCode, val message: String) : IssueReportResult
+
+    /** Represents different error cases that can occur when reporting an issue. */
+    sealed interface Error : IssueReportResult {
+        val message: String
+
+        /** Generic network connectivity problems. */
+        data class Network(override val message: String) : Error
+
+        /** Failures when serializing or deserializing payloads. */
+        data class Serialization(override val message: String) : Error
+
+        /** HTTP 400 Bad Request */
+        data class BadRequest(override val message: String) : Error
+
+        /** HTTP 401 Unauthorized */
+        data class Unauthorized(override val message: String) : Error
+
+        /** HTTP 403 Forbidden */
+        data class Forbidden(override val message: String) : Error
+
+        /** Any other HTTP status code not explicitly handled. */
+        data class Unknown(val status: HttpStatusCode, override val message: String) : Error
+    }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/domain/usecases/SendIssueReportUseCase.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/domain/usecases/SendIssueReportUseCase.kt
@@ -31,7 +31,7 @@ class SendIssueReportUseCase(
             .catch { throwable ->
                 if (throwable is CancellationException) throw throwable
                 emit(
-                    IssueReportResult.Error(
+                    IssueReportResult.Error.Unknown(
                         status = HttpStatusCode.InternalServerError,
                         message = throwable.message ?: "",
                     ),

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/IssueReporterViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/IssueReporterViewModel.kt
@@ -131,13 +131,19 @@ class IssueReporterViewModel(
             }
 
             is IssueReportResult.Error -> {
-                val msg = when (outcome.status) {
-                    HttpStatusCode.Unauthorized -> UiTextHelper.StringResource(R.string.error_unauthorized)
-                    HttpStatusCode.Forbidden -> UiTextHelper.StringResource(R.string.error_forbidden)
-                    HttpStatusCode.Gone -> UiTextHelper.StringResource(R.string.error_gone)
-                    HttpStatusCode.UnprocessableEntity -> UiTextHelper.StringResource(R.string.error_unprocessable)
+                val msg = when (outcome) {
+                    is IssueReportResult.Error.Unauthorized ->
+                        UiTextHelper.StringResource(R.string.error_unauthorized)
+                    is IssueReportResult.Error.Forbidden ->
+                        UiTextHelper.StringResource(R.string.error_forbidden)
+                    is IssueReportResult.Error.Unknown -> when (outcome.status) {
+                        HttpStatusCode.Gone -> UiTextHelper.StringResource(R.string.error_gone)
+                        HttpStatusCode.UnprocessableEntity -> UiTextHelper.StringResource(R.string.error_unprocessable)
+                        else -> UiTextHelper.StringResource(R.string.snack_report_failed)
+                    }
                     else -> UiTextHelper.StringResource(R.string.snack_report_failed)
                 }
+
                 screenState.update { current ->
                     current.copy(
                         screenState = ScreenState.Error(),

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/data/TestIssueReporterRepository.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/data/TestIssueReporterRepository.kt
@@ -65,10 +65,8 @@ class TestIssueReporterRepository {
         val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo.create(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
         val result = repository.sendReport(report, target)
-
-        assertThat(result).isInstanceOf(IssueReportResult.Error::class.java)
-        val error = result as IssueReportResult.Error
-        assertThat(error.status).isEqualTo(HttpStatusCode.BadRequest)
+        assertThat(result).isInstanceOf(IssueReportResult.Error.BadRequest::class.java)
+        val error = result as IssueReportResult.Error.BadRequest
         assertThat(error.message).isEqualTo("fail")
         println("\uD83C\uDFC1 [TEST DONE] repository error")
     }
@@ -98,10 +96,8 @@ class TestIssueReporterRepository {
         val repository: IssueReporterRepository = DefaultIssueReporterRepository(client, testDispatchers(testScheduler))
         val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo.create(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
-
-        assertFailsWith<SocketTimeoutException> {
-            repository.sendReport(report, target)
-        }
+        val result = repository.sendReport(report, target)
+        assertThat(result).isInstanceOf(IssueReportResult.Error.Network::class.java)
     }
 
     @Test
@@ -111,10 +107,8 @@ class TestIssueReporterRepository {
         val repository: IssueReporterRepository = DefaultIssueReporterRepository(client, testDispatchers(testScheduler))
         val report = Report("t", "d", com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo.create(android.app.Application()), ExtraInfo(), null)
         val target = GithubTarget("user", "repo")
-
-        assertFailsWith<kotlinx.serialization.SerializationException> {
-            repository.sendReport(report, target)
-        }
+        val result = repository.sendReport(report, target)
+        assertThat(result).isInstanceOf(IssueReportResult.Error.Serialization::class.java)
     }
 
     @Test
@@ -126,8 +120,8 @@ class TestIssueReporterRepository {
         val target = GithubTarget("user", "repo")
 
         val result = repository.sendReport(report, target)
-        assertThat(result).isInstanceOf(IssueReportResult.Error::class.java)
-        val error = result as IssueReportResult.Error
+        assertThat(result).isInstanceOf(IssueReportResult.Error.Unknown::class.java)
+        val error = result as IssueReportResult.Error.Unknown
         assertThat(error.status).isEqualTo(HttpStatusCode.PaymentRequired)
         assertThat(error.message).isEqualTo("weird")
     }
@@ -157,8 +151,8 @@ class TestIssueReporterRepository {
         val target = GithubTarget("user", "repo")
 
         val result = repository.sendReport(report, target)
-        assertThat(result).isInstanceOf(IssueReportResult.Error::class.java)
-        val error = result as IssueReportResult.Error
+        assertThat(result).isInstanceOf(IssueReportResult.Error.Unknown::class.java)
+        val error = result as IssueReportResult.Error.Unknown
         assertThat(error.status).isEqualTo(HttpStatusCode.BadGateway)
         assertThat(error.message).isEqualTo("broke")
     }
@@ -172,8 +166,8 @@ class TestIssueReporterRepository {
         val target = GithubTarget("user", "repo")
 
         val result = repository.sendReport(report, target)
-        assertThat(result).isInstanceOf(IssueReportResult.Error::class.java)
-        val error = result as IssueReportResult.Error
+        assertThat(result).isInstanceOf(IssueReportResult.Error.Unknown::class.java)
+        val error = result as IssueReportResult.Error.Unknown
         assertThat(error.status).isEqualTo(HttpStatusCode.fromValue(418))
         assertThat(error.message).isEqualTo("hot")
     }
@@ -213,9 +207,8 @@ class TestIssueReporterRepository {
         val target = GithubTarget("user", "repo")
 
         val result = repository.sendReport(report, target)
-        assertThat(result).isInstanceOf(IssueReportResult.Error::class.java)
-        val error = result as IssueReportResult.Error
-        assertThat(error.status).isEqualTo(HttpStatusCode.Unauthorized)
+        assertThat(result).isInstanceOf(IssueReportResult.Error.Unauthorized::class.java)
+        val error = result as IssueReportResult.Error.Unauthorized
         assertThat(error.message).isEqualTo("unauth")
     }
 
@@ -228,9 +221,8 @@ class TestIssueReporterRepository {
         val target = GithubTarget("user", "repo")
 
         val result = repository.sendReport(report, target)
-        assertThat(result).isInstanceOf(IssueReportResult.Error::class.java)
-        val error = result as IssueReportResult.Error
-        assertThat(error.status).isEqualTo(HttpStatusCode.Forbidden)
+        assertThat(result).isInstanceOf(IssueReportResult.Error.Forbidden::class.java)
+        val error = result as IssueReportResult.Error.Forbidden
         assertThat(error.message).isEqualTo("stop")
     }
 

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/domain/usecases/SendIssueReportUseCaseTest.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/domain/usecases/SendIssueReportUseCaseTest.kt
@@ -52,8 +52,8 @@ class SendIssueReportUseCaseTest {
         val useCase = SendIssueReportUseCase(repository, dispatchers)
         val result = useCase(params).first()
 
-        assertThat(result).isInstanceOf(IssueReportResult.Error::class.java)
-        val error = result as IssueReportResult.Error
+        assertThat(result).isInstanceOf(IssueReportResult.Error.Unknown::class.java)
+        val error = result as IssueReportResult.Error.Unknown
         assertThat(error.status).isEqualTo(HttpStatusCode.InternalServerError)
         assertThat(error.message).isEqualTo("boom")
     }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/IssueReporterViewModelTest.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/IssueReporterViewModelTest.kt
@@ -92,22 +92,31 @@ class IssueReporterViewModelTest {
     companion object {
         @JvmStatic
         fun errorCases() = listOf(
-            Arguments.of(HttpStatusCode.Unauthorized, R.string.error_unauthorized),
-            Arguments.of(HttpStatusCode.Forbidden, R.string.error_forbidden),
-            Arguments.of(HttpStatusCode.Gone, R.string.error_gone),
-            Arguments.of(HttpStatusCode.UnprocessableEntity, R.string.error_unprocessable),
-            Arguments.of(HttpStatusCode.InternalServerError, R.string.snack_report_failed),
+            Arguments.of(IssueReportResult.Error.Unauthorized(""), R.string.error_unauthorized),
+            Arguments.of(IssueReportResult.Error.Forbidden(""), R.string.error_forbidden),
+            Arguments.of(
+                IssueReportResult.Error.Unknown(HttpStatusCode.Gone, ""),
+                R.string.error_gone
+            ),
+            Arguments.of(
+                IssueReportResult.Error.Unknown(HttpStatusCode.UnprocessableEntity, ""),
+                R.string.error_unprocessable
+            ),
+            Arguments.of(
+                IssueReportResult.Error.Unknown(HttpStatusCode.InternalServerError, ""),
+                R.string.snack_report_failed
+            ),
         )
     }
 
     @ParameterizedTest
     @MethodSource("errorCases")
-    fun `send report error maps message`(status: HttpStatusCode, expected: Int) = runTest {
+    fun `send report error maps message`(error: IssueReportResult.Error, expected: Int) = runTest {
         val dispatcher = StandardTestDispatcher(testScheduler)
         Dispatchers.setMain(dispatcher)
         try {
             val useCase = mockk<SendIssueReportUseCase>()
-            every { useCase.invoke(any()) } returns flowOf(IssueReportResult.Error(status, ""))
+            every { useCase.invoke(any()) } returns flowOf(error)
             val viewModel = IssueReporterViewModel(useCase, githubTarget, "tok", deviceInfoProvider)
             backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) { viewModel.uiState.collect() }
 


### PR DESCRIPTION
## Summary
- Allow configuring the base URL for issue reporting
- Wrap network calls to surface network and serialization failures
- Map HTTP responses to descriptive `IssueReportResult` error types

## Testing
- `./gradlew apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b197e60da8832dbd912377292c53c5