### PR TITLE
feat(apps): add share option for app list items

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/AppCard.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/AppCard.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -16,6 +17,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.outlined.Share
 import androidx.compose.material.icons.outlined.StarOutline
 import androidx.compose.material3.Card
 import androidx.compose.material3.Text
@@ -115,12 +117,24 @@ fun AppCard(
                     fontWeight = FontWeight.Bold
                 )
             }
-            IconButton(
-                onClick = onFavoriteToggle,
-                modifier = Modifier.align(Alignment.TopEnd),
-                icon = if (isFavorite) Icons.Filled.Star else Icons.Outlined.StarOutline,
-                iconContentDescription = null
-            )
+            Row(modifier = Modifier.align(Alignment.TopEnd)) {
+                IconButton(
+                    onClick = {
+                        IntentsHelper.shareApp(
+                            context = context,
+                            shareMessageFormat = com.d4rk.android.libs.apptoolkit.R.string.summary_share_message,
+                            packageName = appInfo.packageName
+                        )
+                    },
+                    icon = Icons.Outlined.Share,
+                    iconContentDescription = null
+                )
+                IconButton(
+                    onClick = onFavoriteToggle,
+                    icon = if (isFavorite) Icons.Filled.Star else Icons.Outlined.StarOutline,
+                    iconContentDescription = null
+                )
+            }
         }
     }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/IntentsHelper.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/IntentsHelper.kt
@@ -178,8 +178,15 @@ object IntentsHelper {
      *                           Example : "Check out this awesome app! Download it here: %s"
      *                           The %s will be replaced by the app's Play Store URL.
      */
-    fun shareApp(context : Context , @StringRes shareMessageFormat : Int) : Boolean {
-        val messageToShare : String = context.getString(shareMessageFormat , "${AppLinks.PLAY_STORE_APP}${context.packageName}")
+    fun shareApp(
+        context: Context,
+        @StringRes shareMessageFormat: Int,
+        packageName: String = context.packageName
+    ): Boolean {
+        val messageToShare: String = context.getString(
+            shareMessageFormat,
+            "${AppLinks.PLAY_STORE_APP}$packageName"
+        )
         val sendIntent : Intent = Intent().apply {
             action = Intent.ACTION_SEND
             putExtra(Intent.EXTRA_TEXT , messageToShare)

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestIntentsHelper.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestIntentsHelper.kt
@@ -172,6 +172,36 @@ class TestIntentsHelper {
     }
 
     @Test
+    fun `shareApp uses provided package name`() {
+        println("\uD83D\uDE80 [TEST] shareApp uses provided package name")
+        val context = mockk<Context>()
+        val res = mockk<Resources>()
+        every { context.packageName } returns "pkg"
+        every { context.resources } returns res
+        every { res.getText(R.string.send_email_using) } returns "send"
+        every {
+            context.getString(
+                R.string.summary_share_message,
+                "${AppLinks.PLAY_STORE_APP}other"
+            )
+        } returns "msg"
+        val slot = slot<Intent>()
+        justRun { context.startActivity(capture(slot)) }
+
+        IntentsHelper.shareApp(context, R.string.summary_share_message, packageName = "other")
+
+        val chooser = slot.captured
+        val sendIntent = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            chooser.getParcelableExtra(Intent.EXTRA_INTENT, Intent::class.java)
+        } else {
+            @Suppress("DEPRECATION")
+            chooser.getParcelableExtra(Intent.EXTRA_INTENT)
+        }
+        assertEquals("msg", sendIntent?.getStringExtra(Intent.EXTRA_TEXT))
+        println("\uD83C\uDFC1 [TEST DONE] shareApp uses provided package name")
+    }
+
+    @Test
     fun `sendEmailToDeveloper builds mailto chooser`() {
         println("🚀 [TEST] sendEmailToDeveloper builds mailto chooser")
         val context = mockk<Context>()


### PR DESCRIPTION
## Summary
- allow sharing of app links from the apps list
- support sharing arbitrary package names
- cover new share behavior with tests

## Testing
- `./gradlew :app:testDebugUnitTest :apptoolkit:testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b3051284832db74337aaefd615e1