### PR TITLE
Translate device info error string

### DIFF
--- a/apptoolkit/src/main/res/values-ar-rEG/strings.xml
+++ b/apptoolkit/src/main/res/values-ar-rEG/strings.xml
@@ -258,6 +258,7 @@
     <string name="android_version">إصدار أندرويد:</string>
     <string name="api_level">مستوى API:</string>
     <string name="snack_device_info_copied">تم نسخ معلومات الجهاز إلى الحافظة</string>
+    <string name="snack_device_info_failed">تعذر تحميل معلومات الجهاز</string>
 
     <string name="help_and_feedback">المساعدة والملاحظات</string>
     <string name="help">مساعدة</string>

--- a/apptoolkit/src/main/res/values-bg-rBG/strings.xml
+++ b/apptoolkit/src/main/res/values-bg-rBG/strings.xml
@@ -258,6 +258,7 @@
     <string name="android_version">Версия на Android:</string>
     <string name="api_level">API ниво:</string>
     <string name="snack_device_info_copied">Информацията за устройството е копирана в клипборда</string>
+    <string name="snack_device_info_failed">Неуспешно зареждане на информация за устройството</string>
 
     <string name="help_and_feedback">Помощ и обратна връзка</string>
     <string name="help">Помощ</string>

--- a/apptoolkit/src/main/res/values-bn-rBD/strings.xml
+++ b/apptoolkit/src/main/res/values-bn-rBD/strings.xml
@@ -258,6 +258,7 @@
     <string name="android_version">অ্যান্ড্রয়েড সংস্করণ:</string>
     <string name="api_level">API লেভেল:</string>
     <string name="snack_device_info_copied">ডিভাইসের তথ্য ক্লিপবোর্ডে কপি করা হয়েছে</string>
+    <string name="snack_device_info_failed">ডিভাইসের তথ্য লোড করা যায়নি</string>
 
     <string name="help_and_feedback">সাহায্য ও প্রতিক্রিয়া</string>
     <string name="help">সাহায্য</string>

--- a/apptoolkit/src/main/res/values-de-rDE/strings.xml
+++ b/apptoolkit/src/main/res/values-de-rDE/strings.xml
@@ -258,6 +258,7 @@
     <string name="android_version">Android-Version:</string>
     <string name="api_level">API-Stufe:</string>
     <string name="snack_device_info_copied">Geräteinformationen wurden in die Zwischenablage kopiert</string>
+    <string name="snack_device_info_failed">Geräteinformationen konnten nicht geladen werden</string>
 
     <string name="help_and_feedback">Hilfe &amp; Feedback</string>
     <string name="help">Hilfe</string>

--- a/apptoolkit/src/main/res/values-es-rGQ/strings.xml
+++ b/apptoolkit/src/main/res/values-es-rGQ/strings.xml
@@ -258,6 +258,7 @@
     <string name="android_version">Versión de Android:</string>
     <string name="api_level">Nivel de API:</string>
     <string name="snack_device_info_copied">Información del dispositivo copiada al portapapeles</string>
+    <string name="snack_device_info_failed">No se pudo cargar la información del dispositivo</string>
 
     <string name="help_and_feedback">Ayuda y comentarios</string>
     <string name="help">Ayuda</string>

--- a/apptoolkit/src/main/res/values-es-rMX/strings.xml
+++ b/apptoolkit/src/main/res/values-es-rMX/strings.xml
@@ -258,6 +258,7 @@
     <string name="android_version">Versión de Android:</string>
     <string name="api_level">Nivel de API:</string>
     <string name="snack_device_info_copied">Información del dispositivo copiada al portapapeles</string>
+    <string name="snack_device_info_failed">No se pudo cargar la información del dispositivo</string>
 
     <string name="help_and_feedback">Ayuda &amp; comentarios</string>
     <string name="help">Ayuda</string>

