### PR TITLE
test: add coverage for onboarding and favorites repositories

### DIFF
--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/core/data/favorites/FavoritesRepositoryImplTest.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/core/data/favorites/FavoritesRepositoryImplTest.kt
@@ -1,0 +1,71 @@
+package com.d4rk.android.apps.apptoolkit.core.data.favorites
+
+import android.content.Context
+import android.content.Intent
+import app.cash.turbine.test
+import com.d4rk.android.apps.apptoolkit.app.core.utils.dispatchers.UnconfinedDispatcherExtension
+import com.d4rk.android.apps.apptoolkit.core.broadcast.FavoritesChangedReceiver
+import com.d4rk.android.apps.apptoolkit.core.data.datastore.DataStore
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.slot
+import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FavoritesRepositoryImplTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val dispatcherExtension = UnconfinedDispatcherExtension()
+    }
+
+    @Test
+    fun `observeFavorites forwards datastore flow`() = runTest(dispatcherExtension.testDispatcher) {
+        val context = mockk<Context>()
+        val dataStore = mockk<DataStore>()
+        val favoritesFlow = MutableSharedFlow<Set<String>>()
+        every { dataStore.favoriteApps } returns favoritesFlow
+        val repository = FavoritesRepositoryImpl(
+            context = context,
+            dataStore = dataStore,
+            ioDispatcher = dispatcherExtension.testDispatcher,
+        )
+
+        repository.observeFavorites().test {
+            favoritesFlow.emit(setOf("pkg1"))
+            assertThat(awaitItem()).containsExactly("pkg1")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `toggleFavorite toggles and broadcasts`() = runTest(dispatcherExtension.testDispatcher) {
+        val context = mockk<Context>()
+        val dataStore = mockk<DataStore>()
+        coEvery { dataStore.toggleFavoriteApp(any()) } returns Unit
+        val intentSlot = slot<Intent>()
+        every { context.sendBroadcast(capture(intentSlot)) } returns Unit
+        val repository = FavoritesRepositoryImpl(
+            context = context,
+            dataStore = dataStore,
+            ioDispatcher = dispatcherExtension.testDispatcher,
+        )
+
+        repository.toggleFavorite("pkg.name")
+
+        coVerify { dataStore.toggleFavoriteApp("pkg.name") }
+        verify { context.sendBroadcast(any()) }
+        assertThat(intentSlot.captured.action).isEqualTo(FavoritesChangedReceiver.ACTION_FAVORITES_CHANGED)
+        assertThat(intentSlot.captured.getStringExtra(FavoritesChangedReceiver.EXTRA_PACKAGE_NAME)).isEqualTo("pkg.name")
+    }
+}
+

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/onboarding/data/repository/TestDefaultOnboardingRepository.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/onboarding/data/repository/TestDefaultOnboardingRepository.kt
@@ -1,0 +1,62 @@
+package com.d4rk.android.libs.apptoolkit.app.onboarding.data.repository
+
+import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.UnconfinedDispatcherExtension
+import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
+import com.google.common.truth.Truth.assertThat
+import io.mockk.coEvery
+import io.mockk.coVerify
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.flow.toList
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TestDefaultOnboardingRepository {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val dispatcherExtension = UnconfinedDispatcherExtension()
+    }
+
+    @Test
+    fun `observeOnboardingCompletion emits inverted startup`() = runTest(dispatcherExtension.testDispatcher) {
+        val startupFlow = MutableSharedFlow<Boolean>()
+        val dataStore = mockk<CommonDataStore>()
+        every { dataStore.startup } returns startupFlow
+        val repository = DefaultOnboardingRepository(
+            dataStore = dataStore,
+            ioDispatcher = dispatcherExtension.testDispatcher,
+        )
+        val values = mutableListOf<Boolean>()
+        backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            repository.observeOnboardingCompletion().toList(values)
+        }
+
+        startupFlow.emit(true)
+        startupFlow.emit(false)
+
+        assertThat(values).containsExactly(false, true).inOrder()
+    }
+
+    @Test
+    fun `setOnboardingCompleted saves value`() = runTest(dispatcherExtension.testDispatcher) {
+        val dataStore = mockk<CommonDataStore>()
+        coEvery { dataStore.saveStartup(isFirstTime = false) } returns Unit
+        val repository = DefaultOnboardingRepository(
+            dataStore = dataStore,
+            ioDispatcher = dispatcherExtension.testDispatcher,
+        )
+
+        repository.setOnboardingCompleted()
+
+        coVerify { dataStore.saveStartup(isFirstTime = false) }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add flow-based tests for DefaultOnboardingRepository
- cover FavoritesRepositoryImpl observe and toggle behavior

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b232e06b94832dbfc85b18b582800c