### PR TITLE
Refactor help screen to use Flow data streams

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppToolkitModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppToolkitModule.kt
@@ -3,6 +3,9 @@ package com.d4rk.android.apps.apptoolkit.core.di.modules
 import com.d4rk.android.apps.apptoolkit.BuildConfig
 import com.d4rk.android.apps.apptoolkit.app.startup.utils.interfaces.providers.AppStartupProvider
 import com.d4rk.android.libs.apptoolkit.app.help.domain.data.model.HelpScreenConfig
+import com.d4rk.android.libs.apptoolkit.app.help.domain.repository.HelpRepository
+import com.d4rk.android.libs.apptoolkit.app.help.domain.data.DefaultHelpRepository
+import com.d4rk.android.libs.apptoolkit.app.help.ui.HelpViewModel
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.data.DefaultIssueReporterRepository
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.repository.IssueReporterRepository
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.github.GithubTarget
@@ -42,6 +45,9 @@ val appToolkitModule : Module = module {
         SupportViewModel(billingRepository = get())
     }
     viewModel { StartupViewModel() }
+
+    single<HelpRepository> { DefaultHelpRepository(context = get(), ioDispatcher = get<AppDispatchers>().io) }
+    viewModel { HelpViewModel(helpRepository = get()) }
 
     single<AppDispatchers> { AppDispatchersImpl() }
     single<DeviceInfoProvider> { DeviceInfoProviderImpl(get(), get()) }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/domain/actions/HelpAction.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/domain/actions/HelpAction.kt
@@ -1,0 +1,6 @@
+package com.d4rk.android.libs.apptoolkit.app.help.domain.actions
+
+import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.ActionEvent
+
+sealed interface HelpAction : ActionEvent
+

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/domain/actions/HelpEvent.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/domain/actions/HelpEvent.kt
@@ -1,0 +1,9 @@
+package com.d4rk.android.libs.apptoolkit.app.help.domain.actions
+
+import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.UiEvent
+
+sealed interface HelpEvent : UiEvent {
+    data object LoadFaq : HelpEvent
+    data object DismissSnackbar : HelpEvent
+}
+

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/domain/data/DefaultHelpRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/domain/data/DefaultHelpRepository.kt
@@ -1,16 +1,21 @@
-package com.d4rk.android.libs.apptoolkit.app.help.ui
+package com.d4rk.android.libs.apptoolkit.app.help.domain.data
 
-import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
-import androidx.compose.ui.platform.LocalContext
+import android.content.Context
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.help.domain.data.model.UiHelpQuestion
+import com.d4rk.android.libs.apptoolkit.app.help.domain.repository.HelpRepository
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
 
