### PR TITLE
Refactor help module to use Kotlin Flows for FAQs

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/domain/data/DefaultHelpRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/domain/data/DefaultHelpRepository.kt
@@ -5,15 +5,17 @@ import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.help.domain.data.model.UiHelpQuestion
 import com.d4rk.android.libs.apptoolkit.app.help.domain.repository.HelpRepository
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.withContext
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
 
 class DefaultHelpRepository(
     private val context: Context,
     private val ioDispatcher: CoroutineDispatcher
 ) : HelpRepository {
 
-    override suspend fun fetchFaq(): List<UiHelpQuestion> = withContext(ioDispatcher) {
-        listOf(
+    override fun fetchFaq(): Flow<List<UiHelpQuestion>> = flow {
+        val faq = listOf(
             R.string.question_1 to R.string.summary_preference_faq_1,
             R.string.question_2 to R.string.summary_preference_faq_2,
             R.string.question_3 to R.string.summary_preference_faq_3,
@@ -29,5 +31,6 @@ class DefaultHelpRepository(
                 answer = context.getString(answerRes)
             )
         }.filter { it.question.isNotBlank() && it.answer.isNotBlank() }
-    }
+        emit(faq)
+    }.flowOn(ioDispatcher)
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/domain/repository/HelpRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/domain/repository/HelpRepository.kt
@@ -1,7 +1,14 @@
 package com.d4rk.android.libs.apptoolkit.app.help.domain.repository
 
 import com.d4rk.android.libs.apptoolkit.app.help.domain.data.model.UiHelpQuestion
+import kotlinx.coroutines.flow.Flow
 
+/**
+ * Repository for retrieving help and FAQ information.
+ */
 interface HelpRepository {
-    suspend fun fetchFaq(): List<UiHelpQuestion>
+    /**
+     * Fetches the frequently asked questions as a cold [Flow].
+     */
+    fun fetchFaq(): Flow<List<UiHelpQuestion>>
 }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpViewModelTest.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpViewModelTest.kt
@@ -6,6 +6,8 @@ import com.d4rk.android.libs.apptoolkit.app.help.domain.repository.HelpRepositor
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.resetMain
@@ -25,8 +27,7 @@ class HelpViewModelTest {
         Dispatchers.setMain(dispatcher)
         try {
             val repository = object : HelpRepository {
-                override suspend fun fetchFaq(): List<UiHelpQuestion> =
-                    listOf(UiHelpQuestion("Q", "A"))
+                override fun fetchFaq() = flowOf(listOf(UiHelpQuestion("Q", "A")))
             }
             val viewModel = HelpViewModel(repository)
             viewModel.onEvent(HelpEvent.LoadFaq)
@@ -44,9 +45,7 @@ class HelpViewModelTest {
         Dispatchers.setMain(dispatcher)
         try {
             val repository = object : HelpRepository {
-                override suspend fun fetchFaq(): List<UiHelpQuestion> {
-                    throw IOException("error")
-                }
+                override fun fetchFaq() = flow<List<UiHelpQuestion>> { throw IOException("error") }
             }
             val viewModel = HelpViewModel(repository)
             viewModel.onEvent(HelpEvent.LoadFaq)


### PR DESCRIPTION
## Summary
- expose FAQs as a Flow from `HelpRepository`
- collect FAQs in `HelpViewModel` with `onStart` and `catch`
- adjust tests for flow-based repository

## Testing
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b205dc1220832d9979cd5b64fa4411