### PR TITLE
Use coroutines for processing past billing purchases

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/AppToolkit.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/AppToolkit.kt
@@ -14,6 +14,7 @@ import com.d4rk.android.libs.apptoolkit.data.core.BaseCoreManager
 import com.d4rk.android.libs.apptoolkit.data.core.ads.AdsCoreManager
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.supervisorScope
 import org.koin.android.ext.android.getKoin
 
@@ -41,7 +42,9 @@ class AppToolkit : BaseCoreManager(), DefaultLifecycleObserver {
     }
 
     override fun onResume(owner: LifecycleOwner) {
-        billingRepository.processPastPurchases()
+        owner.lifecycleScope.launch {
+            billingRepository.processPastPurchases()
+        }
     }
 
     override fun onActivityCreated(activity : Activity , savedInstanceState : Bundle?) {}


### PR DESCRIPTION
## Summary
- make BillingRepository.processPastPurchases a suspend function using IO dispatcher and suspendCancellableCoroutine
- launch past purchase processing from lifecycle scope in AppToolkit and after billing setup

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b24682b038832da510ddea90dd0b3c