-@Composable
-fun rememberFaqList(): List<UiHelpQuestion> {
-    val context = LocalContext.current
-    return remember {
-        listOf(
+class DefaultHelpRepository(
+    private val context: Context,
+    private val ioDispatcher: CoroutineDispatcher
+) : HelpRepository {
+
+    override fun observeFaq(): Flow<List<UiHelpQuestion>> = flow {
+        val questions = listOf(
             R.string.question_1 to R.string.summary_preference_faq_1,
             R.string.question_2 to R.string.summary_preference_faq_2,
             R.string.question_3 to R.string.summary_preference_faq_3,
@@ -26,5 +31,6 @@ fun rememberFaqList(): List<UiHelpQuestion> {
                 answer = context.getString(answerRes)
             )
         }.filter { it.question.isNotBlank() && it.answer.isNotBlank() }
-    }
+        emit(questions)
+    }.flowOn(ioDispatcher)
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/domain/model/ui/UiHelpScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/domain/model/ui/UiHelpScreen.kt
@@ -1,0 +1,8 @@
+package com.d4rk.android.libs.apptoolkit.app.help.domain.model.ui
+
+import com.d4rk.android.libs.apptoolkit.app.help.domain.data.model.UiHelpQuestion
+
+data class UiHelpScreen(
+    val questions: List<UiHelpQuestion> = emptyList()
+)
+

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/domain/repository/HelpRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/domain/repository/HelpRepository.kt
@@ -1,0 +1,8 @@
+package com.d4rk.android.libs.apptoolkit.app.help.domain.repository
+
+import com.d4rk.android.libs.apptoolkit.app.help.domain.data.model.UiHelpQuestion
+import kotlinx.coroutines.flow.Flow
+
+interface HelpRepository {
+    fun observeFaq(): Flow<List<UiHelpQuestion>>
+}

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpActivity.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpActivity.kt
@@ -9,12 +9,14 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.ui.Modifier
 import androidx.lifecycle.lifecycleScope
+import org.koin.androidx.viewmodel.ext.android.viewModel
 import com.d4rk.android.libs.apptoolkit.app.help.domain.data.model.HelpScreenConfig
 import com.d4rk.android.libs.apptoolkit.app.theme.style.AppTheme
 import org.koin.android.ext.android.inject
 
 class HelpActivity : AppCompatActivity() {
     private val config : HelpScreenConfig by inject()
+    private val viewModel: HelpViewModel by viewModel()
 
     override fun onCreate(savedInstanceState : Bundle?) {
         super.onCreate(savedInstanceState)
@@ -22,7 +24,7 @@ class HelpActivity : AppCompatActivity() {
         setContent {
             AppTheme {
                 Surface(modifier = Modifier.fillMaxSize() , color = MaterialTheme.colorScheme.background) {
-                    HelpScreen(activity = this@HelpActivity , config = config, scope = lifecycleScope)
+                    HelpScreen(activity = this@HelpActivity , config = config, scope = lifecycleScope, viewModel = viewModel)
                 }
             }
         }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpScreen.kt
@@ -16,18 +16,26 @@ import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import com.d4rk.android.libs.apptoolkit.R
+import com.d4rk.android.libs.apptoolkit.app.help.domain.actions.HelpEvent
 import com.d4rk.android.libs.apptoolkit.app.help.domain.data.model.HelpScreenConfig
 import com.d4rk.android.libs.apptoolkit.app.help.domain.data.model.UiHelpQuestion
+import com.d4rk.android.libs.apptoolkit.app.help.domain.model.ui.UiHelpScreen
 import com.d4rk.android.libs.apptoolkit.app.help.ui.components.ContactUsCard
 import com.d4rk.android.libs.apptoolkit.app.help.ui.components.HelpQuestionsList
 import com.d4rk.android.libs.apptoolkit.app.help.ui.components.dropdown.HelpScreenMenuActions
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.fab.AnimatedExtendedFloatingActionButton
+import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.LoadingScreen
+import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.NoDataScreen
+import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.ScreenStateHandler
 import com.d4rk.android.libs.apptoolkit.core.ui.components.navigation.LargeTopAppBarWithScaffold
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.ExtraLargeVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.MediumVerticalSpacer
@@ -38,11 +46,15 @@ import kotlinx.coroutines.CoroutineScope
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun HelpScreen(activity: ComponentActivity, config: HelpScreenConfig, scope: CoroutineScope) {
-    val scrollBehavior : TopAppBarScrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(state = rememberTopAppBarState())
-    val context : Context = LocalContext.current
-    val isFabExtended : MutableState<Boolean> = remember { mutableStateOf(value = true) }
-    val faqList: List<UiHelpQuestion> = rememberFaqList()
+fun HelpScreen(activity: ComponentActivity, config: HelpScreenConfig, scope: CoroutineScope, viewModel: HelpViewModel) {
+    val scrollBehavior: TopAppBarScrollBehavior = TopAppBarDefaults.enterAlwaysScrollBehavior(state = rememberTopAppBarState())
+    val context: Context = LocalContext.current
+    val isFabExtended: MutableState<Boolean> = remember { mutableStateOf(value = true) }
+    val screenState: UiStateScreen<UiHelpScreen> by viewModel.uiState.collectAsStateWithLifecycle()
+
+    LaunchedEffect(Unit) {
+        viewModel.onEvent(HelpEvent.LoadFaq)
+    }
 
     LaunchedEffect(key1 = scrollBehavior.state.contentOffset) {
         isFabExtended.value = scrollBehavior.state.contentOffset >= 0f
@@ -72,7 +84,19 @@ fun HelpScreen(activity: ComponentActivity, config: HelpScreenConfig, scope: Cor
             )
         }
     ) { paddingValues ->
-        HelpScreenContent(questions = faqList, paddingValues = paddingValues, activity = activity)
+        ScreenStateHandler(
+            screenState = screenState,
+            onLoading = { LoadingScreen() },
+            onEmpty = {
+                NoDataScreen(showRetry = true, onRetry = { viewModel.onEvent(HelpEvent.LoadFaq) })
+            },
+            onError = {
+                NoDataScreen(isError = true, showRetry = true, onRetry = { viewModel.onEvent(HelpEvent.LoadFaq) })
+            },
+            onSuccess = { data: UiHelpScreen ->
+                HelpScreenContent(questions = data.questions, paddingValues = paddingValues, activity = activity)
+            }
+        )
     }
 }
 

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpViewModel.kt
@@ -1,0 +1,56 @@
+package com.d4rk.android.libs.apptoolkit.app.help.ui
+
+import androidx.lifecycle.viewModelScope
+import com.d4rk.android.libs.apptoolkit.app.help.domain.actions.HelpAction
+import com.d4rk.android.libs.apptoolkit.app.help.domain.actions.HelpEvent
+import com.d4rk.android.libs.apptoolkit.app.help.domain.model.ui.UiHelpScreen
+import com.d4rk.android.libs.apptoolkit.app.help.domain.repository.HelpRepository
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiSnackbar
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.dismissSnackbar
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.setErrors
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.updateData
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.updateState
+import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
+import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
+import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.launch
+
+class HelpViewModel(
+    private val helpRepository: HelpRepository,
+) : ScreenViewModel<UiHelpScreen, HelpEvent, HelpAction>(
+    initialState = UiStateScreen(screenState = ScreenState.IsLoading(), data = UiHelpScreen())
+) {
+
+    override fun onEvent(event: HelpEvent) {
+        when (event) {
+            HelpEvent.LoadFaq -> loadFaq()
+            HelpEvent.DismissSnackbar -> screenState.dismissSnackbar()
+        }
+    }
+
+    private fun loadFaq() {
+        viewModelScope.launch {
+            helpRepository.observeFaq()
+                .catch { error ->
+                    screenState.setErrors(
+                        listOf(
+                            UiSnackbar(message = UiTextHelper.DynamicString(error.message ?: "Failed to load FAQs"))
+                        )
+                    )
+                    screenState.updateState(ScreenState.Error())
+                }
+                .collect { questions ->
+                    if (questions.isEmpty()) {
+                        screenState.updateState(ScreenState.NoData())
+                    } else {
+                        screenState.updateData(newState = ScreenState.Success()) { current ->
+                            current.copy(questions = questions)
+                        }
+                    }
+                }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- align HelpViewModel with ScreenViewModel pattern and error-aware screen state
- add HelpEvent/HelpAction and UiHelpScreen to model FAQ state
- render HelpScreen via ScreenStateHandler with retry support

## Testing
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1d6d34670832d8a509ede745c6789