### PR TITLE
test: add advanced cache flow tests

### DIFF
--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/advanced/data/TestDefaultCacheRepository.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/advanced/data/TestDefaultCacheRepository.kt
@@ -3,11 +3,13 @@ package com.d4rk.android.libs.apptoolkit.app.advanced.data
 import android.content.Context
 import com.d4rk.android.libs.apptoolkit.core.domain.model.Result
 import com.google.common.truth.Truth.assertThat
+import app.cash.turbine.test
 import io.mockk.every
 import io.mockk.mockk
 import kotlin.io.path.createTempDirectory
 import kotlin.test.assertFalse
 import kotlinx.coroutines.flow.single
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
@@ -15,7 +17,6 @@ class TestDefaultCacheRepository {
 
     @Test
     fun `clearCache deletes cache directories`() = runTest {
-        println("\uD83D\uDE80 [TEST] clearCache deletes cache directories")
         val dir1 = createTempDirectory().toFile()
         val dir2 = createTempDirectory().toFile()
         val dir3 = createTempDirectory().toFile()
@@ -32,12 +33,10 @@ class TestDefaultCacheRepository {
         assertFalse(dir1.exists())
         assertFalse(dir2.exists())
         assertFalse(dir3.exists())
-        println("\uD83C\uDFC1 [TEST DONE] clearCache deletes cache directories")
     }
 
     @Test
     fun `clearCache returns false when deletion fails`() = runTest {
-        println("\uD83D\uDE80 [TEST] clearCache returns false when deletion fails")
         val dir1 = createTempDirectory().toFile()
         val failing = mockk<java.io.File>()
         every { failing.deleteRecursively() } returns false
@@ -55,24 +54,20 @@ class TestDefaultCacheRepository {
         assertThat(result).isInstanceOf(Result.Error::class.java)
         assertFalse(dir1.exists())
         assertFalse(dir3.exists())
-        println("\uD83C\uDFC1 [TEST DONE] clearCache returns false when deletion fails")
     }
 
     @Test
     fun `clearCache emits error when directory inaccessible`() = runTest {
-        println("\uD83D\uDE80 [TEST] clearCache emits error when directory inaccessible")
         val context = mockk<Context>()
         every { context.cacheDir } throws SecurityException("denied")
 
         val repository = DefaultCacheRepository(context)
         val result = repository.clearCache().single()
         assertThat(result).isInstanceOf(Result.Error::class.java)
-        println("\uD83C\uDFC1 [TEST DONE] clearCache emits error when directory inaccessible")
     }
 
     @Test
     fun `clearCache handles missing directories`() = runTest {
-        println("\uD83D\uDE80 [TEST] clearCache handles missing directories")
         val dir1 = createTempDirectory().toFile().also { it.deleteRecursively() }
         val dir2 = createTempDirectory().toFile().also { it.deleteRecursively() }
         val dir3 = createTempDirectory().toFile().also { it.deleteRecursively() }
@@ -86,12 +81,10 @@ class TestDefaultCacheRepository {
         val result = repository.clearCache().single()
 
         assertThat(result).isInstanceOf(Result.Success::class.java)
-        println("\uD83C\uDFC1 [TEST DONE] clearCache handles missing directories")
     }
 
     @Test
     fun `clearCache emits error when io exception`() = runTest {
-        println("\uD83D\uDE80 [TEST] clearCache emits error when io exception")
         val dir1 = createTempDirectory().toFile()
         val failing = mockk<java.io.File>()
         every { failing.deleteRecursively() } throws java.io.IOException("io")
@@ -106,6 +99,29 @@ class TestDefaultCacheRepository {
         val repository = DefaultCacheRepository(context)
         val result = repository.clearCache().single()
         assertThat(result).isInstanceOf(Result.Error::class.java)
-        println("\uD83C\uDFC1 [TEST DONE] clearCache emits error when io exception")
+    }
+
+    @Test
+    fun `clearCache emits success and completes`() = runTest {
+        val dir1 = createTempDirectory().toFile()
+        val dir2 = createTempDirectory().toFile()
+        val dir3 = createTempDirectory().toFile()
+
+        val context = mockk<Context>()
+        every { context.cacheDir } returns dir1
+        every { context.codeCacheDir } returns dir2
+        every { context.filesDir } returns dir3
+
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val repository = DefaultCacheRepository(context, dispatcher)
+
+        repository.clearCache().test {
+            assertThat(awaitItem()).isInstanceOf(Result.Success::class.java)
+            awaitComplete()
+        }
+
+        assertFalse(dir1.exists())
+        assertFalse(dir2.exists())
+        assertFalse(dir3.exists())
     }
 }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/advanced/ui/TestAdvancedSettingsViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/advanced/ui/TestAdvancedSettingsViewModel.kt
@@ -2,10 +2,12 @@ package com.d4rk.android.libs.apptoolkit.app.advanced.ui
 
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.advanced.data.CacheRepository
-import com.d4rk.android.libs.apptoolkit.core.domain.model.Result
 import com.d4rk.android.libs.apptoolkit.app.advanced.domain.actions.AdvancedSettingsEvent
+import com.d4rk.android.libs.apptoolkit.core.domain.model.Result
 import com.google.common.truth.Truth.assertThat
+import app.cash.turbine.test
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -19,7 +21,6 @@ class TestAdvancedSettingsViewModel {
 
     @Test
     fun `onClearCache emits success message`() = runTest {
-        println("\uD83D\uDE80 [TEST] onClearCache emits success message")
         val viewModel = AdvancedSettingsViewModel(repository = FakeCacheRepository(Result.Success(Unit)))
 
         viewModel.onEvent(AdvancedSettingsEvent.ClearCache)
@@ -29,18 +30,48 @@ class TestAdvancedSettingsViewModel {
         viewModel.onEvent(AdvancedSettingsEvent.MessageShown)
         advanceUntilIdle()
         assertThat(viewModel.uiState.value.data?.cacheClearMessage).isNull()
-        println("\uD83C\uDFC1 [TEST DONE] onClearCache emits success message")
     }
 
     @Test
     fun `onClearCache emits error message when failure`() = runTest {
-        println("\uD83D\uDE80 [TEST] onClearCache emits error message when failure")
         val viewModel = AdvancedSettingsViewModel(repository = FakeCacheRepository(Result.Error(Exception("fail"))))
 
         viewModel.onEvent(AdvancedSettingsEvent.ClearCache)
         advanceUntilIdle()
 
         assertThat(viewModel.uiState.value.data?.cacheClearMessage).isEqualTo(R.string.cache_cleared_error)
-        println("\uD83C\uDFC1 [TEST DONE] onClearCache emits error message when failure")
     }
+
+    @Test
+    fun `clearCache emits messages for success and error`() = runTest {
+        val repository = HotFakeCacheRepository()
+        val viewModel = AdvancedSettingsViewModel(repository)
+
+        viewModel.uiState.test {
+            // Initial state
+            assertThat(awaitItem().data?.cacheClearMessage).isNull()
+
+            // Success emission
+            viewModel.onEvent(AdvancedSettingsEvent.ClearCache)
+            repository.emit(Result.Success(Unit))
+            assertThat(awaitItem().data?.cacheClearMessage).isEqualTo(R.string.cache_cleared_success)
+
+            // Reset message
+            viewModel.onEvent(AdvancedSettingsEvent.MessageShown)
+            assertThat(awaitItem().data?.cacheClearMessage).isNull()
+
+            // Error emission
+            viewModel.onEvent(AdvancedSettingsEvent.ClearCache)
+            repository.emit(Result.Error(Exception("boom")))
+            assertThat(awaitItem().data?.cacheClearMessage).isEqualTo(R.string.cache_cleared_error)
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}
+
+private class HotFakeCacheRepository : CacheRepository {
+    private val flow = MutableSharedFlow<Result<Unit>>()
+    override fun clearCache(): Flow<Result<Unit>> = flow
+    suspend fun emit(result: Result<Unit>) = flow.emit(result)
 }


### PR DESCRIPTION
## Summary
- add flow-based test for advanced settings viewmodel
- cover DefaultCacheRepository flow completion

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b238326cf8832d9213f68bb98f5a78