--- a/apptoolkit/src/main/res/values-fil-rPH/strings.xml
+++ b/apptoolkit/src/main/res/values-fil-rPH/strings.xml
@@ -258,6 +258,7 @@
     <string name="android_version">Bersyon ng Android:</string>
     <string name="api_level">Antas ng API:</string>
     <string name="snack_device_info_copied">Nakopya sa clipboard ang impormasyon ng device</string>
+    <string name="snack_device_info_failed">Hindi ma-load ang impormasyon ng device</string>
 
     <string name="help_and_feedback">Tulong &amp; Feedback</string>
     <string name="help">Tulong</string>

--- a/apptoolkit/src/main/res/values-fr-rFR/strings.xml
+++ b/apptoolkit/src/main/res/values-fr-rFR/strings.xml
@@ -258,6 +258,7 @@
     <string name="android_version">Version d\'Android:</string>
     <string name="api_level">Niveau d\'API:</string>
     <string name="snack_device_info_copied">Les informations sur l\'appareil ont été copiées dans le presse-papiers</string>
+    <string name="snack_device_info_failed">Impossible de charger les informations sur l\'appareil</string>
 
     <string name="help_and_feedback">Aide et commentaires</string>
     <string name="help">Aide</string>

--- a/apptoolkit/src/main/res/values-hi-rIN/strings.xml
+++ b/apptoolkit/src/main/res/values-hi-rIN/strings.xml
@@ -258,6 +258,7 @@
     <string name="android_version">एंड्रॉइड संस्करण:</string>
     <string name="api_level">एपीआई स्तर:</string>
     <string name="snack_device_info_copied">डिवाइस जानकारी क्लिपबोर्ड में कॉपी की गई</string>
+    <string name="snack_device_info_failed">डिवाइस की जानकारी लोड नहीं हो सकी</string>
 
     <string name="help_and_feedback">मदद और प्रतिक्रिया</string>
     <string name="help">मदद</string>

--- a/apptoolkit/src/main/res/values-hu-rHU/strings.xml
+++ b/apptoolkit/src/main/res/values-hu-rHU/strings.xml
@@ -258,6 +258,7 @@
     <string name="android_version">Android verzió:</string>
     <string name="api_level">API szint:</string>
     <string name="snack_device_info_copied">Eszközinformáció másolva a vágólapra</string>
+    <string name="snack_device_info_failed">Nem sikerült betölteni az eszköz adatait</string>
 
     <string name="help_and_feedback">Segítség és visszajelzés</string>
     <string name="help">Segítség</string>

--- a/apptoolkit/src/main/res/values-in-rID/strings.xml
+++ b/apptoolkit/src/main/res/values-in-rID/strings.xml
@@ -258,6 +258,7 @@
     <string name="android_version">Versi Android:</string>
     <string name="api_level">Level API:</string>
     <string name="snack_device_info_copied">Informasi perangkat disalin ke papan klip</string>
+    <string name="snack_device_info_failed">Tidak dapat memuat info perangkat</string>
 
     <string name="help_and_feedback">Bantuan &amp; umpan balik</string>
     <string name="help">Bantuan</string>

--- a/apptoolkit/src/main/res/values-it-rIT/strings.xml
+++ b/apptoolkit/src/main/res/values-it-rIT/strings.xml
@@ -258,6 +258,7 @@
     <string name="android_version">Versione Android:</string>
     <string name="api_level">Livello API:</string>
     <string name="snack_device_info_copied">Informazioni sul dispositivo copiate negli appunti</string>
+    <string name="snack_device_info_failed">Impossibile caricare le informazioni del dispositivo</string>
 
     <string name="help_and_feedback">Aiuto e feedback</string>
     <string name="help">Aiuto</string>

--- a/apptoolkit/src/main/res/values-ja-rJP/strings.xml
+++ b/apptoolkit/src/main/res/values-ja-rJP/strings.xml
@@ -258,6 +258,7 @@
     <string name="android_version">Androidバージョン:</string>
     <string name="api_level">APIレベル:</string>
     <string name="snack_device_info_copied">デバイス情報がクリップボードにコピーされました</string>
