### PR TITLE
Expand HelpViewModel flow test coverage

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpViewModel.kt
@@ -9,9 +9,10 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiSnackbar
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.dismissSnackbar
-import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.setErrors
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.updateData
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.updateState
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.showSnackbar
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.ScreenMessageType
 import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
 import kotlinx.coroutines.CancellationException
@@ -39,9 +40,12 @@ class HelpViewModel(
                 .onStart { screenState.updateState(ScreenState.IsLoading()) }
                 .catch { error ->
                     if (error is CancellationException) throw error
-                    screenState.setErrors(
-                        listOf(
-                            UiSnackbar(message = UiTextHelper.DynamicString(error.message ?: "Failed to load FAQs"))
+                    screenState.showSnackbar(
+                        UiSnackbar(
+                            message = UiTextHelper.DynamicString(error.message ?: "Failed to load FAQs"),
+                            type = ScreenMessageType.SNACKBAR,
+                            isError = true,
+                            timeStamp = System.currentTimeMillis(),
                         )
                     )
                     screenState.updateState(ScreenState.Error())

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpViewModelTest.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpViewModelTest.kt
@@ -4,56 +4,110 @@ import com.d4rk.android.libs.apptoolkit.app.help.domain.actions.HelpEvent
 import com.d4rk.android.libs.apptoolkit.app.help.domain.data.model.UiHelpQuestion
 import com.d4rk.android.libs.apptoolkit.app.help.domain.repository.HelpRepository
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
-import kotlinx.coroutines.Dispatchers
+import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.UnconfinedDispatcherExtension
+import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
-import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
-import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
-import kotlinx.coroutines.test.setMain
-import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
 import java.io.IOException
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class HelpViewModelTest {
 
-    @Test
-    fun `loadFaq sets success state when repository returns data`() = runTest {
-        val dispatcher = UnconfinedTestDispatcher(testScheduler)
-        Dispatchers.setMain(dispatcher)
-        try {
-            val repository = object : HelpRepository {
-                override fun fetchFaq() = flowOf(listOf(UiHelpQuestion("Q", "A")))
-            }
-            val viewModel = HelpViewModel(repository)
-            viewModel.onEvent(HelpEvent.LoadFaq)
-            advanceUntilIdle()
-            assertTrue(viewModel.uiState.value.screenState is ScreenState.Success)
-            assertEquals(1, viewModel.uiState.value.data?.questions?.size)
-        } finally {
-            Dispatchers.resetMain()
-        }
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val dispatcherExtension = UnconfinedDispatcherExtension()
     }
 
     @Test
-    fun `loadFaq sets error state when repository throws`() = runTest {
-        val dispatcher = UnconfinedTestDispatcher(testScheduler)
-        Dispatchers.setMain(dispatcher)
-        try {
-            val repository = object : HelpRepository {
-                override fun fetchFaq() = flow<List<UiHelpQuestion>> { throw IOException("error") }
-            }
-            val viewModel = HelpViewModel(repository)
-            viewModel.onEvent(HelpEvent.LoadFaq)
-            advanceUntilIdle()
-            assertTrue(viewModel.uiState.value.screenState is ScreenState.Error)
-        } finally {
-            Dispatchers.resetMain()
+    fun `loadFaq emits loading then success`() = runTest(dispatcherExtension.testDispatcher) {
+        val faqFlow = MutableSharedFlow<List<UiHelpQuestion>>()
+        val repo = object : HelpRepository {
+            override fun fetchFaq() = faqFlow
         }
+        val viewModel = HelpViewModel(repo)
+
+        viewModel.onEvent(HelpEvent.LoadFaq)
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.screenState)
+            .isInstanceOf(ScreenState.IsLoading::class.java)
+
+        faqFlow.emit(listOf(UiHelpQuestion("Q", "A")))
+        advanceUntilIdle()
+        val state = viewModel.uiState.value
+        assertThat(state.screenState).isInstanceOf(ScreenState.Success::class.java)
+        assertThat(state.data?.questions).containsExactly(UiHelpQuestion("Q", "A"))
+    }
+
+    @Test
+    fun `loadFaq sets NoData when repository returns empty`() = runTest(dispatcherExtension.testDispatcher) {
+        val repo = object : HelpRepository {
+            override fun fetchFaq() = flowOf(emptyList<UiHelpQuestion>())
+        }
+        val viewModel = HelpViewModel(repo)
+
+        viewModel.onEvent(HelpEvent.LoadFaq)
+        advanceUntilIdle()
+
+        assertThat(viewModel.uiState.value.screenState)
+            .isInstanceOf(ScreenState.NoData::class.java)
+    }
+
+    @Test
+    fun `loadFaq sets error state and shows snackbar`() = runTest(dispatcherExtension.testDispatcher) {
+        val repo = object : HelpRepository {
+            override fun fetchFaq() = flow<List<UiHelpQuestion>> { throw IOException("boom") }
+        }
+        val viewModel = HelpViewModel(repo)
+
+        viewModel.onEvent(HelpEvent.LoadFaq)
+        advanceUntilIdle()
+
+        val state = viewModel.uiState.value
+        assertThat(state.screenState).isInstanceOf(ScreenState.Error::class.java)
+        assertThat(state.snackbar).isNotNull()
+    }
+
+    @Test
+    fun `dismiss snackbar clears snackbar`() = runTest(dispatcherExtension.testDispatcher) {
+        val repo = object : HelpRepository {
+            override fun fetchFaq() = flow<List<UiHelpQuestion>> { throw IOException("boom") }
+        }
+        val viewModel = HelpViewModel(repo)
+
+        viewModel.onEvent(HelpEvent.LoadFaq)
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.snackbar).isNotNull()
+
+        viewModel.onEvent(HelpEvent.DismissSnackbar)
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.snackbar).isNull()
+    }
+
+    @Test
+    fun `additional emissions update questions`() = runTest(dispatcherExtension.testDispatcher) {
+        val faqFlow = MutableSharedFlow<List<UiHelpQuestion>>()
+        val repo = object : HelpRepository {
+            override fun fetchFaq() = faqFlow
+        }
+        val viewModel = HelpViewModel(repo)
+
+        viewModel.onEvent(HelpEvent.LoadFaq)
+        faqFlow.emit(listOf(UiHelpQuestion("Q1", "A1")))
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.data?.questions?.single()?.question)
+            .isEqualTo("Q1")
+
+        faqFlow.emit(listOf(UiHelpQuestion("Q2", "A2")))
+        advanceUntilIdle()
+        assertThat(viewModel.uiState.value.data?.questions?.single()?.question)
+            .isEqualTo("Q2")
     }
 }
 


### PR DESCRIPTION
## Summary
- replace error handling in HelpViewModel with snackbar display
- add comprehensive unit tests for HelpViewModel covering loading, success, empty, error and snackbar dismissal

## Testing
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2383cc7d4832da267de9c374ea9fb