### PR TITLE
feat: add route to navigation drawer items

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainViewModel.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.viewModelScope
 import com.d4rk.android.apps.apptoolkit.app.main.domain.action.MainAction
 import com.d4rk.android.apps.apptoolkit.app.main.domain.action.MainEvent
 import com.d4rk.android.apps.apptoolkit.app.main.domain.model.ui.UiMainScreen
-import com.d4rk.android.apps.apptoolkit.app.main.domain.repository.MainRepository
+import com.d4rk.android.libs.apptoolkit.app.main.domain.repository.MainRepository
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.successData
 import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/components/navigation/AppNavigationHost.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/components/navigation/AppNavigationHost.kt
@@ -15,6 +15,7 @@ import com.d4rk.android.apps.apptoolkit.app.main.utils.constants.NavigationRoute
 import com.d4rk.android.apps.apptoolkit.core.data.datastore.DataStore
 import com.d4rk.android.libs.apptoolkit.app.help.ui.HelpActivity
 import com.d4rk.android.libs.apptoolkit.app.main.ui.components.navigation.NavigationHost
+import com.d4rk.android.libs.apptoolkit.app.main.utils.constants.NavigationDrawerRoutes
 import com.d4rk.android.libs.apptoolkit.app.settings.settings.ui.SettingsActivity
 import com.d4rk.android.libs.apptoolkit.core.domain.model.navigation.NavigationDrawerItem
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.IntentsHelper
@@ -48,11 +49,11 @@ fun handleNavigationItemClick(
     coroutineScope: CoroutineScope? = null,
     onChangelogRequested: () -> Unit = {},
 ) {
-    when (item.title) {
-        com.d4rk.android.libs.apptoolkit.R.string.settings -> IntentsHelper.openActivity(context = context , activityClass = SettingsActivity::class.java)
-        com.d4rk.android.libs.apptoolkit.R.string.help_and_feedback -> IntentsHelper.openActivity(context = context , activityClass = HelpActivity::class.java)
-        com.d4rk.android.libs.apptoolkit.R.string.updates -> onChangelogRequested()
-        com.d4rk.android.libs.apptoolkit.R.string.share -> IntentsHelper.shareApp(context = context , shareMessageFormat = com.d4rk.android.libs.apptoolkit.R.string.summary_share_message)
+    when (item.route) {
+        NavigationDrawerRoutes.ROUTE_SETTINGS -> IntentsHelper.openActivity(context = context, activityClass = SettingsActivity::class.java)
+        NavigationDrawerRoutes.ROUTE_HELP_AND_FEEDBACK -> IntentsHelper.openActivity(context = context, activityClass = HelpActivity::class.java)
+        NavigationDrawerRoutes.ROUTE_UPDATES -> onChangelogRequested()
+        NavigationDrawerRoutes.ROUTE_SHARE -> IntentsHelper.shareApp(context = context, shareMessageFormat = com.d4rk.android.libs.apptoolkit.R.string.summary_share_message)
     }
     if (drawerState != null && coroutineScope != null) {
         coroutineScope.launch { drawerState.close() }

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppModule.kt
@@ -8,7 +8,7 @@ import com.d4rk.android.apps.apptoolkit.app.apps.list.data.repository.DeveloperA
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.repository.DeveloperAppsRepository
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.usecases.FetchDeveloperAppsUseCase
 import com.d4rk.android.apps.apptoolkit.app.apps.list.ui.AppsListViewModel
-import com.d4rk.android.apps.apptoolkit.app.main.data.repository.MainRepositoryImpl
+import com.d4rk.android.libs.apptoolkit.app.main.data.repository.MainRepositoryImpl
 import com.d4rk.android.apps.apptoolkit.app.main.ui.MainViewModel
 import com.d4rk.android.apps.apptoolkit.app.onboarding.utils.interfaces.providers.AppOnboardingProvider
 import com.d4rk.android.apps.apptoolkit.core.data.datastore.DataStore
@@ -19,7 +19,7 @@ import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases.Toggl
 import com.d4rk.android.libs.apptoolkit.app.onboarding.utils.interfaces.providers.OnboardingProvider
 import com.d4rk.android.libs.apptoolkit.data.client.KtorClient
 import com.d4rk.android.libs.apptoolkit.data.core.ads.AdsCoreManager
-import com.d4rk.android.apps.apptoolkit.app.main.domain.repository.MainRepository
+import com.d4rk.android.libs.apptoolkit.app.main.domain.repository.MainRepository
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import org.koin.core.module.Module

--- a/app/src/test/java/com/d4rk/android/libs/apptoolkit/app/main/data/repository/MainRepositoryImplTest.kt
+++ b/app/src/test/java/com/d4rk/android/libs/apptoolkit/app/main/data/repository/MainRepositoryImplTest.kt
@@ -1,6 +1,7 @@
-package com.d4rk.android.apps.apptoolkit.app.main.data.repository
+package com.d4rk.android.libs.apptoolkit.app.main.data.repository
 
 import com.d4rk.android.libs.apptoolkit.R
+import com.d4rk.android.libs.apptoolkit.app.main.utils.constants.NavigationDrawerRoutes
 import com.d4rk.android.libs.apptoolkit.core.domain.model.navigation.NavigationDrawerItem
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
@@ -28,6 +29,15 @@ class MainRepositoryImplTest {
                 R.string.share
             ),
             items.map(NavigationDrawerItem::title)
+        )
+        assertEquals(
+            listOf(
+                NavigationDrawerRoutes.ROUTE_SETTINGS,
+                NavigationDrawerRoutes.ROUTE_HELP_AND_FEEDBACK,
+                NavigationDrawerRoutes.ROUTE_UPDATES,
+                NavigationDrawerRoutes.ROUTE_SHARE,
+            ),
+            items.map(NavigationDrawerItem::route)
         )
     }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/main/data/repository/MainRepositoryImpl.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/main/data/repository/MainRepositoryImpl.kt
@@ -1,12 +1,13 @@
-package com.d4rk.android.apps.apptoolkit.app.main.data.repository
+package com.d4rk.android.libs.apptoolkit.app.main.data.repository
 
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.EventNote
 import androidx.compose.material.icons.automirrored.outlined.HelpOutline
 import androidx.compose.material.icons.outlined.Settings
 import androidx.compose.material.icons.outlined.Share
-import com.d4rk.android.apps.apptoolkit.app.main.domain.repository.MainRepository
 import com.d4rk.android.libs.apptoolkit.R
+import com.d4rk.android.libs.apptoolkit.app.main.domain.repository.MainRepository
+import com.d4rk.android.libs.apptoolkit.app.main.utils.constants.NavigationDrawerRoutes
 import com.d4rk.android.libs.apptoolkit.core.domain.model.navigation.NavigationDrawerItem
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
@@ -21,16 +22,24 @@ class MainRepositoryImpl(
             emit(
                 listOf(
                     NavigationDrawerItem(
-                        title = R.string.settings, selectedIcon = Icons.Outlined.Settings
+                        title = R.string.settings,
+                        selectedIcon = Icons.Outlined.Settings,
+                        route = NavigationDrawerRoutes.ROUTE_SETTINGS,
                     ),
                     NavigationDrawerItem(
-                        title = R.string.help_and_feedback, selectedIcon = Icons.AutoMirrored.Outlined.HelpOutline
+                        title = R.string.help_and_feedback,
+                        selectedIcon = Icons.AutoMirrored.Outlined.HelpOutline,
+                        route = NavigationDrawerRoutes.ROUTE_HELP_AND_FEEDBACK,
                     ),
                     NavigationDrawerItem(
-                        title = R.string.updates, selectedIcon = Icons.AutoMirrored.Outlined.EventNote
+                        title = R.string.updates,
+                        selectedIcon = Icons.AutoMirrored.Outlined.EventNote,
+                        route = NavigationDrawerRoutes.ROUTE_UPDATES,
                     ),
                     NavigationDrawerItem(
-                        title = R.string.share, selectedIcon = Icons.Outlined.Share
+                        title = R.string.share,
+                        selectedIcon = Icons.Outlined.Share,
+                        route = NavigationDrawerRoutes.ROUTE_SHARE,
                     )
                 )
             )

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/main/domain/repository/MainRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/main/domain/repository/MainRepository.kt
@@ -1,4 +1,4 @@
-package com.d4rk.android.apps.apptoolkit.app.main.domain.repository
+package com.d4rk.android.libs.apptoolkit.app.main.domain.repository
 
 import com.d4rk.android.libs.apptoolkit.core.domain.model.navigation.NavigationDrawerItem
 import kotlinx.coroutines.flow.Flow

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/main/utils/constants/NavigationDrawerRoutes.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/main/utils/constants/NavigationDrawerRoutes.kt
@@ -1,0 +1,8 @@
+package com.d4rk.android.libs.apptoolkit.app.main.utils.constants
+
+object NavigationDrawerRoutes {
+    const val ROUTE_SETTINGS: String = "settings"
+    const val ROUTE_HELP_AND_FEEDBACK: String = "help_and_feedback"
+    const val ROUTE_UPDATES: String = "updates"
+    const val ROUTE_SHARE: String = "share"
+}

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/domain/model/navigation/NavigationDrawerItem.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/domain/model/navigation/NavigationDrawerItem.kt
@@ -7,8 +7,12 @@ import androidx.compose.ui.graphics.vector.ImageVector
  *
  * @property title The resource ID of the string to display as the title of the item.
  * @property selectedIcon The icon to display when the item is selected.
+ * @property route The unique identifier used for handling navigation actions.
  * @property badgeText An optional string to display as a badge on the item, defaults to an empty string.
  */
 data class NavigationDrawerItem(
-    val title : Int , val selectedIcon : ImageVector , val badgeText : String = ""
+    val title: Int,
+    val selectedIcon: ImageVector,
+    val route: String,
+    val badgeText: String = "",
 )


### PR DESCRIPTION
## Summary
- add route field to NavigationDrawerItem and route constants
- move MainRepositoryImpl into library with route-aware items
- switch handleNavigationItemClick to use routes instead of titles

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ab003c30832db23a73bfb74da561