### PR TITLE
docs: add architecture overview page

### DIFF
--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -1,0 +1,20 @@
+# Architecture
+
+The project is split into three top-level modules, each with a clear responsibility.
+
+## app
+- Android application layer.
+- Hosts the UI and wires together features from the toolkit.
+
+## core
+- Shared business logic and utilities.
+- Defines interfaces consumed by the app and data modules.
+
+## data
+- Handles persistence, network, and other data sources.
+- Provides repository implementations for the core layer.
+
+### Data Flow & Dependencies
+- **Dependencies:** `app → core → data`
+- **Data flow:** `data → core → app`
+

--- a/docs/wiki/Home.md
+++ b/docs/wiki/Home.md
@@ -4,6 +4,7 @@ Welcome to the **AppToolkit** wiki! This section provides extended documentation
 
 ## Available Pages
 
+- [[Architecture]]
 - [[Installation]]
 - [[Contributing]]
 - [[Wiki-Guide]]


### PR DESCRIPTION
## Summary
- add Architecture wiki page describing `app`, `core`, and `data` modules
- link Architecture page from wiki home

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2affeaee4832d8193989ba8c2bdbc