### PR TITLE
docs: expand wiki navigation

### DIFF
--- a/docs/wiki/About.md
+++ b/docs/wiki/About.md
@@ -1,0 +1,9 @@
+# About
+
+App information and links to licenses.
+
+## Related Pages
+- [[Architecture]]
+- [[Core-Module|Core Module]]
+- [[UI-Components|UI Components]]
+- [[Home]]

--- a/docs/wiki/Ads-Settings.md
+++ b/docs/wiki/Ads-Settings.md
@@ -1,0 +1,9 @@
+# Ads Settings
+
+Configuration for displaying ads and consent forms.
+
+## Related Pages
+- [[Architecture]]
+- [[Core-Module|Core Module]]
+- [[UI-Components|UI Components]]
+- [[Home]]

--- a/docs/wiki/Advanced-Settings.md
+++ b/docs/wiki/Advanced-Settings.md
@@ -1,0 +1,9 @@
+# Advanced Settings
+
+Cache controls and developer options.
+
+## Related Pages
+- [[Architecture]]
+- [[Core-Module|Core Module]]
+- [[UI-Components|UI Components]]
+- [[Home]]

--- a/docs/wiki/Architecture.md
+++ b/docs/wiki/Architecture.md
@@ -1,0 +1,9 @@
+# Architecture
+
+AppToolkit follows a modular architecture that separates data, domain, and UI layers.
+
+## Related Pages
+- [[Core-Module|Core Module]]
+- [[Data-Layer|Data Layer]]
+- [[UI-Components|UI Components]]
+- [[Home]]

--- a/docs/wiki/Core-Module.md
+++ b/docs/wiki/Core-Module.md
@@ -1,0 +1,9 @@
+# Core Module
+
+The core module provides foundational helpers, models, and utilities used across the toolkit.
+
+## Related Pages
+- [[Architecture]]
+- [[Data-Layer|Data Layer]]
+- [[UI-Components|UI Components]]
+- [[Home]]

--- a/docs/wiki/Data-Layer.md
+++ b/docs/wiki/Data-Layer.md
@@ -1,0 +1,8 @@
+# Data Layer
+
+Shared networking and persistence components for feature repositories.
+
+## Related Pages
+- [[Architecture]]
+- [[Core-Module|Core Module]]
+- [[Home]]

--- a/docs/wiki/Diagnostics.md
+++ b/docs/wiki/Diagnostics.md
@@ -1,0 +1,9 @@
+# Diagnostics
+
+Usage and diagnostics consent management.
+
+## Related Pages
+- [[Architecture]]
+- [[Core-Module|Core Module]]
+- [[UI-Components|UI Components]]
+- [[Home]]

--- a/docs/wiki/Display-and-Theme.md
+++ b/docs/wiki/Display-and-Theme.md
@@ -1,0 +1,9 @@
+# Display & Theme
+
+Dialogs and lists for appearance preferences.
+
+## Related Pages
+- [[Architecture]]
+- [[Core-Module|Core Module]]
+- [[UI-Components|UI Components]]
+- [[Home]]

--- a/docs/wiki/General-Settings.md
+++ b/docs/wiki/General-Settings.md
@@ -1,0 +1,9 @@
+# General Settings
+
+Core application preferences.
+
+## Related Pages
+- [[Architecture]]
+- [[Core-Module|Core Module]]
+- [[UI-Components|UI Components]]
+- [[Home]]

--- a/docs/wiki/Help.md
+++ b/docs/wiki/Help.md
@@ -1,0 +1,9 @@
+# Help
+
+FAQ style support screen with contact options.
+
+## Related Pages
+- [[Architecture]]
+- [[Core-Module|Core Module]]
+- [[UI-Components|UI Components]]
+- [[Home]]

--- a/docs/wiki/Issue-Reporter.md
+++ b/docs/wiki/Issue-Reporter.md
@@ -1,0 +1,9 @@
+# Issue Reporter
+
+Collect device info and create GitHub issues.
+
+## Related Pages
+- [[Architecture]]
+- [[Core-Module|Core Module]]
+- [[UI-Components|UI Components]]
+- [[Home]]

--- a/docs/wiki/Onboarding.md
+++ b/docs/wiki/Onboarding.md
@@ -1,0 +1,9 @@
+# Onboarding
+
+Animated onboarding pages and theme selection.
+
+## Related Pages
+- [[Architecture]]
+- [[Core-Module|Core Module]]
+- [[UI-Components|UI Components]]
+- [[Home]]

--- a/docs/wiki/Permissions.md
+++ b/docs/wiki/Permissions.md
@@ -1,0 +1,9 @@
+# Permissions
+
+Flows for requesting and explaining app permissions.
+
+## Related Pages
+- [[Architecture]]
+- [[Core-Module|Core Module]]
+- [[UI-Components|UI Components]]
+- [[Home]]

--- a/docs/wiki/Startup.md
+++ b/docs/wiki/Startup.md
@@ -1,0 +1,9 @@
+# Startup
+
+Initial screens and utilities to run on app launch.
+
+## Related Pages
+- [[Architecture]]
+- [[Core-Module|Core Module]]
+- [[UI-Components|UI Components]]
+- [[Home]]

--- a/docs/wiki/Support.md
+++ b/docs/wiki/Support.md
@@ -1,0 +1,9 @@
+# Support
+
+Donation screen backed by Google Play Billing.
+
+## Related Pages
+- [[Architecture]]
+- [[Core-Module|Core Module]]
+- [[UI-Components|UI Components]]
+- [[Home]]

--- a/docs/wiki/UI-Components.md
+++ b/docs/wiki/UI-Components.md
@@ -1,0 +1,8 @@
+# UI Components
+
+Reusable composable UI elements such as dialogs, text fields, carousels, and preference items.
+
+## Related Pages
+- [[Architecture]]
+- [[Core-Module|Core Module]]
+- [[Home]]

--- a/docs/wiki/_Sidebar.md
+++ b/docs/wiki/_Sidebar.md
@@ -1,6 +1,4 @@
-# AppToolkit Wiki
-
-Welcome to the **AppToolkit** wiki! This section provides extended documentation beyond the [README](../README.md).
+- [[Home]]
 
 ## Getting Started
 - [[Installation]]
@@ -27,5 +25,3 @@ Welcome to the **AppToolkit** wiki! This section provides extended documentation
 - [[Display-and-Theme|Display & Theme]]
 - [[About]]
 - [[Issue-Reporter|Issue Reporter]]
-
-Use the sidebar to navigate between pages.


### PR DESCRIPTION
## Summary
- expand home wiki page with links to architecture, core modules, data layer, UI components, and individual feature docs
- add `_Sidebar.md` for consistent navigation across wiki pages
- stub out architecture, module, layer, UI, and feature pages with cross references

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b05607e8832db31aa42b32c35939