### PR TITLE
Refactor favorites feature to use flows

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/data/favorites/FavoritesRepositoryImpl.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/data/favorites/FavoritesRepositoryImpl.kt
@@ -10,6 +10,7 @@ import com.d4rk.android.apps.apptoolkit.core.data.datastore.DataStore
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.withContext
 
@@ -18,7 +19,10 @@ class FavoritesRepositoryImpl(
     private val dataStore: DataStore,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
 ) : FavoritesRepository {
-    override fun observeFavorites(): Flow<Set<String>> = dataStore.favoriteApps.flowOn(ioDispatcher)
+    override fun observeFavorites(): Flow<Set<String>> =
+        dataStore.favoriteApps
+            .catch { emit(emptySet()) }
+            .flowOn(ioDispatcher)
 
     override suspend fun toggleFavorite(packageName: String) {
         withContext(ioDispatcher) {


### PR DESCRIPTION
## Summary
- share favorites via StateFlow and eagerly load flow results
- handle repository and ViewModel flow errors with catch and proper dispatchers

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e2590abc832daaff2612f354da8e