### PR TITLE
Refactor about repository to Flow and expand unit tests

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/data/DefaultAboutRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/data/DefaultAboutRepository.kt
@@ -8,6 +8,9 @@ import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoPr
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.ClipboardHelper
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.withContext
 
 /**
@@ -22,14 +25,16 @@ class DefaultAboutRepository(
     private val mainDispatcher: CoroutineDispatcher = Dispatchers.Main,
 ) : AboutRepository {
 
-    override suspend fun getAboutInfoStream(): UiAboutScreen =
-        withContext(ioDispatcher) {
-            UiAboutScreen(
-                appVersion = configProvider.appVersion,
-                appVersionCode = configProvider.appVersionCode,
-                deviceInfo = deviceProvider.deviceInfo,
+    override fun getAboutInfoStream(): Flow<UiAboutScreen> =
+        flow {
+            emit(
+                UiAboutScreen(
+                    appVersion = configProvider.appVersion,
+                    appVersionCode = configProvider.appVersionCode,
+                    deviceInfo = deviceProvider.deviceInfo,
+                ),
             )
-        }
+        }.flowOn(ioDispatcher)
 
     override suspend fun copyDeviceInfo(label: String, deviceInfo: String) {
         withContext(mainDispatcher) {

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/domain/repository/AboutRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/domain/repository/AboutRepository.kt
@@ -1,6 +1,7 @@
 package com.d4rk.android.libs.apptoolkit.app.about.domain.repository
 
 import com.d4rk.android.libs.apptoolkit.app.about.domain.model.ui.UiAboutScreen
+import kotlinx.coroutines.flow.Flow
 
 /**
  * Repository responsible for providing data for the about screen.
@@ -11,7 +12,7 @@ interface AboutRepository {
      *
      * @return A [UiAboutScreen] data object.
      */
-    suspend fun getAboutInfoStream(): UiAboutScreen
+    fun getAboutInfoStream(): Flow<UiAboutScreen>
 
     /**
      * Copy the provided [deviceInfo] string to the clipboard with the given [label].

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/ui/AboutViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/ui/AboutViewModel.kt
@@ -16,7 +16,6 @@ import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.ScreenMessageTyp
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 
 open class AboutViewModel(
@@ -37,7 +36,7 @@ open class AboutViewModel(
 
     private fun loadAboutInfo() {
         viewModelScope.launch {
-            flow { emit(repository.getAboutInfoStream()) }
+            repository.getAboutInfoStream()
                 .catch { error ->
                     if (error is CancellationException) {
                         throw error

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/about/data/TestDefaultAboutRepository.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/about/data/TestDefaultAboutRepository.kt
@@ -1,0 +1,70 @@
+package com.d4rk.android.libs.apptoolkit.app.about.data
+
+import android.content.Context
+import com.d4rk.android.libs.apptoolkit.app.about.domain.model.ui.UiAboutScreen
+import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.AboutSettingsProvider
+import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoProvider
+import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.UnconfinedDispatcherExtension
+import com.d4rk.android.libs.apptoolkit.core.utils.helpers.ClipboardHelper
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.unmockkObject
+import io.mockk.verify
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+class TestDefaultAboutRepository {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val dispatcherExtension = UnconfinedDispatcherExtension()
+    }
+
+    private val deviceProvider = object : AboutSettingsProvider {
+        override val deviceInfo: String = "device-info"
+    }
+
+    private val buildInfoProvider = object : BuildInfoProvider {
+        override val appVersion: String = "1.0"
+        override val appVersionCode: Int = 1
+        override val packageName: String = "pkg"
+        override val isDebugBuild: Boolean = false
+    }
+
+    private fun repository(context: Context = mockk()): DefaultAboutRepository =
+        DefaultAboutRepository(
+            deviceProvider = deviceProvider,
+            configProvider = buildInfoProvider,
+            context = context,
+            ioDispatcher = dispatcherExtension.testDispatcher,
+            mainDispatcher = dispatcherExtension.testDispatcher,
+        )
+
+    @Test
+    fun `getAboutInfoStream emits expected info`() = runTest(dispatcherExtension.testDispatcher) {
+        val repo = repository()
+        val result: UiAboutScreen = repo.getAboutInfoStream().first()
+        assertThat(result.appVersion).isEqualTo(buildInfoProvider.appVersion)
+        assertThat(result.appVersionCode).isEqualTo(buildInfoProvider.appVersionCode)
+        assertThat(result.deviceInfo).isEqualTo(deviceProvider.deviceInfo)
+    }
+
+    @Test
+    fun `copyDeviceInfo delegates to ClipboardHelper`() = runTest(dispatcherExtension.testDispatcher) {
+        val ctx = mockk<Context>(relaxed = true)
+        val repo = repository(ctx)
+        mockkObject(ClipboardHelper)
+        try {
+            every { ClipboardHelper.copyTextToClipboard(ctx, any(), any(), any()) } returns Unit
+            repo.copyDeviceInfo("label", "info")
+            verify { ClipboardHelper.copyTextToClipboard(ctx, "label", "info", any()) }
+        } finally {
+            unmockkObject(ClipboardHelper)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- expose AboutRepository info stream as Flow
- simplify AboutViewModel flow handling
- add unit tests for DefaultAboutRepository and ViewModel updates

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b237d4a530832d855e8896cd78380b