### PR TITLE
Move AppCard share icon to bottom-right corner

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/AppCard.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/AppCard.kt
@@ -8,7 +8,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -117,24 +116,24 @@ fun AppCard(
                     fontWeight = FontWeight.Bold
                 )
             }
-            Row(modifier = Modifier.align(Alignment.TopEnd)) {
-                IconButton(
-                    onClick = {
-                        IntentsHelper.shareApp(
-                            context = context,
-                            shareMessageFormat = com.d4rk.android.libs.apptoolkit.R.string.summary_share_message,
-                            packageName = appInfo.packageName
-                        )
-                    },
-                    icon = Icons.Outlined.Share,
-                    iconContentDescription = null
-                )
-                IconButton(
-                    onClick = onFavoriteToggle,
-                    icon = if (isFavorite) Icons.Filled.Star else Icons.Outlined.StarOutline,
-                    iconContentDescription = null
-                )
-            }
+            IconButton(
+                modifier = Modifier.align(Alignment.BottomEnd),
+                onClick = {
+                    IntentsHelper.shareApp(
+                        context = context,
+                        shareMessageFormat = com.d4rk.android.libs.apptoolkit.R.string.summary_share_message,
+                        packageName = appInfo.packageName
+                    )
+                },
+                icon = Icons.Outlined.Share,
+                iconContentDescription = null
+            )
+            IconButton(
+                modifier = Modifier.align(Alignment.TopEnd),
+                onClick = onFavoriteToggle,
+                icon = if (isFavorite) Icons.Filled.Star else Icons.Outlined.StarOutline,
+                iconContentDescription = null
+            )
         }
     }
 }


### PR DESCRIPTION
## Summary
- position AppCard's share action at the bottom-right corner
- keep favorite icon at top-right using separate IconButtons

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2b68369d4832d894d4f26a2c709e9