### PR TITLE
Refactor main navigation loading to Kotlin Flow

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/data/repository/MainRepositoryImpl.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/data/repository/MainRepositoryImpl.kt
@@ -9,24 +9,31 @@ import com.d4rk.android.apps.apptoolkit.app.main.domain.repository.MainRepositor
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.core.domain.model.navigation.NavigationDrawerItem
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
 
 class MainRepositoryImpl(
     private val ioDispatcher: CoroutineDispatcher
 ) : MainRepository {
-    override suspend fun getNavigationDrawerItems(): List<NavigationDrawerItem> =
-        withContext(ioDispatcher) {
-            listOf(
-                NavigationDrawerItem(
-                    title = R.string.settings, selectedIcon = Icons.Outlined.Settings
-                ), NavigationDrawerItem(
-                    title = R.string.help_and_feedback, selectedIcon = Icons.AutoMirrored.Outlined.HelpOutline
-                ), NavigationDrawerItem(
-                    title = R.string.updates, selectedIcon = Icons.AutoMirrored.Outlined.EventNote
-                ), NavigationDrawerItem(
-                    title = R.string.share, selectedIcon = Icons.Outlined.Share
+    override fun getNavigationDrawerItems(): Flow<List<NavigationDrawerItem>> =
+        flow {
+            emit(
+                listOf(
+                    NavigationDrawerItem(
+                        title = R.string.settings, selectedIcon = Icons.Outlined.Settings
+                    ),
+                    NavigationDrawerItem(
+                        title = R.string.help_and_feedback, selectedIcon = Icons.AutoMirrored.Outlined.HelpOutline
+                    ),
+                    NavigationDrawerItem(
+                        title = R.string.updates, selectedIcon = Icons.AutoMirrored.Outlined.EventNote
+                    ),
+                    NavigationDrawerItem(
+                        title = R.string.share, selectedIcon = Icons.Outlined.Share
+                    )
                 )
             )
-        }
+        }.flowOn(ioDispatcher)
 }
 

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/domain/repository/MainRepository.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/domain/repository/MainRepository.kt
@@ -1,8 +1,9 @@
 package com.d4rk.android.apps.apptoolkit.app.main.domain.repository
 
 import com.d4rk.android.libs.apptoolkit.core.domain.model.navigation.NavigationDrawerItem
+import kotlinx.coroutines.flow.Flow
 
 interface MainRepository {
-    suspend fun getNavigationDrawerItems(): List<NavigationDrawerItem>
+    fun getNavigationDrawerItems(): Flow<List<NavigationDrawerItem>>
 }
 


### PR DESCRIPTION
## Summary
- expose navigation items as a Flow in `MainRepository`
- collect navigation drawer items in `MainViewModel` with Flow operators and error handling

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e108388c832daaaf9c6cf4ec45b8