### PR TITLE
chore: opt in to ExperimentalCoroutinesApi in tests

### DIFF
--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModel.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModel.kt
@@ -4,12 +4,14 @@ import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
 import com.d4rk.android.apps.apptoolkit.app.core.utils.dispatchers.StandardDispatcherExtension
 import app.cash.turbine.test
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class TestFavoriteAppsViewModel : TestFavoriteAppsViewModelBase() {
 
     companion object {

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/ads/ui/TestAdsSettingsViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/ads/ui/TestAdsSettingsViewModel.kt
@@ -6,6 +6,7 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.Result
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
 import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.UnconfinedDispatcherExtension
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flow
@@ -15,6 +16,7 @@ import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 import java.io.IOException
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class TestAdsSettingsViewModel {
 
     companion object {

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/advanced/ui/TestAdvancedSettingsViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/advanced/ui/TestAdvancedSettingsViewModel.kt
@@ -6,6 +6,7 @@ import com.d4rk.android.libs.apptoolkit.app.advanced.domain.actions.AdvancedSett
 import com.d4rk.android.libs.apptoolkit.core.domain.model.Result
 import com.google.common.truth.Truth.assertThat
 import app.cash.turbine.test
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flowOf
@@ -17,6 +18,7 @@ private class FakeCacheRepository(private val result: Result<Unit>) : CacheRepos
     override fun clearCache(): Flow<Result<Unit>> = flowOf(result)
 }
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class TestAdvancedSettingsViewModel {
 
     @Test

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestAppInfoHelper.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestAppInfoHelper.kt
@@ -13,12 +13,14 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
 import io.mockk.verify
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class TestAppInfoHelper {
 
     @Test


### PR DESCRIPTION
## Summary
- suppress ExperimentalCoroutinesApi warnings in various tests by opting in to the API

## Testing
- `./gradlew :apptoolkit:compileDebugUnitTestKotlin :app:compileDebugUnitTestKotlin` *(fails: SDK location not found)*
- `apt-get install -y android-sdk` *(fails: ca-certificates-java post-installation script error)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b2191538832d99f0a44d709f7f99