### PR TITLE
refactor: use structured coroutines for diagnostics

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/ui/UsageAndDiagnosticsViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/ui/UsageAndDiagnosticsViewModel.kt
@@ -15,6 +15,7 @@ import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 
 class UsageAndDiagnosticsViewModel(
     private val dataStore: CommonDataStore,
@@ -69,35 +70,45 @@ class UsageAndDiagnosticsViewModel(
     }
 
     private fun updateUsageAndDiagnostics(enabled: Boolean) {
-        viewModelScope.launch(dispatcher) {
-            dataStore.saveUsageAndDiagnostics(isChecked = enabled)
+        viewModelScope.launch {
+            withContext(dispatcher) {
+                dataStore.saveUsageAndDiagnostics(isChecked = enabled)
+            }
         }
     }
 
     private fun updateAnalyticsConsent(granted: Boolean) {
-        viewModelScope.launch(dispatcher) {
-            dataStore.saveAnalyticsConsent(isGranted = granted)
+        viewModelScope.launch {
+            withContext(dispatcher) {
+                dataStore.saveAnalyticsConsent(isGranted = granted)
+            }
             updateAllConsents()
         }
     }
 
     private fun updateAdStorageConsent(granted: Boolean) {
-        viewModelScope.launch(dispatcher) {
-            dataStore.saveAdStorageConsent(isGranted = granted)
+        viewModelScope.launch {
+            withContext(dispatcher) {
+                dataStore.saveAdStorageConsent(isGranted = granted)
+            }
             updateAllConsents()
         }
     }
 
     private fun updateAdUserDataConsent(granted: Boolean) {
-        viewModelScope.launch(dispatcher) {
-            dataStore.saveAdUserDataConsent(isGranted = granted)
+        viewModelScope.launch {
+            withContext(dispatcher) {
+                dataStore.saveAdUserDataConsent(isGranted = granted)
+            }
             updateAllConsents()
         }
     }
 
     private fun updateAdPersonalizationConsent(granted: Boolean) {
-        viewModelScope.launch(dispatcher) {
-            dataStore.saveAdPersonalizationConsent(isGranted = granted)
+        viewModelScope.launch {
+            withContext(dispatcher) {
+                dataStore.saveAdPersonalizationConsent(isGranted = granted)
+            }
             updateAllConsents()
         }
     }


### PR DESCRIPTION
## Summary
- align usage and diagnostics ViewModel with structured concurrency
- run DataStore writes on IO dispatcher while keeping consent updates on main

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2c4934478832d8c2b4e99db5344e4