### PR TITLE
test: expand settings and repository tests

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsViewModel.kt
@@ -37,6 +37,7 @@ class SettingsViewModel(
                 settingsProvider.provideSettingsConfig(context = context)
             }
             if (result.categories.isNotEmpty()) {
+                screenState.setErrors(emptyList())
                 screenState.successData {
                     copy(title = result.title, categories = result.categories)
                 }


### PR DESCRIPTION
## Summary
- clear SettingsViewModel errors when loading succeeds
- add SettingsViewModel tests for error clearing and provider invocation
- expand DeveloperAppsRepository tests for sorting and HTTP error handling

## Testing
- `./gradlew :apptoolkit:testDebugUnitTest :app:testDebugUnitTest`

------
https://chatgpt.com/codex/tasks/task_e_68b23a4c479c832d96ae7482d7724b77