### PR TITLE
Refactor About feature using domain use cases

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/SettingsModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/SettingsModule.kt
@@ -10,6 +10,8 @@ import com.d4rk.android.apps.apptoolkit.app.settings.settings.utils.providers.Pe
 import com.d4rk.android.libs.apptoolkit.app.about.data.DefaultAboutRepository
 import com.d4rk.android.libs.apptoolkit.app.about.domain.repository.AboutRepository
 import com.d4rk.android.libs.apptoolkit.app.about.ui.AboutViewModel
+import com.d4rk.android.libs.apptoolkit.app.about.domain.usecases.CopyDeviceInfoUseCase
+import com.d4rk.android.libs.apptoolkit.app.about.domain.usecases.ObserveAboutInfoUseCase
 import com.d4rk.android.libs.apptoolkit.app.advanced.data.CacheRepository
 import com.d4rk.android.libs.apptoolkit.app.advanced.data.DefaultCacheRepository
 import com.d4rk.android.libs.apptoolkit.app.advanced.ui.AdvancedSettingsViewModel
@@ -56,6 +58,8 @@ val settingsModule = module {
             mainDispatcher = get(named("main")),
         )
     }
+    single { ObserveAboutInfoUseCase(repository = get()) }
+    single { CopyDeviceInfoUseCase(repository = get()) }
     single<GeneralSettingsRepository> {
         DefaultGeneralSettingsRepository(dispatcher = get(named("default")))
     }
@@ -74,7 +78,8 @@ val settingsModule = module {
 
     viewModel {
         AboutViewModel(
-            repository = get(),
+            observeAboutInfo = get(),
+            copyDeviceInfo = get(),
         )
     }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/domain/model/ui/UiAboutScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/domain/model/ui/UiAboutScreen.kt
@@ -1,11 +1,14 @@
 package com.d4rk.android.libs.apptoolkit.app.about.domain.model.ui
 
+import androidx.compose.runtime.Immutable
+
 /**
  * UI representation for the about screen.
  *
  * Values are loaded by [AboutViewModel] using the provided data sources and are
  * exposed as immutable properties to the UI layer.
  */
+@Immutable
 data class UiAboutScreen(
     val appVersion: String = "",
     val appVersionCode: Int = 0,

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/domain/usecases/CopyDeviceInfoUseCase.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/domain/usecases/CopyDeviceInfoUseCase.kt
@@ -1,0 +1,21 @@
+package com.d4rk.android.libs.apptoolkit.app.about.domain.usecases
+
+import com.d4rk.android.libs.apptoolkit.app.about.domain.repository.AboutRepository
+
+/**
+ * Use case responsible for delegating the copy of the device information to the
+ * [AboutRepository]. Extracting this logic into a use case keeps the
+ * [AboutViewModel][com.d4rk.android.libs.apptoolkit.app.about.ui.AboutViewModel]
+ * focused on coordinating UI events.
+ */
+class CopyDeviceInfoUseCase(
+    private val repository: AboutRepository,
+) {
+    /**
+     * Copy the device information using the repository.
+     */
+    suspend operator fun invoke(label: String, deviceInfo: String) {
+        repository.copyDeviceInfo(label = label, deviceInfo = deviceInfo)
+    }
+}
+

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/domain/usecases/ObserveAboutInfoUseCase.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/domain/usecases/ObserveAboutInfoUseCase.kt
@@ -1,0 +1,22 @@
+package com.d4rk.android.libs.apptoolkit.app.about.domain.usecases
+
+import com.d4rk.android.libs.apptoolkit.app.about.domain.model.ui.UiAboutScreen
+import com.d4rk.android.libs.apptoolkit.app.about.domain.repository.AboutRepository
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Use case that exposes the about information as a cold [Flow].
+ *
+ * This abstraction allows the [AboutViewModel][com.d4rk.android.libs.apptoolkit.app.about.ui.AboutViewModel]
+ * to remain agnostic of the underlying data source implementation and follows the
+ * guidance of the official Google architecture recommendations.
+ */
+class ObserveAboutInfoUseCase(
+    private val repository: AboutRepository,
+) {
+    /**
+     * Invoke the use case to receive updates for the about screen.
+     */
+    operator fun invoke(): Flow<UiAboutScreen> = repository.getAboutInfoStream()
+}
+

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/ui/AboutViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/ui/AboutViewModel.kt
@@ -5,7 +5,8 @@ import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.about.domain.actions.AboutAction
 import com.d4rk.android.libs.apptoolkit.app.about.domain.actions.AboutEvent
 import com.d4rk.android.libs.apptoolkit.app.about.domain.model.ui.UiAboutScreen
-import com.d4rk.android.libs.apptoolkit.app.about.domain.repository.AboutRepository
+import com.d4rk.android.libs.apptoolkit.app.about.domain.usecases.CopyDeviceInfoUseCase
+import com.d4rk.android.libs.apptoolkit.app.about.domain.usecases.ObserveAboutInfoUseCase
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiSnackbar
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.dismissSnackbar
@@ -19,7 +20,8 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.launch
 
 open class AboutViewModel(
-    private val repository: AboutRepository,
+    private val observeAboutInfo: ObserveAboutInfoUseCase,
+    private val copyDeviceInfo: CopyDeviceInfoUseCase,
 ) :
     ScreenViewModel<UiAboutScreen, AboutEvent, AboutAction>(initialState = UiStateScreen(data = UiAboutScreen())) {
 
@@ -36,7 +38,7 @@ open class AboutViewModel(
 
     private fun loadAboutInfo() {
         viewModelScope.launch {
-            repository.getAboutInfoStream()
+            observeAboutInfo()
                 .catch { error ->
                     if (error is CancellationException) {
                         throw error
@@ -60,7 +62,7 @@ open class AboutViewModel(
         screenData?.let { data ->
             viewModelScope.launch {
                 runCatching {
-                    repository.copyDeviceInfo(label = label, deviceInfo = data.deviceInfo)
+                    copyDeviceInfo(label = label, deviceInfo = data.deviceInfo)
                 }.onSuccess {
                     screenState.showSnackbar(
                         UiSnackbar(


### PR DESCRIPTION
## Summary
- introduce `ObserveAboutInfoUseCase` and `CopyDeviceInfoUseCase` to decouple ViewModel from repository
- update `AboutViewModel` and DI module to leverage the new use cases and mark `UiAboutScreen` as `@Immutable`
- adjust About ViewModel tests for new architecture

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b46aa1b4832dafa2999e651bc1bc