### PR TITLE
Refactor diagnostics settings to ViewModel-based architecture

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/SettingsModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/SettingsModule.kt
@@ -47,7 +47,7 @@ val settingsModule = module {
     single<DisplaySettingsProvider> { AppDisplaySettingsProvider(context = get()) }
     single<PrivacySettingsProvider> { AppPrivacySettingsProvider(context = get()) }
     single<BuildInfoProvider> { AppBuildInfoProvider(context = get()) }
-    single<GeneralSettingsContentProvider> { GeneralSettingsContentProvider(displayProvider = get() , privacyProvider = get() , configProvider = get()) }
+    single<GeneralSettingsContentProvider> { GeneralSettingsContentProvider(displayProvider = get(), privacyProvider = get()) }
     single<CacheRepository> { DefaultCacheRepository(context = get(), ioDispatcher = get(named("io"))) }
     single<AboutRepository> {
         DefaultAboutRepository(
@@ -84,6 +84,7 @@ val settingsModule = module {
         UsageAndDiagnosticsViewModel(
             dataStore = CommonDataStore.getInstance(get()),
             configProvider = get(),
+            dispatcher = get(named("io")),
         )
     }
 }

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/SettingsModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/SettingsModule.kt
@@ -13,6 +13,7 @@ import com.d4rk.android.libs.apptoolkit.app.about.ui.AboutViewModel
 import com.d4rk.android.libs.apptoolkit.app.advanced.data.CacheRepository
 import com.d4rk.android.libs.apptoolkit.app.advanced.data.DefaultCacheRepository
 import com.d4rk.android.libs.apptoolkit.app.advanced.ui.AdvancedSettingsViewModel
+import com.d4rk.android.libs.apptoolkit.app.diagnostics.ui.UsageAndDiagnosticsViewModel
 import com.d4rk.android.libs.apptoolkit.app.permissions.ui.PermissionsViewModel
 import com.d4rk.android.libs.apptoolkit.app.permissions.domain.repository.PermissionsRepository
 import com.d4rk.android.libs.apptoolkit.app.settings.general.ui.GeneralSettingsViewModel
@@ -26,6 +27,7 @@ import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoPr
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.DisplaySettingsProvider
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.GeneralSettingsContentProvider
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.PrivacySettingsProvider
+import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
 import org.koin.core.module.dsl.viewModel
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
@@ -75,6 +77,13 @@ val settingsModule = module {
     viewModel {
         AboutViewModel(
             repository = get(),
+        )
+    }
+
+    viewModel {
+        UsageAndDiagnosticsViewModel(
+            dataStore = CommonDataStore.getInstance(get()),
+            configProvider = get(),
         )
     }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/domain/actions/UsageAndDiagnosticsAction.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/domain/actions/UsageAndDiagnosticsAction.kt
@@ -1,0 +1,5 @@
+package com.d4rk.android.libs.apptoolkit.app.diagnostics.domain.actions
+
+import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.ActionEvent
+
+sealed interface UsageAndDiagnosticsAction : ActionEvent

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/domain/actions/UsageAndDiagnosticsEvent.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/domain/actions/UsageAndDiagnosticsEvent.kt
@@ -1,0 +1,11 @@
+package com.d4rk.android.libs.apptoolkit.app.diagnostics.domain.actions
+
+import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.UiEvent
+
+sealed interface UsageAndDiagnosticsEvent : UiEvent {
+    data class SetUsageAndDiagnostics(val enabled: Boolean) : UsageAndDiagnosticsEvent
+    data class SetAnalyticsConsent(val granted: Boolean) : UsageAndDiagnosticsEvent
+    data class SetAdStorageConsent(val granted: Boolean) : UsageAndDiagnosticsEvent
+    data class SetAdUserDataConsent(val granted: Boolean) : UsageAndDiagnosticsEvent
+    data class SetAdPersonalizationConsent(val granted: Boolean) : UsageAndDiagnosticsEvent
+}

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/domain/model/ui/UiUsageAndDiagnosticsScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/domain/model/ui/UiUsageAndDiagnosticsScreen.kt
@@ -1,0 +1,18 @@
+package com.d4rk.android.libs.apptoolkit.app.diagnostics.domain.model.ui
+
+/**
+ * Represents the state for [com.d4rk.android.libs.apptoolkit.app.diagnostics.ui.UsageAndDiagnosticsViewModel].
+ *
+ * @param usageAndDiagnostics whether usage and diagnostics collection is enabled
+ * @param analyticsConsent user consent for analytics
+ * @param adStorageConsent user consent for ad storage
+ * @param adUserDataConsent user consent for ad user data
+ * @param adPersonalizationConsent user consent for ad personalization
+ */
+data class UiUsageAndDiagnosticsScreen(
+    val usageAndDiagnostics: Boolean = false,
+    val analyticsConsent: Boolean = false,
+    val adStorageConsent: Boolean = false,
+    val adUserDataConsent: Boolean = false,
+    val adPersonalizationConsent: Boolean = false,
+)

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/ui/UsageAndDiagnosticsViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/ui/UsageAndDiagnosticsViewModel.kt
@@ -1,0 +1,111 @@
+package com.d4rk.android.libs.apptoolkit.app.diagnostics.ui
+
+import androidx.lifecycle.viewModelScope
+import com.d4rk.android.libs.apptoolkit.app.diagnostics.domain.actions.UsageAndDiagnosticsAction
+import com.d4rk.android.libs.apptoolkit.app.diagnostics.domain.actions.UsageAndDiagnosticsEvent
+import com.d4rk.android.libs.apptoolkit.app.diagnostics.domain.model.ui.UiUsageAndDiagnosticsScreen
+import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoProvider
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.getData
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.successData
+import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
+import com.d4rk.android.libs.apptoolkit.core.utils.helpers.ConsentManagerHelper
+import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.launch
+
+class UsageAndDiagnosticsViewModel(
+    private val dataStore: CommonDataStore,
+    private val configProvider: BuildInfoProvider,
+) : ScreenViewModel<UiUsageAndDiagnosticsScreen, UsageAndDiagnosticsEvent, UsageAndDiagnosticsAction>(
+    initialState = UiStateScreen(
+        data = UiUsageAndDiagnosticsScreen(
+            usageAndDiagnostics = !configProvider.isDebugBuild,
+            analyticsConsent = !configProvider.isDebugBuild,
+            adStorageConsent = !configProvider.isDebugBuild,
+            adUserDataConsent = !configProvider.isDebugBuild,
+            adPersonalizationConsent = !configProvider.isDebugBuild,
+        )
+    ),
+) {
+
+    init {
+        observeConsents()
+    }
+
+    override fun onEvent(event: UsageAndDiagnosticsEvent) {
+        when (event) {
+            is UsageAndDiagnosticsEvent.SetUsageAndDiagnostics -> updateUsageAndDiagnostics(event.enabled)
+            is UsageAndDiagnosticsEvent.SetAnalyticsConsent -> updateAnalyticsConsent(event.granted)
+            is UsageAndDiagnosticsEvent.SetAdStorageConsent -> updateAdStorageConsent(event.granted)
+            is UsageAndDiagnosticsEvent.SetAdUserDataConsent -> updateAdUserDataConsent(event.granted)
+            is UsageAndDiagnosticsEvent.SetAdPersonalizationConsent -> updateAdPersonalizationConsent(event.granted)
+        }
+    }
+
+    private fun observeConsents() {
+        viewModelScope.launch {
+            combine(
+                dataStore.usageAndDiagnostics(default = !configProvider.isDebugBuild),
+                dataStore.analyticsConsent(default = !configProvider.isDebugBuild),
+                dataStore.adStorageConsent(default = !configProvider.isDebugBuild),
+                dataStore.adUserDataConsent(default = !configProvider.isDebugBuild),
+                dataStore.adPersonalizationConsent(default = !configProvider.isDebugBuild),
+            ) { usage, analytics, adStorage, adUserData, adPersonalization ->
+                UiUsageAndDiagnosticsScreen(
+                    usageAndDiagnostics = usage,
+                    analyticsConsent = analytics,
+                    adStorageConsent = adStorage,
+                    adUserDataConsent = adUserData,
+                    adPersonalizationConsent = adPersonalization,
+                )
+            }.collect { data ->
+                screenState.successData { data }
+            }
+        }
+    }
+
+    private fun updateUsageAndDiagnostics(enabled: Boolean) {
+        viewModelScope.launch {
+            dataStore.saveUsageAndDiagnostics(isChecked = enabled)
+        }
+    }
+
+    private fun updateAnalyticsConsent(granted: Boolean) {
+        viewModelScope.launch {
+            dataStore.saveAnalyticsConsent(isGranted = granted)
+            updateAllConsents()
+        }
+    }
+
+    private fun updateAdStorageConsent(granted: Boolean) {
+        viewModelScope.launch {
+            dataStore.saveAdStorageConsent(isGranted = granted)
+            updateAllConsents()
+        }
+    }
+
+    private fun updateAdUserDataConsent(granted: Boolean) {
+        viewModelScope.launch {
+            dataStore.saveAdUserDataConsent(isGranted = granted)
+            updateAllConsents()
+        }
+    }
+
+    private fun updateAdPersonalizationConsent(granted: Boolean) {
+        viewModelScope.launch {
+            dataStore.saveAdPersonalizationConsent(isGranted = granted)
+            updateAllConsents()
+        }
+    }
+
+    private fun updateAllConsents() {
+        val data = screenState.getData()
+        ConsentManagerHelper.updateConsent(
+            analyticsGranted = data.analyticsConsent,
+            adStorageGranted = data.adStorageConsent,
+            adUserDataGranted = data.adUserDataConsent,
+            adPersonalizationGranted = data.adPersonalizationConsent,
+        )
+    }
+}

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/ui/UsageAndDiagnosticsViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/ui/UsageAndDiagnosticsViewModel.kt
@@ -11,12 +11,15 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.successData
 import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.ConsentManagerHelper
 import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
 
 class UsageAndDiagnosticsViewModel(
     private val dataStore: CommonDataStore,
     private val configProvider: BuildInfoProvider,
+    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : ScreenViewModel<UiUsageAndDiagnosticsScreen, UsageAndDiagnosticsEvent, UsageAndDiagnosticsAction>(
     initialState = UiStateScreen(
         data = UiUsageAndDiagnosticsScreen(
@@ -66,34 +69,34 @@ class UsageAndDiagnosticsViewModel(
     }
 
     private fun updateUsageAndDiagnostics(enabled: Boolean) {
-        viewModelScope.launch {
+        viewModelScope.launch(dispatcher) {
             dataStore.saveUsageAndDiagnostics(isChecked = enabled)
         }
     }
 
     private fun updateAnalyticsConsent(granted: Boolean) {
-        viewModelScope.launch {
+        viewModelScope.launch(dispatcher) {
             dataStore.saveAnalyticsConsent(isGranted = granted)
             updateAllConsents()
         }
     }
 
     private fun updateAdStorageConsent(granted: Boolean) {
-        viewModelScope.launch {
+        viewModelScope.launch(dispatcher) {
             dataStore.saveAdStorageConsent(isGranted = granted)
             updateAllConsents()
         }
     }
 
     private fun updateAdUserDataConsent(granted: Boolean) {
-        viewModelScope.launch {
+        viewModelScope.launch(dispatcher) {
             dataStore.saveAdUserDataConsent(isGranted = granted)
             updateAllConsents()
         }
     }
 
     private fun updateAdPersonalizationConsent(granted: Boolean) {
-        viewModelScope.launch {
+        viewModelScope.launch(dispatcher) {
             dataStore.saveAdPersonalizationConsent(isGranted = granted)
             updateAllConsents()
         }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/settings/utils/providers/GeneralSettingsContentProvider.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/settings/utils/providers/GeneralSettingsContentProvider.kt
@@ -14,7 +14,6 @@ import com.d4rk.android.libs.apptoolkit.app.theme.ThemeSettingsList
 class GeneralSettingsContentProvider(
     private val displayProvider: DisplaySettingsProvider,
     private val privacyProvider: PrivacySettingsProvider,
-    private val configProvider: BuildInfoProvider,
     private val customScreens: Map<String, @Composable (PaddingValues) -> Unit> = emptyMap(),
 ) {
     @Composable
@@ -25,7 +24,7 @@ class GeneralSettingsContentProvider(
             SettingsContent.DISPLAY -> DisplaySettingsList(paddingValues = paddingValues, provider = displayProvider)
             SettingsContent.SECURITY_AND_PRIVACY -> PrivacySettingsList(paddingValues = paddingValues, provider = privacyProvider)
             SettingsContent.THEME -> ThemeSettingsList(paddingValues = paddingValues)
-            SettingsContent.USAGE_AND_DIAGNOSTICS -> UsageAndDiagnosticsList(paddingValues = paddingValues, configProvider = configProvider)
+            SettingsContent.USAGE_AND_DIAGNOSTICS -> UsageAndDiagnosticsList(paddingValues = paddingValues)
             else -> customScreens[contentKey]?.invoke(paddingValues)
         }
     }


### PR DESCRIPTION
## Summary
- migrate Usage & Diagnostics screen to ViewModel and event-based state
- add domain state and events for usage and diagnostics consents
- register UsageAndDiagnosticsViewModel in settings module

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b5a5c6f4832db6c20c0e521f509f