+    <string name="snack_device_info_failed">デバイス情報を読み込めませんでした</string>
 
     <string name="help_and_feedback">ヘルプとフィードバック</string>
     <string name="help">ヘルプ</string>

--- a/apptoolkit/src/main/res/values-ko-rKR/strings.xml
+++ b/apptoolkit/src/main/res/values-ko-rKR/strings.xml
@@ -258,6 +258,7 @@
     <string name="android_version">Android 버전:</string>
     <string name="api_level">API 레벨:</string>
     <string name="snack_device_info_copied">기기 정보가 클립보드에 복사되었습니다.</string>
+    <string name="snack_device_info_failed">디바이스 정보를 불러올 수 없습니다</string>
 
     <string name="help_and_feedback">도움말 &amp; 의견</string>
     <string name="help">도움말</string>

--- a/apptoolkit/src/main/res/values-pl-rPL/strings.xml
+++ b/apptoolkit/src/main/res/values-pl-rPL/strings.xml
@@ -258,6 +258,7 @@
     <string name="android_version">Wersja Androida:</string>
     <string name="api_level">Poziom API:</string>
     <string name="snack_device_info_copied">Informacje o urządzeniu zostały skopiowane do schowka</string>
+    <string name="snack_device_info_failed">Nie można załadować informacji o urządzeniu</string>
 
     <string name="help_and_feedback">Pomoc i opinie</string>
     <string name="help">Pomoc</string>

--- a/apptoolkit/src/main/res/values-pt-rBR/strings.xml
+++ b/apptoolkit/src/main/res/values-pt-rBR/strings.xml
@@ -258,6 +258,7 @@
     <string name="android_version">Versão do Android:</string>
     <string name="api_level">Nível da API:</string>
     <string name="snack_device_info_copied">Informações do dispositivo copiadas para a área de transferência</string>
+    <string name="snack_device_info_failed">Não foi possível carregar as informações do dispositivo</string>
 
     <string name="help_and_feedback">Ajuda e feedback</string>
     <string name="help">Ajuda</string>

--- a/apptoolkit/src/main/res/values-ro-rRO/strings.xml
+++ b/apptoolkit/src/main/res/values-ro-rRO/strings.xml
@@ -258,6 +258,7 @@
     <string name="android_version">Versiune Android:</string>
     <string name="api_level">Nivel API:</string>
     <string name="snack_device_info_copied">Informațiile dispozitivului au fost copiate în clipboard</string>
+    <string name="snack_device_info_failed">Nu s-a putut încărca informațiile despre dispozitiv</string>
 
     <string name="help_and_feedback">Ajutor și feedback</string>
     <string name="help">Ajutor</string>

--- a/apptoolkit/src/main/res/values-ru-rRU/strings.xml
+++ b/apptoolkit/src/main/res/values-ru-rRU/strings.xml
@@ -258,6 +258,7 @@
     <string name="android_version">Версия Android:</string>
     <string name="api_level">Уровень API:</string>
     <string name="snack_device_info_copied">Информация об устройстве скопирована в буфер обмена</string>
+    <string name="snack_device_info_failed">Не удалось загрузить информацию об устройстве</string>
 
     <string name="help_and_feedback">Помощь и отзывы</string>
     <string name="help">Помощь</string>

--- a/apptoolkit/src/main/res/values-sv-rSE/strings.xml
+++ b/apptoolkit/src/main/res/values-sv-rSE/strings.xml
@@ -258,6 +258,7 @@
     <string name="android_version">Android-version:</string>
     <string name="api_level">API-nivå:</string>
     <string name="snack_device_info_copied">Enhetsinformation kopierad till urklipp</string>
+    <string name="snack_device_info_failed">Det gick inte att läsa in enhetsinformation</string>
 
     <string name="help_and_feedback">Hjälp och feedback</string>
     <string name="help">Hjälp</string>

