### PR TITLE
test: expand favorites flow coverage

### DIFF
--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModel.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModel.kt
@@ -6,6 +6,7 @@ import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 
@@ -36,5 +37,55 @@ class TestFavoriteAppsViewModel : TestFavoriteAppsViewModelBase() {
             cancelAndIgnoreRemainingEvents()
         }
         println("\uD83C\uDFC1 [TEST DONE] toggle favorite throws after load")
+    }
+
+    @Test
+    fun `load favorites emits saved apps`() = runTest(dispatcherExtension.testDispatcher) {
+        val apps = listOf(
+            AppInfo("App1", "pkg1", "url1"),
+            AppInfo("App2", "pkg2", "url2")
+        )
+        setup(
+            fetchApps = apps,
+            initialFavorites = setOf("pkg1")
+        )
+
+        viewModel.uiState.test {
+            val initial = awaitItem()
+            assertThat(initial.screenState).isInstanceOf(ScreenState.IsLoading::class.java)
+
+            val success = awaitItem()
+            assertThat(success.screenState).isInstanceOf(ScreenState.Success::class.java)
+            assertThat(success.data?.apps?.map { it.packageName }).containsExactly("pkg1")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `toggle favorite updates favorites flow`() = runTest(dispatcherExtension.testDispatcher) {
+        val apps = listOf(AppInfo("App", "pkg", "url"))
+        setup(fetchApps = apps)
+
+        viewModel.favorites.test {
+            assertThat(awaitItem()).isEmpty()
+            viewModel.toggleFavorite("pkg")
+            assertThat(awaitItem()).containsExactly("pkg")
+            viewModel.toggleFavorite("pkg")
+            assertThat(awaitItem()).isEmpty()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `load favorites with no saved apps shows no data`() = runTest(dispatcherExtension.testDispatcher) {
+        val apps = listOf(AppInfo("App", "pkg", "url"))
+        setup(fetchApps = apps, initialFavorites = emptySet())
+
+        viewModel.uiState.test {
+            awaitItem() // Initial loading
+            val state = awaitItem()
+            assertThat(state.screenState).isInstanceOf(ScreenState.NoData::class.java)
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 }

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/domain/usecases/FavoritesUseCasesTest.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/domain/usecases/FavoritesUseCasesTest.kt
@@ -1,0 +1,47 @@
+package com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases
+
+import com.d4rk.android.apps.apptoolkit.app.apps.favorites.FakeFavoritesRepository
+import com.d4rk.android.apps.apptoolkit.app.core.utils.dispatchers.StandardDispatcherExtension
+import app.cash.turbine.test
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases.ObserveFavoritesUseCase
+import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases.ToggleFavoriteUseCase
+
+class FavoritesUseCasesTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val dispatcherExtension = StandardDispatcherExtension()
+    }
+
+    @Test
+    fun `observe favorites emits initial set`() = runTest(dispatcherExtension.testDispatcher) {
+        val repository = FakeFavoritesRepository(initialFavorites = setOf("pkg1", "pkg2"))
+        val useCase = ObserveFavoritesUseCase(repository)
+
+        useCase().test {
+            assertThat(awaitItem()).containsExactly("pkg1", "pkg2")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `toggle favorite updates repository`() = runTest(dispatcherExtension.testDispatcher) {
+        val repository = FakeFavoritesRepository()
+        val toggleUseCase = ToggleFavoriteUseCase(repository)
+        val observeUseCase = ObserveFavoritesUseCase(repository)
+
+        observeUseCase().test {
+            assertThat(awaitItem()).isEmpty()
+            toggleUseCase("pkg")
+            assertThat(awaitItem()).containsExactly("pkg")
+            toggleUseCase("pkg")
+            assertThat(awaitItem()).isEmpty()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add comprehensive FavoriteAppsViewModel tests for loading, toggling, and no-data cases
- cover ObserveFavoritesUseCase and ToggleFavoriteUseCase

## Testing
- `./gradlew test --no-daemon --console=plain` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b237bf7108832dae776423c9ae4204