### PR TITLE
docs: document ads settings module

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/domain/actions/AdsSettingsAction.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/domain/actions/AdsSettingsAction.kt
@@ -2,5 +2,6 @@ package com.d4rk.android.libs.apptoolkit.app.ads.domain.actions
 
 import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.ActionEvent
 
+/** Actions triggered from the ads settings screen. */
 sealed interface AdsSettingsAction : ActionEvent
 

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/domain/actions/AdsSettingsEvent.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/domain/actions/AdsSettingsEvent.kt
@@ -2,6 +2,7 @@ package com.d4rk.android.libs.apptoolkit.app.ads.domain.actions
 
 import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.UiEvent
 
+/** User interactions on the ads settings screen. */
 sealed interface AdsSettingsEvent : UiEvent {
     data class SetAdsEnabled(val enabled: Boolean) : AdsSettingsEvent
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/domain/model/ui/UiAdsSettingsScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/domain/model/ui/UiAdsSettingsScreen.kt
@@ -1,5 +1,6 @@
 package com.d4rk.android.libs.apptoolkit.app.ads.domain.model.ui
 
+/** UI model for [AdsSettingsScreen]. */
 data class UiAdsSettingsScreen(
     val adsEnabled: Boolean = false,
 )

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/ui/AdsSettingsActivity.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/ui/AdsSettingsActivity.kt
@@ -7,10 +7,11 @@ import androidx.appcompat.app.AppCompatActivity
 import com.d4rk.android.libs.apptoolkit.app.theme.style.AppTheme
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
+/** Activity that hosts [AdsSettingsScreen] and configures its ViewModel. */
 class AdsSettingsActivity : AppCompatActivity() {
     private val viewModel: AdsSettingsViewModel by viewModel()
 
-    override fun onCreate(savedInstanceState : Bundle?) {
+    override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
         setContent {

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/ui/AdsSettingsScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/ui/AdsSettingsScreen.kt
@@ -33,6 +33,7 @@ import com.google.android.ump.ConsentInformation
 import com.google.android.ump.UserMessagingPlatform
 import kotlinx.coroutines.launch
 
+/** Compose screen displaying ad preferences. */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun AdsSettingsScreen(activity: Activity, viewModel: AdsSettingsViewModel) {


### PR DESCRIPTION
## Summary
- document ads settings events and actions
- clarify UI model and screen behavior
- add activity documentation and fix style

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b4e579bc832dbbd2952380cc06c4