### PR TITLE
Add comprehensive flow tests

### DIFF
--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModel.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModel.kt
@@ -2,7 +2,12 @@ package com.d4rk.android.apps.apptoolkit.app.apps.list
 
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
 import com.d4rk.android.apps.apptoolkit.app.core.utils.dispatchers.StandardDispatcherExtension
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.runTest
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 
@@ -27,5 +32,45 @@ class TestAppsListViewModel : TestAppsListViewModelBase() {
         setup(fetchApps = apps)
         toggleAndAssert(packageName = "pkg", expected = true)
         toggleAndAssert(packageName = "pkg", expected = false)
+    }
+
+    @Test
+    fun `fetch apps - empty list results in NoData`() = runTest(dispatcherExtension.testDispatcher) {
+        setup(fetchApps = emptyList())
+        viewModel.uiState.testNoData()
+    }
+
+    @Test
+    fun `fetch apps - repository error emits Error state`() = runTest(dispatcherExtension.testDispatcher) {
+        setup(fetchApps = emptyList(), fetchThrows = RuntimeException("boom"))
+        viewModel.uiState.testError()
+    }
+
+    @Test
+    fun `favorites flow emits initial favorites and updates`() = runTest(dispatcherExtension.testDispatcher) {
+        val flow = MutableSharedFlow<Set<String>>(replay = 1)
+        flow.tryEmit(setOf("pkg"))
+        setup(fetchApps = listOf(AppInfo("App", "pkg", "url")), favoritesFlow = flow)
+
+        viewModel.favorites.test {
+            assertThat(awaitItem()).containsExactly("pkg")
+            flow.emit(setOf("pkg2"))
+            assertThat(awaitItem()).containsExactly("pkg2")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `toggle favorite error updates uiState to Error`() = runTest(dispatcherExtension.testDispatcher) {
+        val apps = listOf(AppInfo("App", "pkg", "url"))
+        setup(fetchApps = apps, toggleError = RuntimeException("fail"))
+
+        viewModel.uiState.test {
+            awaitItem() // initial emission
+            viewModel.toggleFavorite("pkg")
+            val errorState = awaitItem()
+            assertTrue(errorState.screenState is ScreenState.Error)
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 }

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModelBase.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModelBase.kt
@@ -60,6 +60,40 @@ open class TestAppsListViewModelBase {
         println("\uD83C\uDFC1 [TEST END] testSuccess")
     }
 
+    protected suspend fun Flow<UiStateScreen<UiHomeScreen>>.testNoData() {
+        println("\uD83D\uDE80 [TEST START] testNoData")
+        this@testNoData.test {
+            val first = awaitItem()
+            if (first.screenState is ScreenState.IsLoading) {
+                val second = awaitItem()
+                assertTrue(second.screenState is ScreenState.NoData) { "Second emission should be NoData but was ${second.screenState}" }
+                assertThat(second.data?.apps).isEmpty()
+            } else {
+                assertTrue(first.screenState is ScreenState.NoData) { "Expected NoData state" }
+                assertThat(first.data?.apps).isEmpty()
+            }
+            cancelAndIgnoreRemainingEvents()
+        }
+        println("\uD83C\uDFC1 [TEST END] testNoData")
+    }
+
+    protected suspend fun Flow<UiStateScreen<UiHomeScreen>>.testError() {
+        println("\uD83D\uDE80 [TEST START] testError")
+        this@testError.test {
+            val first = awaitItem()
+            if (first.screenState is ScreenState.IsLoading) {
+                val second = awaitItem()
+                assertTrue(second.screenState is ScreenState.Error) { "Second emission should be Error but was ${second.screenState}" }
+                assertThat(second.snackbar).isNotNull()
+            } else {
+                assertTrue(first.screenState is ScreenState.Error) { "Expected Error state" }
+                assertThat(first.snackbar).isNotNull()
+            }
+            cancelAndIgnoreRemainingEvents()
+        }
+        println("\uD83C\uDFC1 [TEST END] testError")
+    }
+
     protected suspend fun toggleAndAssert(packageName: String, expected: Boolean) {
         println("\uD83D\uDE80 [TEST START] toggleAndAssert for $packageName expecting $expected")
         viewModel.favorites.test {

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/usecases/FetchDeveloperAppsUseCaseTest.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/usecases/FetchDeveloperAppsUseCaseTest.kt
@@ -1,0 +1,41 @@
+package com.d4rk.android.apps.apptoolkit.app.apps.list.domain.usecases
+
+import app.cash.turbine.test
+import com.d4rk.android.apps.apptoolkit.app.apps.list.FakeDeveloperAppsRepository
+import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import com.google.common.truth.Truth.assertThat
+import kotlin.test.assertTrue
+
+class FetchDeveloperAppsUseCaseTest {
+
+    @Test
+    fun `invoke emits Loading then Success`() = runTest {
+        val apps = listOf(AppInfo("App", "pkg", "url"))
+        val useCase = FetchDeveloperAppsUseCase(FakeDeveloperAppsRepository(apps))
+
+        useCase().test {
+            assertTrue(awaitItem() is DataState.Loading)
+            val success = awaitItem()
+            assertTrue(success is DataState.Success)
+            assertThat((success as DataState.Success).data).isEqualTo(apps)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `invoke emits Loading then Error when repository throws`() = runTest {
+        val useCase = FetchDeveloperAppsUseCase(
+            FakeDeveloperAppsRepository(emptyList(), RuntimeException("fail"))
+        )
+
+        useCase().test {
+            assertTrue(awaitItem() is DataState.Loading)
+            val error = awaitItem()
+            assertTrue(error is DataState.Error)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- expand AppsListViewModel tests for empty lists, repository errors, favorites updates, and toggle failure
- add helper functions for NoData and Error state assertions
- cover FetchDeveloperAppsUseCase with loading-success and loading-error flow tests

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b237af1654832dac4159e21166d725