### PR TITLE
Add unit tests for flow use case and error mapping

### DIFF
--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/usecases/FetchDeveloperAppsUseCaseTest.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/usecases/FetchDeveloperAppsUseCaseTest.kt
@@ -1,0 +1,49 @@
+package com.d4rk.android.apps.apptoolkit.app.apps.list.domain.usecases
+
+import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
+import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.repository.DeveloperAppsRepository
+import com.d4rk.android.apps.apptoolkit.core.domain.model.network.Errors
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.test.runTest
+import org.junit.Test
+import java.net.SocketTimeoutException
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+class FetchDeveloperAppsUseCaseTest {
+
+    @Test
+    fun `invoke emits loading then success`() = runTest {
+        val apps = listOf(AppInfo(name = "App", packageName = "pkg", iconUrl = "icon"))
+        val repository = object : DeveloperAppsRepository {
+            override fun fetchDeveloperApps(): Flow<List<AppInfo>> = flow { emit(apps) }
+        }
+        val useCase = FetchDeveloperAppsUseCase(repository)
+
+        val emissions = useCase().toList()
+
+        assertEquals(2, emissions.size)
+        assertTrue(emissions[0] is DataState.Loading)
+        val success = emissions[1] as DataState.Success
+        assertEquals(apps, success.data)
+    }
+
+    @Test
+    fun `invoke emits error when repository fails`() = runTest {
+        val repository = object : DeveloperAppsRepository {
+            override fun fetchDeveloperApps(): Flow<List<AppInfo>> = flow { throw SocketTimeoutException("timeout") }
+        }
+        val useCase = FetchDeveloperAppsUseCase(repository)
+
+        val emissions = useCase().toList()
+
+        assertEquals(2, emissions.size)
+        assertTrue(emissions[0] is DataState.Loading)
+        val errorState = emissions[1] as DataState.Error
+        assertEquals(Errors.Network.REQUEST_TIMEOUT, errorState.error)
+    }
+}
+

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/extensions/ErrorsKtTest.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/extensions/ErrorsKtTest.kt
@@ -1,0 +1,33 @@
+package com.d4rk.android.libs.apptoolkit.core.utils.extensions
+
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Errors
+import kotlinx.serialization.SerializationException
+import org.junit.Test
+import java.net.ConnectException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+import java.sql.SQLException
+import kotlin.test.assertEquals
+
+class ErrorsKtTest {
+
+    @Test
+    fun `maps network exceptions to errors`() {
+        assertEquals(Errors.Network.NO_INTERNET, UnknownHostException().toError())
+        assertEquals(Errors.Network.NO_INTERNET, ConnectException().toError())
+        assertEquals(Errors.Network.REQUEST_TIMEOUT, SocketTimeoutException().toError())
+    }
+
+    @Test
+    fun `maps serialization and database exceptions`() {
+        assertEquals(Errors.Network.SERIALIZATION, SerializationException("oops").toError())
+        assertEquals(Errors.Database.DATABASE_OPERATION_FAILED, SQLException().toError())
+    }
+
+    @Test
+    fun `returns default error when not mapped`() {
+        val default = Errors.UseCase.NO_DATA
+        assertEquals(default, IllegalStateException().toError(default))
+    }
+}
+


### PR DESCRIPTION
## Summary
- cover FetchDeveloperAppsUseCase to ensure loading, success, and error emissions
- verify Throwable.toError maps exceptions to network and database errors

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68b23e84a9f8832d8c25bcfccec057b5