### PR TITLE
refactor help feature with use case

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppToolkitModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppToolkitModule.kt
@@ -5,6 +5,7 @@ import com.d4rk.android.apps.apptoolkit.app.startup.utils.interfaces.providers.A
 import com.d4rk.android.libs.apptoolkit.app.help.domain.data.model.HelpScreenConfig
 import com.d4rk.android.libs.apptoolkit.app.help.domain.repository.HelpRepository
 import com.d4rk.android.libs.apptoolkit.app.help.domain.data.DefaultHelpRepository
+import com.d4rk.android.libs.apptoolkit.app.help.domain.usecases.ObserveFaqUseCase
 import com.d4rk.android.libs.apptoolkit.app.help.ui.HelpViewModel
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.data.DefaultIssueReporterRepository
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.repository.IssueReporterRepository
@@ -47,7 +48,8 @@ val appToolkitModule : Module = module {
     viewModel { StartupViewModel() }
 
     single<HelpRepository> { DefaultHelpRepository(context = get(), ioDispatcher = get<AppDispatchers>().io) }
-    viewModel { HelpViewModel(helpRepository = get()) }
+    single { ObserveFaqUseCase(repository = get()) }
+    viewModel { HelpViewModel(observeFaqUseCase = get()) }
 
     single<AppDispatchers> { AppDispatchersImpl() }
     single<DeviceInfoProvider> { DeviceInfoProviderImpl(get(), get()) }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/domain/usecases/ObserveFaqUseCase.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/domain/usecases/ObserveFaqUseCase.kt
@@ -1,0 +1,12 @@
+package com.d4rk.android.libs.apptoolkit.app.help.domain.usecases
+
+import com.d4rk.android.libs.apptoolkit.app.help.domain.data.model.UiHelpQuestion
+import com.d4rk.android.libs.apptoolkit.app.help.domain.repository.HelpRepository
+import com.d4rk.android.libs.apptoolkit.core.domain.usecases.RepositoryWithoutParam
+import kotlinx.coroutines.flow.Flow
+
+class ObserveFaqUseCase(
+    private val repository: HelpRepository
+) : RepositoryWithoutParam<Flow<List<UiHelpQuestion>>> {
+    override suspend operator fun invoke(): Flow<List<UiHelpQuestion>> = repository.observeFaq()
+}

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpScreen.kt
@@ -52,10 +52,6 @@ fun HelpScreen(activity: ComponentActivity, config: HelpScreenConfig, scope: Cor
     val isFabExtended: MutableState<Boolean> = remember { mutableStateOf(value = true) }
     val screenState: UiStateScreen<UiHelpScreen> by viewModel.uiState.collectAsStateWithLifecycle()
 
-    LaunchedEffect(Unit) {
-        viewModel.onEvent(HelpEvent.LoadFaq)
-    }
-
     LaunchedEffect(key1 = scrollBehavior.state.contentOffset) {
         isFabExtended.value = scrollBehavior.state.contentOffset >= 0f
     }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.viewModelScope
 import com.d4rk.android.libs.apptoolkit.app.help.domain.actions.HelpAction
 import com.d4rk.android.libs.apptoolkit.app.help.domain.actions.HelpEvent
 import com.d4rk.android.libs.apptoolkit.app.help.domain.model.ui.UiHelpScreen
-import com.d4rk.android.libs.apptoolkit.app.help.domain.repository.HelpRepository
+import com.d4rk.android.libs.apptoolkit.app.help.domain.usecases.ObserveFaqUseCase
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiSnackbar
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
@@ -18,10 +18,14 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.launch
 
 class HelpViewModel(
-    private val helpRepository: HelpRepository,
+    private val observeFaqUseCase: ObserveFaqUseCase,
 ) : ScreenViewModel<UiHelpScreen, HelpEvent, HelpAction>(
     initialState = UiStateScreen(screenState = ScreenState.IsLoading(), data = UiHelpScreen())
 ) {
+
+    init {
+        onEvent(HelpEvent.LoadFaq)
+    }
 
     override fun onEvent(event: HelpEvent) {
         when (event) {
@@ -32,7 +36,7 @@ class HelpViewModel(
 
     private fun loadFaq() {
         viewModelScope.launch {
-            helpRepository.observeFaq()
+            observeFaqUseCase()
                 .catch { error ->
                     screenState.setErrors(
                         listOf(


### PR DESCRIPTION
## Summary
- add ObserveFaqUseCase to expose FAQs via repository
- load FAQs from HelpViewModel using the use case and init block
- adjust HelpScreen and DI module to the new architecture

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1e45384ec832da40956a4b9dbed17