### PR TITLE
test: add startup tests

### DIFF
--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/startup/utils/interfaces/providers/AppStartupProviderTest.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/startup/utils/interfaces/providers/AppStartupProviderTest.kt
@@ -1,0 +1,63 @@
+package com.d4rk.android.apps.apptoolkit.app.startup.utils.interfaces.providers
+
+import android.Manifest
+import android.content.Context
+import android.os.Build
+import com.d4rk.android.libs.apptoolkit.app.onboarding.ui.OnboardingActivity
+import com.google.common.truth.Truth.assertThat
+import io.mockk.mockk
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import java.lang.reflect.Field
+
+class AppStartupProviderTest {
+
+    private var originalSdk: Int = Build.VERSION.SDK_INT
+
+    @BeforeEach
+    fun setup() {
+        originalSdk = Build.VERSION.SDK_INT
+    }
+
+    @AfterEach
+    fun tearDown() {
+        setSdk(originalSdk)
+    }
+
+    @Test
+    fun `required permissions contains post notifications on api 33 plus`() {
+        setSdk(Build.VERSION_CODES.TIRAMISU)
+        val provider = AppStartupProvider()
+        assertThat(provider.requiredPermissions.asList())
+            .containsExactly(Manifest.permission.POST_NOTIFICATIONS)
+    }
+
+    @Test
+    fun `required permissions empty below api 33`() {
+        setSdk(Build.VERSION_CODES.S_V2)
+        val provider = AppStartupProvider()
+        assertThat(provider.requiredPermissions.toList()).isEmpty()
+    }
+
+    @Test
+    fun `get next intent returns onboarding activity`() {
+        val context = mockk<Context>(relaxed = true)
+        val provider = AppStartupProvider()
+        val intent = provider.getNextIntent(context)
+        assertThat(intent.component?.className).isEqualTo(OnboardingActivity::class.java.name)
+    }
+
+    @Test
+    fun `consent request parameters not null`() {
+        val provider = AppStartupProvider()
+        assertThat(provider.consentRequestParameters).isNotNull()
+    }
+
+    private fun setSdk(value: Int) {
+        val field: Field = Build.VERSION::class.java.getDeclaredField("SDK_INT")
+        field.isAccessible = true
+        field.setInt(null, value)
+    }
+}
+

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupViewModelTest.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupViewModelTest.kt
@@ -1,13 +1,12 @@
 package com.d4rk.android.libs.apptoolkit.app.startup.ui
 
-import com.d4rk.android.libs.apptoolkit.app.startup.domain.actions.StartupEvent
+import app.cash.turbine.test
 import com.d4rk.android.libs.apptoolkit.app.startup.domain.actions.StartupAction
+import com.d4rk.android.libs.apptoolkit.app.startup.domain.actions.StartupEvent
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
-import com.google.common.truth.Truth.assertThat
 import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.UnconfinedDispatcherExtension
+import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.launch
-import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
@@ -22,6 +21,15 @@ class StartupViewModelTest {
     }
 
     @Test
+    fun `initial state is loading and consent form not loaded`() =
+        runTest(dispatcherExtension.testDispatcher) {
+            val viewModel = StartupViewModel()
+            val state = viewModel.uiState.value
+            assertThat(state.screenState).isInstanceOf(ScreenState.IsLoading::class.java)
+            assertThat(state.data?.consentFormLoaded).isFalse()
+        }
+
+    @Test
     fun `consent event updates state`() = runTest(dispatcherExtension.testDispatcher) {
         val viewModel = StartupViewModel()
         viewModel.onEvent(StartupEvent.ConsentFormLoaded)
@@ -31,13 +39,35 @@ class StartupViewModelTest {
     }
 
     @Test
+    fun `consent event does not emit actions`() = runTest(dispatcherExtension.testDispatcher) {
+        val viewModel = StartupViewModel()
+        viewModel.actionEvent.test {
+            viewModel.onEvent(StartupEvent.ConsentFormLoaded)
+            expectNoEvents()
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
     fun `continue event emits navigation action`() = runTest(dispatcherExtension.testDispatcher) {
         val viewModel = StartupViewModel()
-        val actions = mutableListOf<StartupAction>()
-        val job = launch { viewModel.actionEvent.collect { actions.add(it) } }
-        viewModel.onEvent(StartupEvent.Continue)
-        advanceUntilIdle()
-        assertThat(actions).containsExactly(StartupAction.NavigateNext)
-        job.cancel()
+        viewModel.actionEvent.test {
+            viewModel.onEvent(StartupEvent.Continue)
+            assertThat(awaitItem()).isEqualTo(StartupAction.NavigateNext)
+            cancelAndIgnoreRemainingEvents()
+        }
     }
+
+    @Test
+    fun `multiple continue events emit navigation action each time`() =
+        runTest(dispatcherExtension.testDispatcher) {
+            val viewModel = StartupViewModel()
+            viewModel.actionEvent.test {
+                repeat(3) {
+                    viewModel.onEvent(StartupEvent.Continue)
+                    assertThat(awaitItem()).isEqualTo(StartupAction.NavigateNext)
+                }
+                cancelAndIgnoreRemainingEvents()
+            }
+        }
 }


### PR DESCRIPTION
## Summary
- add comprehensive StartupViewModel tests using Turbine
- cover AppStartupProvider behavior across API levels

## Testing
- `./gradlew test` *(fails: Failed to install the following Android SDK packages as some licences have not been accepted)*

------
https://chatgpt.com/codex/tasks/task_e_68b244d8e420832d860b8e2a3cb39a9b