### PR TITLE
Refactor help FAQ loading to suspend API

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/domain/data/DefaultHelpRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/domain/data/DefaultHelpRepository.kt
@@ -5,17 +5,15 @@ import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.help.domain.data.model.UiHelpQuestion
 import com.d4rk.android.libs.apptoolkit.app.help.domain.repository.HelpRepository
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.withContext
 
 class DefaultHelpRepository(
     private val context: Context,
     private val ioDispatcher: CoroutineDispatcher
 ) : HelpRepository {
 
-    override fun observeFaq(): Flow<List<UiHelpQuestion>> = flow {
-        val questions = listOf(
+    override suspend fun fetchFaq(): List<UiHelpQuestion> = withContext(ioDispatcher) {
+        listOf(
             R.string.question_1 to R.string.summary_preference_faq_1,
             R.string.question_2 to R.string.summary_preference_faq_2,
             R.string.question_3 to R.string.summary_preference_faq_3,
@@ -31,6 +29,5 @@ class DefaultHelpRepository(
                 answer = context.getString(answerRes)
             )
         }.filter { it.question.isNotBlank() && it.answer.isNotBlank() }
-        emit(questions)
-    }.flowOn(ioDispatcher)
+    }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/domain/repository/HelpRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/domain/repository/HelpRepository.kt
@@ -1,8 +1,7 @@
 package com.d4rk.android.libs.apptoolkit.app.help.domain.repository
 
 import com.d4rk.android.libs.apptoolkit.app.help.domain.data.model.UiHelpQuestion
-import kotlinx.coroutines.flow.Flow
 
 interface HelpRepository {
-    fun observeFaq(): Flow<List<UiHelpQuestion>>
+    suspend fun fetchFaq(): List<UiHelpQuestion>
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpViewModel.kt
@@ -14,7 +14,7 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.updateData
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.updateState
 import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
-import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.launch
 
 class HelpViewModel(
@@ -32,24 +32,24 @@ class HelpViewModel(
 
     private fun loadFaq() {
         viewModelScope.launch {
-            helpRepository.observeFaq()
-                .catch { error ->
-                    screenState.setErrors(
-                        listOf(
-                            UiSnackbar(message = UiTextHelper.DynamicString(error.message ?: "Failed to load FAQs"))
-                        )
-                    )
-                    screenState.updateState(ScreenState.Error())
-                }
-                .collect { questions ->
-                    if (questions.isEmpty()) {
-                        screenState.updateState(ScreenState.NoData())
-                    } else {
-                        screenState.updateData(newState = ScreenState.Success()) { current ->
-                            current.copy(questions = questions)
-                        }
+            try {
+                val questions = helpRepository.fetchFaq()
+                if (questions.isEmpty()) {
+                    screenState.updateState(ScreenState.NoData())
+                } else {
+                    screenState.updateData(newState = ScreenState.Success()) { current ->
+                        current.copy(questions = questions)
                     }
                 }
+            } catch (error: Throwable) {
+                if (error is CancellationException) throw error
+                screenState.setErrors(
+                    listOf(
+                        UiSnackbar(message = UiTextHelper.DynamicString(error.message ?: "Failed to load FAQs"))
+                    )
+                )
+                screenState.updateState(ScreenState.Error())
+            }
         }
     }
 }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpViewModelTest.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpViewModelTest.kt
@@ -1,0 +1,60 @@
+package com.d4rk.android.libs.apptoolkit.app.help.ui
+
+import com.d4rk.android.libs.apptoolkit.app.help.domain.actions.HelpEvent
+import com.d4rk.android.libs.apptoolkit.app.help.domain.data.model.UiHelpQuestion
+import com.d4rk.android.libs.apptoolkit.app.help.domain.repository.HelpRepository
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.api.Test
+import java.io.IOException
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class HelpViewModelTest {
+
+    @Test
+    fun `loadFaq sets success state when repository returns data`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        Dispatchers.setMain(dispatcher)
+        try {
+            val repository = object : HelpRepository {
+                override suspend fun fetchFaq(): List<UiHelpQuestion> =
+                    listOf(UiHelpQuestion("Q", "A"))
+            }
+            val viewModel = HelpViewModel(repository)
+            viewModel.onEvent(HelpEvent.LoadFaq)
+            advanceUntilIdle()
+            assertTrue(viewModel.uiState.value.screenState is ScreenState.Success)
+            assertEquals(1, viewModel.uiState.value.data?.questions?.size)
+        } finally {
+            Dispatchers.resetMain()
+        }
+    }
+
+    @Test
+    fun `loadFaq sets error state when repository throws`() = runTest {
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        Dispatchers.setMain(dispatcher)
+        try {
+            val repository = object : HelpRepository {
+                override suspend fun fetchFaq(): List<UiHelpQuestion> {
+                    throw IOException("error")
+                }
+            }
+            val viewModel = HelpViewModel(repository)
+            viewModel.onEvent(HelpEvent.LoadFaq)
+            advanceUntilIdle()
+            assertTrue(viewModel.uiState.value.screenState is ScreenState.Error)
+        } finally {
+            Dispatchers.resetMain()
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- expose a suspend `fetchFaq` in `HelpRepository`
- make `DefaultHelpRepository` main-safe using `withContext` and injected dispatcher
- update `HelpViewModel` to use new API and handle cancellation
- add unit tests for `HelpViewModel` with coroutine test dispatcher

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e261bfb4832dad8b6ff6ffcb9002