### PR TITLE
Expand startup module unit tests

### DIFF
--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/startup/utils/interfaces/providers/AppStartupProviderTest.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/startup/utils/interfaces/providers/AppStartupProviderTest.kt
@@ -1,0 +1,32 @@
+package com.d4rk.android.apps.apptoolkit.app.startup.utils.interfaces.providers
+
+import android.Manifest
+import android.content.Context
+import android.os.Build
+import com.d4rk.android.libs.apptoolkit.app.onboarding.ui.OnboardingActivity
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.Test
+
+class AppStartupProviderTest {
+    private val provider = AppStartupProvider()
+
+    @Test
+    fun `required permissions reflect platform`() {
+        val expected = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            arrayOf(Manifest.permission.POST_NOTIFICATIONS)
+        } else {
+            emptyArray()
+        }
+        assertThat(provider.requiredPermissions).isEqualTo(expected)
+    }
+
+    @Test
+    fun `getNextIntent targets onboarding activity`() {
+        val context = mockk<Context>(relaxed = true)
+        every { context.packageName } returns "com.test"
+        val intent = provider.getNextIntent(context)
+        assertThat(intent.component?.className).isEqualTo(OnboardingActivity::class.java.name)
+    }
+}

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupViewModelTest.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupViewModelTest.kt
@@ -1,13 +1,12 @@
 package com.d4rk.android.libs.apptoolkit.app.startup.ui
 
-import com.d4rk.android.libs.apptoolkit.app.startup.domain.actions.StartupEvent
+import app.cash.turbine.test
 import com.d4rk.android.libs.apptoolkit.app.startup.domain.actions.StartupAction
+import com.d4rk.android.libs.apptoolkit.app.startup.domain.actions.StartupEvent
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
-import com.google.common.truth.Truth.assertThat
 import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.UnconfinedDispatcherExtension
+import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
@@ -22,6 +21,14 @@ class StartupViewModelTest {
     }
 
     @Test
+    fun `initial state is loading and consent not loaded`() = runTest(dispatcherExtension.testDispatcher) {
+        val viewModel = StartupViewModel()
+        val state = viewModel.uiState.value
+        assertThat(state.screenState).isInstanceOf(ScreenState.IsLoading::class.java)
+        assertThat(state.data?.consentFormLoaded).isFalse()
+    }
+
+    @Test
     fun `consent event updates state`() = runTest(dispatcherExtension.testDispatcher) {
         val viewModel = StartupViewModel()
         viewModel.onEvent(StartupEvent.ConsentFormLoaded)
@@ -33,11 +40,22 @@ class StartupViewModelTest {
     @Test
     fun `continue event emits navigation action`() = runTest(dispatcherExtension.testDispatcher) {
         val viewModel = StartupViewModel()
-        val actions = mutableListOf<StartupAction>()
-        val job = launch { viewModel.actionEvent.collect { actions.add(it) } }
-        viewModel.onEvent(StartupEvent.Continue)
-        advanceUntilIdle()
-        assertThat(actions).containsExactly(StartupAction.NavigateNext)
-        job.cancel()
+        viewModel.actionEvent.test {
+            viewModel.onEvent(StartupEvent.Continue)
+            assertThat(awaitItem()).isEqualTo(StartupAction.NavigateNext)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `multiple continue events emit multiple navigation actions`() = runTest(dispatcherExtension.testDispatcher) {
+        val viewModel = StartupViewModel()
+        viewModel.actionEvent.test {
+            viewModel.onEvent(StartupEvent.Continue)
+            viewModel.onEvent(StartupEvent.Continue)
+            assertThat(awaitItem()).isEqualTo(StartupAction.NavigateNext)
+            assertThat(awaitItem()).isEqualTo(StartupAction.NavigateNext)
+            cancelAndIgnoreRemainingEvents()
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Extend `StartupViewModelTest` with initial state coverage and Turbine-based flow assertions
- Add new tests verifying multiple navigation actions from consecutive events
- Introduce `AppStartupProviderTest` to validate permissions and next-intent behavior

## Testing
- `./gradlew apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b23e7bac54832d9f8dc746ebbe1950