### PR TITLE
refactor(apps list): optimize compose recompositions

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/AppCard.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/AppCard.kt
@@ -21,6 +21,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -50,9 +51,10 @@ fun AppCard(
     modifier: Modifier
 ) {
     val context: Context = LocalContext.current
-    val hapticFeedback : HapticFeedback = LocalHapticFeedback.current
-    val view : View = LocalView.current
+    val hapticFeedback: HapticFeedback = LocalHapticFeedback.current
+    val view: View = LocalView.current
     val coroutineScope = rememberCoroutineScope()
+    val appInfoHelper = remember { AppInfoHelper() }
     Card(
         modifier = modifier
             .bounceClick()
@@ -64,12 +66,12 @@ fun AppCard(
                 hapticFeedback.performHapticFeedback(hapticFeedbackType = HapticFeedbackType.ContextClick)
                 if (appInfo.packageName.isNotEmpty()) {
                     coroutineScope.launch {
-                        if (AppInfoHelper().isAppInstalled(
+                        if (appInfoHelper.isAppInstalled(
                                 context = context,
                                 packageName = appInfo.packageName
                             )
                         ) {
-                            if (!AppInfoHelper().openApp(
+                            if (!appInfoHelper.openApp(
                                     context = context,
                                     packageName = appInfo.packageName
                                 )

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/AppsList.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/AppsList.kt
@@ -11,9 +11,9 @@ import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.itemsIndexed
 import androidx.compose.foundation.lazy.grid.rememberLazyGridState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.snapshots.SnapshotStateList
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.compose.ui.Modifier
@@ -43,28 +43,35 @@ fun AppsList(
     val isTabletOrLandscape: Boolean = remember(context) {
         ScreenHelper.isLandscapeOrTablet(context = context)
     }
-    val columnCount: Int = remember(isTabletOrLandscape) { if (isTabletOrLandscape) 4 else 2 }
+    val columnCount: Int by remember(isTabletOrLandscape) {
+        derivedStateOf { if (isTabletOrLandscape) 4 else 2 }
+    }
 
-    val bannerType: String = remember(isTabletOrLandscape) {
-        if (isTabletOrLandscape) "full_banner" else "banner_medium_rectangle"
+    val bannerType: String by remember(isTabletOrLandscape) {
+        derivedStateOf {
+            if (isTabletOrLandscape) "full_banner" else "banner_medium_rectangle"
+        }
     }
     val koin = getKoin()
-    val adsConfig: AdsConfig = remember(bannerType) { koin.get(qualifier = named(bannerType)) }
+    val adsConfig: AdsConfig = remember(bannerType) {
+        koin.get(qualifier = named(bannerType))
+    }
     val listState: LazyGridState = rememberLazyGridState()
     val adFrequency = 4
     val dataStore: DataStore = remember { koin.get() }
-    val adsEnabled: Boolean by remember { dataStore.ads(default = true) }.collectAsStateWithLifecycle(initialValue = true)
+    val adsEnabled: Boolean by remember { dataStore.ads(default = true) }
+        .collectAsStateWithLifecycle(initialValue = true)
     val items: List<AppListItem> by remember(apps, adsEnabled) {
         derivedStateOf {
             buildList {
                 apps.forEachIndexed { index: Int, appInfo: AppInfo ->
-                    add(AppListItem.App(appInfo))
+                    add(element = AppListItem.App(appInfo = appInfo))
                     if (adsEnabled && (index + 1) % adFrequency == 0) {
-                        add(AppListItem.Ad)
+                        add(element = AppListItem.Ad)
                     }
                 }
                 if (adsEnabled && apps.isNotEmpty() && apps.size % adFrequency != 0) {
-                    add(AppListItem.Ad)
+                    add(element = AppListItem.Ad)
                 }
             }
         }
@@ -87,7 +94,7 @@ fun AppsList(
             key = { index, item ->
                 when (item) {
                     is AppListItem.App -> item.appInfo.packageName
-                    AppListItem.Ad -> "ad-$index"
+                    AppListItem.Ad -> "ad_$index"
                 }
             },
             span = { _, item ->

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/screens/loading/HomeLoadingScreen.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/screens/loading/HomeLoadingScreen.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
+import androidx.compose.foundation.lazy.grid.items
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
@@ -23,20 +24,21 @@ fun HomeLoadingScreen(paddingValues: PaddingValues, itemAspectRatio: Float = 1f)
     val isTabletOrLandscape: Boolean = remember(context) {
         ScreenHelper.isLandscapeOrTablet(context = context)
     }
-    val numberOfColumns: Int = remember(isTabletOrLandscape) {
-        if (isTabletOrLandscape) 4 else 2
+    val numberOfColumns: Int by remember(isTabletOrLandscape) {
+        derivedStateOf { if (isTabletOrLandscape) 4 else 2 }
     }
 
-    val actualItemCount by remember(paddingValues, numberOfColumns) {
-        derivedStateOf {
-            val fittedRows = WindowItemFit.count(
-                itemHeight = 180.dp,
-                itemSpacing = SizeConstants.LargeSize,
-                paddingValues = paddingValues
-            )
-            val totalRowsToDisplay = if (fittedRows == 0) 1 else fittedRows + 1
-            totalRowsToDisplay * numberOfColumns
-        }
+    val fittedRows: Int = WindowItemFit.count(
+        itemHeight = 180.dp,
+        itemSpacing = SizeConstants.LargeSize,
+        paddingValues = paddingValues
+    )
+
+    val totalRowsToDisplay: Int by remember(fittedRows) {
+        derivedStateOf { if (fittedRows == 0) 1 else fittedRows + 1 }
+    }
+    val actualItemCount: Int by remember(totalRowsToDisplay, numberOfColumns) {
+        derivedStateOf { totalRowsToDisplay * numberOfColumns }
     }
 
     LazyVerticalGrid(
@@ -47,7 +49,10 @@ fun HomeLoadingScreen(paddingValues: PaddingValues, itemAspectRatio: Float = 1f)
         modifier = Modifier.padding(horizontal = SizeConstants.LargeSize),
         userScrollEnabled = false
     ) {
-        items(count = actualItemCount, key = { it }) {
+        items(
+            count = actualItemCount,
+            key = { index: Int -> index }
+        ) {
             ShimmerPlaceholderAppCard(aspectRatio = itemAspectRatio)
         }
     }

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/screens/loading/HomeLoadingScreen.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/screens/loading/HomeLoadingScreen.kt
@@ -6,6 +6,9 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
@@ -17,27 +20,34 @@ import com.d4rk.android.libs.apptoolkit.core.utils.helpers.WindowItemFit
 fun HomeLoadingScreen(paddingValues: PaddingValues, itemAspectRatio: Float = 1f) {
 
     val context = LocalContext.current
-    val isTabletOrLandscape: Boolean = ScreenHelper.isLandscapeOrTablet(context = context)
-    val numberOfColumns = if (isTabletOrLandscape) 4 else 2
+    val isTabletOrLandscape: Boolean = remember(context) {
+        ScreenHelper.isLandscapeOrTablet(context = context)
+    }
+    val numberOfColumns: Int = remember(isTabletOrLandscape) {
+        if (isTabletOrLandscape) 4 else 2
+    }
 
-    val fittedRows = WindowItemFit.count(
-        itemHeight = 180.dp,
-        itemSpacing = SizeConstants.LargeSize,
-        paddingValues = paddingValues
-    )
-
-    val totalRowsToDisplay = if (fittedRows == 0) 1 else fittedRows + 1
-    val actualItemCount = totalRowsToDisplay * numberOfColumns
+    val actualItemCount by remember(paddingValues, numberOfColumns) {
+        derivedStateOf {
+            val fittedRows = WindowItemFit.count(
+                itemHeight = 180.dp,
+                itemSpacing = SizeConstants.LargeSize,
+                paddingValues = paddingValues
+            )
+            val totalRowsToDisplay = if (fittedRows == 0) 1 else fittedRows + 1
+            totalRowsToDisplay * numberOfColumns
+        }
+    }
 
     LazyVerticalGrid(
-        columns = GridCells.Fixed(count = if (isTabletOrLandscape) 4 else 2),
+        columns = GridCells.Fixed(count = numberOfColumns),
         contentPadding = paddingValues,
         horizontalArrangement = Arrangement.spacedBy(space = SizeConstants.LargeSize),
         verticalArrangement = Arrangement.spacedBy(space = SizeConstants.LargeSize),
         modifier = Modifier.padding(horizontal = SizeConstants.LargeSize),
         userScrollEnabled = false
     ) {
-        items(actualItemCount) {
+        items(count = actualItemCount, key = { it }) {
             ShimmerPlaceholderAppCard(aspectRatio = itemAspectRatio)
         }
     }


### PR DESCRIPTION
## Summary
- cache AppInfoHelper instances in AppCard to avoid repeated work during recomposition
- memoize HomeLoadingScreen layout calculations and add keys for placeholder items

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2ade7c004832d9dcaea8f77bd2527