--- a/apptoolkit/src/main/res/values-th-rTH/strings.xml
+++ b/apptoolkit/src/main/res/values-th-rTH/strings.xml
@@ -258,6 +258,7 @@
     <string name="android_version">เวอร์ชัน Android:</string>
     <string name="api_level">ระดับ API:</string>
     <string name="snack_device_info_copied">คัดลอกข้อมูลอุปกรณ์ไปยังคลิปบอร์ดแล้ว</string>
+    <string name="snack_device_info_failed">ไม่สามารถโหลดข้อมูลอุปกรณ์ได้</string>
 
     <string name="help_and_feedback">ความช่วยเหลือและข้อเสนอแนะ</string>
     <string name="help">ช่วยเหลือ</string>

--- a/apptoolkit/src/main/res/values-tr-rTR/strings.xml
+++ b/apptoolkit/src/main/res/values-tr-rTR/strings.xml
@@ -258,6 +258,7 @@
     <string name="android_version">Android Sürümü:</string>
     <string name="api_level">API Seviyesi:</string>
     <string name="snack_device_info_copied">Cihaz bilgileri panoya kopyalandı</string>
+    <string name="snack_device_info_failed">Cihaz bilgileri yüklenemedi</string>
 
     <string name="help_and_feedback">Yardım ve geri bildirim</string>
     <string name="help">Yardım</string>

--- a/apptoolkit/src/main/res/values-uk-rUA/strings.xml
+++ b/apptoolkit/src/main/res/values-uk-rUA/strings.xml
@@ -258,6 +258,7 @@
     <string name="android_version">Версія Android:</string>
     <string name="api_level">Рівень API:</string>
     <string name="snack_device_info_copied">Інформацію про пристрій скопійовано до буфера обміну</string>
+    <string name="snack_device_info_failed">Не вдалося завантажити інформацію про пристрій</string>
 
     <string name="help_and_feedback">Допомога та зворотній зв\'язок</string>
     <string name="help">Допомога</string>

--- a/apptoolkit/src/main/res/values-ur-rPK/strings.xml
+++ b/apptoolkit/src/main/res/values-ur-rPK/strings.xml
@@ -258,6 +258,7 @@
     <string name="android_version">اینڈرائیڈ ورژن:</string>
     <string name="api_level">API لیول:</string>
     <string name="snack_device_info_copied">ڈیوائس کی معلومات کلپ بورڈ پر کاپی ہو گئیں</string>
+    <string name="snack_device_info_failed">ڈیوائس کی معلومات لوڈ نہیں ہو سکی</string>
 
     <string name="help_and_feedback">مدد اور رائے</string>
     <string name="help">مدد</string>

--- a/apptoolkit/src/main/res/values-vi-rVN/strings.xml
+++ b/apptoolkit/src/main/res/values-vi-rVN/strings.xml
@@ -258,6 +258,7 @@
     <string name="android_version">Phiên bản Android:</string>
     <string name="api_level">Cấp API:</string>
     <string name="snack_device_info_copied">Đã sao chép thông tin thiết bị vào khay nhớ tạm</string>
+    <string name="snack_device_info_failed">Không thể tải thông tin thiết bị</string>
 
     <string name="help_and_feedback">Trợ giúp &amp; phản hồi</string>
     <string name="help">Trợ giúp</string>

--- a/apptoolkit/src/main/res/values-zh-rTW/strings.xml
+++ b/apptoolkit/src/main/res/values-zh-rTW/strings.xml
@@ -258,6 +258,7 @@
     <string name="android_version">Android 版本：</string>
     <string name="api_level">API 等級：</string>
     <string name="snack_device_info_copied">設備資訊已複製到剪貼板</string>
+    <string name="snack_device_info_failed">無法載入裝置資訊</string>
 
     <string name="help_and_feedback">幫助與反饋</string>
     <string name="help">幫助</string>


### PR DESCRIPTION
## Summary
- localize "Unable to load device info" across all existing language resources

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `apt-get install -y android-sdk` *(fails: ca-certificates-java processing error)*

------
https://chatgpt.com/codex/tasks/task_e_68b1dc726738832db603cd1d4d57290f