### PR TITLE
Refactor favorites repository for coroutine architecture

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/domain/usecases/ToggleFavoriteUseCase.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/domain/usecases/ToggleFavoriteUseCase.kt
@@ -2,18 +2,12 @@ package com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases
 
 import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.repository.FavoritesRepository
 import com.d4rk.android.libs.apptoolkit.core.domain.usecases.Repository
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 
 class ToggleFavoriteUseCase(
     private val repository: FavoritesRepository,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : Repository<String, Unit> {
     override suspend operator fun invoke(param: String) {
-        withContext(dispatcher) {
-            repository.toggleFavorite(param)
-        }
+        repository.toggleFavorite(param)
     }
 }
 

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/data/favorites/FavoritesRepositoryImpl.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/data/favorites/FavoritesRepositoryImpl.kt
@@ -7,24 +7,31 @@ import android.util.Log
 import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.repository.FavoritesRepository
 import com.d4rk.android.apps.apptoolkit.core.broadcast.FavoritesChangedReceiver
 import com.d4rk.android.apps.apptoolkit.core.data.datastore.DataStore
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.withContext
 
 class FavoritesRepositoryImpl(
     private val context: Context,
-    private val dataStore: DataStore
+    private val dataStore: DataStore,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : FavoritesRepository {
-    override fun observeFavorites(): Flow<Set<String>> = dataStore.favoriteApps
+    override fun observeFavorites(): Flow<Set<String>> = dataStore.favoriteApps.flowOn(ioDispatcher)
 
     override suspend fun toggleFavorite(packageName: String) {
-        dataStore.toggleFavoriteApp(packageName)
-        val intent = Intent(FavoritesChangedReceiver.ACTION_FAVORITES_CHANGED).apply {
-            component = ComponentName(context, FavoritesChangedReceiver::class.java)
-            putExtra(FavoritesChangedReceiver.EXTRA_PACKAGE_NAME, packageName)
-        }
-        runCatching {
-            context.sendBroadcast(intent)
-        }.onFailure { e ->
-            Log.w("FavoritesRepositoryImpl", "Failed to send favorites broadcast", e)
+        withContext(ioDispatcher) {
+            dataStore.toggleFavoriteApp(packageName)
+            val intent = Intent(FavoritesChangedReceiver.ACTION_FAVORITES_CHANGED).apply {
+                component = ComponentName(context, FavoritesChangedReceiver::class.java)
+                putExtra(FavoritesChangedReceiver.EXTRA_PACKAGE_NAME, packageName)
+            }
+            runCatching {
+                context.sendBroadcast(intent)
+            }.onFailure { e ->
+                Log.w("FavoritesRepositoryImpl", "Failed to send favorites broadcast", e)
+            }
         }
 
     }

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppModule.kt
@@ -33,9 +33,9 @@ val appModule : Module = module {
     single<AdsCoreManager> { AdsCoreManager(context = get(), buildInfoProvider = get(), ioDispatcher = get(named("io"))) }
     single { KtorClient().createClient(enableLogging = BuildConfig.DEBUG) }
 
-    single<FavoritesRepository> { FavoritesRepositoryImpl(context = get(), dataStore = get()) }
+    single<FavoritesRepository> { FavoritesRepositoryImpl(context = get(), dataStore = get(), ioDispatcher = get(named("io"))) }
     single { ObserveFavoritesUseCase(repository = get()) }
-    single { ToggleFavoriteUseCase(repository = get(), dispatcher = get(named("io"))) }
+    single { ToggleFavoriteUseCase(repository = get()) }
 
     single<List<String>>(qualifier = named(name = "startup_entries")) {
         get<Context>().resources.getStringArray(R.array.preference_startup_entries).toList()

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModel.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModel.kt
@@ -24,8 +24,7 @@ class TestFavoriteAppsViewModel : TestFavoriteAppsViewModelBase() {
         setup(
             fetchApps = apps,
             initialFavorites = emptySet(),
-            toggleError = RuntimeException("fail"),
-            dispatcher = dispatcherExtension.testDispatcher
+            toggleError = RuntimeException("fail")
         )
 
         viewModel.favorites.test {

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModelBase.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModelBase.kt
@@ -7,8 +7,6 @@ import com.d4rk.android.apps.apptoolkit.app.apps.favorites.ui.FavoriteAppsViewMo
 import com.d4rk.android.apps.apptoolkit.app.apps.list.FakeDeveloperAppsRepository
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.usecases.FetchDeveloperAppsUseCase
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
@@ -22,15 +20,14 @@ open class TestFavoriteAppsViewModelBase {
         fetchApps: List<AppInfo>,
         initialFavorites: Set<String> = emptySet(),
         favoritesFlow: Flow<Set<String>>? = null,
-        toggleError: Throwable? = null,
-        dispatcher: CoroutineDispatcher = Dispatchers.Main
+        toggleError: Throwable? = null
     ) {
         println("\uD83E\uDDEA [SETUP] Initial favorites: $initialFavorites")
         val developerAppsRepository = FakeDeveloperAppsRepository(fetchApps)
         val fetchUseCase = FetchDeveloperAppsUseCase(developerAppsRepository)
         val favoritesRepository = FakeFavoritesRepository(initialFavorites, favoritesFlow, toggleError)
         val observeFavoritesUseCase = ObserveFavoritesUseCase(favoritesRepository)
-        val toggleFavoriteUseCase = ToggleFavoriteUseCase(favoritesRepository, dispatcher)
+        val toggleFavoriteUseCase = ToggleFavoriteUseCase(favoritesRepository)
         viewModel = FavoriteAppsViewModel(
             fetchDeveloperAppsUseCase = fetchUseCase,
             observeFavoritesUseCase = observeFavoritesUseCase,

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModel.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModel.kt
@@ -17,14 +17,14 @@ class TestAppsListViewModel : TestAppsListViewModelBase() {
     @Test
     fun `fetch apps - large list`() = runTest(dispatcherExtension.testDispatcher) {
         val apps = (1..10_000).map { AppInfo("App$it", "pkg$it", "url$it") }
-        setup(fetchApps = apps, dispatcher = dispatcherExtension.testDispatcher)
+        setup(fetchApps = apps)
         viewModel.uiState.testSuccess(expectedSize = apps.size)
     }
 
     @Test
     fun `toggle favorite updates state`() = runTest(dispatcherExtension.testDispatcher) {
         val apps = listOf(AppInfo("App", "pkg", "url"))
-        setup(fetchApps = apps, dispatcher = dispatcherExtension.testDispatcher)
+        setup(fetchApps = apps)
         toggleAndAssert(packageName = "pkg", expected = true)
         toggleAndAssert(packageName = "pkg", expected = false)
     }

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModelBase.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModelBase.kt
@@ -12,8 +12,6 @@ import com.d4rk.android.apps.apptoolkit.app.apps.list.ui.AppsListViewModel
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.google.common.truth.Truth.assertThat
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
@@ -30,14 +28,13 @@ open class TestAppsListViewModelBase {
         favoritesFlow: Flow<Set<String>>? = null,
         toggleError: Throwable? = null,
         fetchThrows: Throwable? = null,
-        dispatcher: CoroutineDispatcher = Dispatchers.Main,
     ) {
         println("\uD83E\uDDEA [SETUP] Initial favorites: $initialFavorites")
         val developerAppsRepository = FakeDeveloperAppsRepository(fetchApps, fetchThrows)
         val fetchUseCase = FetchDeveloperAppsUseCase(developerAppsRepository)
         val favoritesRepository = FakeFavoritesRepository(initialFavorites, favoritesFlow, toggleError)
         val observeFavoritesUseCase = ObserveFavoritesUseCase(favoritesRepository)
-        val toggleFavoriteUseCase = ToggleFavoriteUseCase(favoritesRepository, dispatcher)
+        val toggleFavoriteUseCase = ToggleFavoriteUseCase(favoritesRepository)
         viewModel = AppsListViewModel(fetchUseCase, observeFavoritesUseCase, toggleFavoriteUseCase)
         println("\u2705 [SETUP] ViewModel initialized")
     }


### PR DESCRIPTION
## Summary
- offload favorites data operations to injected IO dispatcher using withContext and flowOn
- simplify ToggleFavoriteUseCase by delegating thread management to repository
- align dependency injection and tests with new coroutine-based architecture

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1df93c948832dad8a4b4dcf605e72