### PR TITLE
Refactor diagnostics settings to follow repository pattern

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/SettingsModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/SettingsModule.kt
@@ -15,6 +15,8 @@ import com.d4rk.android.libs.apptoolkit.app.about.domain.usecases.ObserveAboutIn
 import com.d4rk.android.libs.apptoolkit.app.advanced.data.CacheRepository
 import com.d4rk.android.libs.apptoolkit.app.advanced.data.DefaultCacheRepository
 import com.d4rk.android.libs.apptoolkit.app.advanced.ui.AdvancedSettingsViewModel
+import com.d4rk.android.libs.apptoolkit.app.diagnostics.data.repository.DefaultUsageAndDiagnosticsRepository
+import com.d4rk.android.libs.apptoolkit.app.diagnostics.domain.repository.UsageAndDiagnosticsRepository
 import com.d4rk.android.libs.apptoolkit.app.diagnostics.ui.UsageAndDiagnosticsViewModel
 import com.d4rk.android.libs.apptoolkit.app.permissions.ui.PermissionsViewModel
 import com.d4rk.android.libs.apptoolkit.app.permissions.domain.repository.PermissionsRepository
@@ -85,11 +87,15 @@ val settingsModule = module {
         )
     }
 
-    viewModel {
-        UsageAndDiagnosticsViewModel(
-            dataStore = CommonDataStore.getInstance(get()),
+    single<UsageAndDiagnosticsRepository> {
+        DefaultUsageAndDiagnosticsRepository(
+            dataSource = CommonDataStore.getInstance(get()),
             configProvider = get(),
-            dispatcher = get(named("io")),
+            ioDispatcher = get(named("io")),
         )
+    }
+
+    viewModel {
+        UsageAndDiagnosticsViewModel(repository = get())
     }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/data/datasource/UsageAndDiagnosticsPreferencesDataSource.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/data/datasource/UsageAndDiagnosticsPreferencesDataSource.kt
@@ -1,0 +1,43 @@
+package com.d4rk.android.libs.apptoolkit.app.diagnostics.data.datasource
+
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Abstraction over storage operations for usage and diagnostics related
+ * preferences. Implementations are responsible for persisting and
+ * exposing the different consent values used by the diagnostics
+ * feature.
+ */
+interface UsageAndDiagnosticsPreferencesDataSource {
+
+    /** Emits whether usage and diagnostics collection is enabled. */
+    fun usageAndDiagnostics(default: Boolean): Flow<Boolean>
+
+    /** Persists whether usage and diagnostics collection is enabled. */
+    suspend fun saveUsageAndDiagnostics(isChecked: Boolean)
+
+    /** Emits the current analytics consent state. */
+    fun analyticsConsent(default: Boolean): Flow<Boolean>
+
+    /** Persists analytics consent. */
+    suspend fun saveAnalyticsConsent(isGranted: Boolean)
+
+    /** Emits the current ad storage consent state. */
+    fun adStorageConsent(default: Boolean): Flow<Boolean>
+
+    /** Persists ad storage consent. */
+    suspend fun saveAdStorageConsent(isGranted: Boolean)
+
+    /** Emits the current ad user data consent state. */
+    fun adUserDataConsent(default: Boolean): Flow<Boolean>
+
+    /** Persists ad user data consent. */
+    suspend fun saveAdUserDataConsent(isGranted: Boolean)
+
+    /** Emits the current ad personalization consent state. */
+    fun adPersonalizationConsent(default: Boolean): Flow<Boolean>
+
+    /** Persists ad personalization consent. */
+    suspend fun saveAdPersonalizationConsent(isGranted: Boolean)
+}
+

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/data/repository/DefaultUsageAndDiagnosticsRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/data/repository/DefaultUsageAndDiagnosticsRepository.kt
@@ -1,0 +1,56 @@
+package com.d4rk.android.libs.apptoolkit.app.diagnostics.data.repository
+
+import com.d4rk.android.libs.apptoolkit.app.diagnostics.data.datasource.UsageAndDiagnosticsPreferencesDataSource
+import com.d4rk.android.libs.apptoolkit.app.diagnostics.domain.model.UsageAndDiagnosticsSettings
+import com.d4rk.android.libs.apptoolkit.app.diagnostics.domain.repository.UsageAndDiagnosticsRepository
+import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoProvider
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.withContext
+
+/**
+ * Default implementation of [UsageAndDiagnosticsRepository] backed by a
+ * [UsageAndDiagnosticsPreferencesDataSource].
+ */
+class DefaultUsageAndDiagnosticsRepository(
+    private val dataSource: UsageAndDiagnosticsPreferencesDataSource,
+    private val configProvider: BuildInfoProvider,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) : UsageAndDiagnosticsRepository {
+
+    override fun observeSettings(): Flow<UsageAndDiagnosticsSettings> =
+        combine(
+            dataSource.usageAndDiagnostics(default = !configProvider.isDebugBuild),
+            dataSource.analyticsConsent(default = !configProvider.isDebugBuild),
+            dataSource.adStorageConsent(default = !configProvider.isDebugBuild),
+            dataSource.adUserDataConsent(default = !configProvider.isDebugBuild),
+            dataSource.adPersonalizationConsent(default = !configProvider.isDebugBuild),
+        ) { usage, analytics, adStorage, adUserData, adPersonalization ->
+            UsageAndDiagnosticsSettings(
+                usageAndDiagnostics = usage,
+                analyticsConsent = analytics,
+                adStorageConsent = adStorage,
+                adUserDataConsent = adUserData,
+                adPersonalizationConsent = adPersonalization,
+            )
+        }.flowOn(ioDispatcher)
+
+    override suspend fun setUsageAndDiagnostics(enabled: Boolean) =
+        withContext(ioDispatcher) { dataSource.saveUsageAndDiagnostics(isChecked = enabled) }
+
+    override suspend fun setAnalyticsConsent(granted: Boolean) =
+        withContext(ioDispatcher) { dataSource.saveAnalyticsConsent(isGranted = granted) }
+
+    override suspend fun setAdStorageConsent(granted: Boolean) =
+        withContext(ioDispatcher) { dataSource.saveAdStorageConsent(isGranted = granted) }
+
+    override suspend fun setAdUserDataConsent(granted: Boolean) =
+        withContext(ioDispatcher) { dataSource.saveAdUserDataConsent(isGranted = granted) }
+
+    override suspend fun setAdPersonalizationConsent(granted: Boolean) =
+        withContext(ioDispatcher) { dataSource.saveAdPersonalizationConsent(isGranted = granted) }
+}
+

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/domain/model/UsageAndDiagnosticsSettings.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/domain/model/UsageAndDiagnosticsSettings.kt
@@ -1,0 +1,15 @@
+package com.d4rk.android.libs.apptoolkit.app.diagnostics.domain.model
+
+/**
+ * Represents the persisted usage and diagnostics consents.
+ * This model belongs to the domain layer and should not contain
+ * any UI specific information.
+ */
+data class UsageAndDiagnosticsSettings(
+    val usageAndDiagnostics: Boolean,
+    val analyticsConsent: Boolean,
+    val adStorageConsent: Boolean,
+    val adUserDataConsent: Boolean,
+    val adPersonalizationConsent: Boolean,
+)
+

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/domain/repository/UsageAndDiagnosticsRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/domain/repository/UsageAndDiagnosticsRepository.kt
@@ -1,0 +1,21 @@
+package com.d4rk.android.libs.apptoolkit.app.diagnostics.domain.repository
+
+import com.d4rk.android.libs.apptoolkit.app.diagnostics.domain.model.UsageAndDiagnosticsSettings
+import kotlinx.coroutines.flow.Flow
+
+/**
+ * Repository exposing usage and diagnostics related settings to the rest of
+ * the application. Implementations should delegate to a data source to read
+ * and persist the underlying values.
+ */
+interface UsageAndDiagnosticsRepository {
+    /** Emits all usage and diagnostics related consent values. */
+    fun observeSettings(): Flow<UsageAndDiagnosticsSettings>
+
+    suspend fun setUsageAndDiagnostics(enabled: Boolean)
+    suspend fun setAnalyticsConsent(granted: Boolean)
+    suspend fun setAdStorageConsent(granted: Boolean)
+    suspend fun setAdUserDataConsent(granted: Boolean)
+    suspend fun setAdPersonalizationConsent(granted: Boolean)
+}
+

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/ui/UsageAndDiagnosticsViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/ui/UsageAndDiagnosticsViewModel.kt
@@ -4,33 +4,18 @@ import androidx.lifecycle.viewModelScope
 import com.d4rk.android.libs.apptoolkit.app.diagnostics.domain.actions.UsageAndDiagnosticsAction
 import com.d4rk.android.libs.apptoolkit.app.diagnostics.domain.actions.UsageAndDiagnosticsEvent
 import com.d4rk.android.libs.apptoolkit.app.diagnostics.domain.model.ui.UiUsageAndDiagnosticsScreen
-import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoProvider
+import com.d4rk.android.libs.apptoolkit.app.diagnostics.domain.repository.UsageAndDiagnosticsRepository
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.getData
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.successData
 import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.ConsentManagerHelper
-import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.withContext
 
 class UsageAndDiagnosticsViewModel(
-    private val dataStore: CommonDataStore,
-    private val configProvider: BuildInfoProvider,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val repository: UsageAndDiagnosticsRepository,
 ) : ScreenViewModel<UiUsageAndDiagnosticsScreen, UsageAndDiagnosticsEvent, UsageAndDiagnosticsAction>(
-    initialState = UiStateScreen(
-        data = UiUsageAndDiagnosticsScreen(
-            usageAndDiagnostics = !configProvider.isDebugBuild,
-            analyticsConsent = !configProvider.isDebugBuild,
-            adStorageConsent = !configProvider.isDebugBuild,
-            adUserDataConsent = !configProvider.isDebugBuild,
-            adPersonalizationConsent = !configProvider.isDebugBuild,
-        )
-    ),
+    initialState = UiStateScreen(data = UiUsageAndDiagnosticsScreen()),
 ) {
 
     init {
@@ -49,66 +34,48 @@ class UsageAndDiagnosticsViewModel(
 
     private fun observeConsents() {
         viewModelScope.launch {
-            combine(
-                dataStore.usageAndDiagnostics(default = !configProvider.isDebugBuild),
-                dataStore.analyticsConsent(default = !configProvider.isDebugBuild),
-                dataStore.adStorageConsent(default = !configProvider.isDebugBuild),
-                dataStore.adUserDataConsent(default = !configProvider.isDebugBuild),
-                dataStore.adPersonalizationConsent(default = !configProvider.isDebugBuild),
-            ) { usage, analytics, adStorage, adUserData, adPersonalization ->
-                UiUsageAndDiagnosticsScreen(
-                    usageAndDiagnostics = usage,
-                    analyticsConsent = analytics,
-                    adStorageConsent = adStorage,
-                    adUserDataConsent = adUserData,
-                    adPersonalizationConsent = adPersonalization,
-                )
-            }.collect { data ->
-                screenState.successData { data }
+            repository.observeSettings().collect { settings ->
+                screenState.successData {
+                    UiUsageAndDiagnosticsScreen(
+                        usageAndDiagnostics = settings.usageAndDiagnostics,
+                        analyticsConsent = settings.analyticsConsent,
+                        adStorageConsent = settings.adStorageConsent,
+                        adUserDataConsent = settings.adUserDataConsent,
+                        adPersonalizationConsent = settings.adPersonalizationConsent,
+                    )
+                }
             }
         }
     }
 
     private fun updateUsageAndDiagnostics(enabled: Boolean) {
-        viewModelScope.launch {
-            withContext(dispatcher) {
-                dataStore.saveUsageAndDiagnostics(isChecked = enabled)
-            }
-        }
+        viewModelScope.launch { repository.setUsageAndDiagnostics(enabled) }
     }
 
     private fun updateAnalyticsConsent(granted: Boolean) {
         viewModelScope.launch {
-            withContext(dispatcher) {
-                dataStore.saveAnalyticsConsent(isGranted = granted)
-            }
+            repository.setAnalyticsConsent(granted)
             updateAllConsents()
         }
     }
 
     private fun updateAdStorageConsent(granted: Boolean) {
         viewModelScope.launch {
-            withContext(dispatcher) {
-                dataStore.saveAdStorageConsent(isGranted = granted)
-            }
+            repository.setAdStorageConsent(granted)
             updateAllConsents()
         }
     }
 
     private fun updateAdUserDataConsent(granted: Boolean) {
         viewModelScope.launch {
-            withContext(dispatcher) {
-                dataStore.saveAdUserDataConsent(isGranted = granted)
-            }
+            repository.setAdUserDataConsent(granted)
             updateAllConsents()
         }
     }
 
     private fun updateAdPersonalizationConsent(granted: Boolean) {
         viewModelScope.launch {
-            withContext(dispatcher) {
-                dataStore.saveAdPersonalizationConsent(isGranted = granted)
-            }
+            repository.setAdPersonalizationConsent(granted)
             updateAllConsents()
         }
     }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/datastore/CommonDataStore.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/datastore/CommonDataStore.kt
@@ -12,6 +12,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.d4rk.android.libs.apptoolkit.app.onboarding.data.datasource.OnboardingPreferencesDataSource
+import com.d4rk.android.libs.apptoolkit.app.diagnostics.data.datasource.UsageAndDiagnosticsPreferencesDataSource
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.datastore.DataStoreNamesConstants
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
@@ -39,7 +40,7 @@ val Context.commonDataStore : DataStore<Preferences> by preferencesDataStore(nam
 open class CommonDataStore(
     context : Context,
     ioDispatcher: CoroutineDispatcher = Dispatchers.IO
-) : OnboardingPreferencesDataSource {
+) : OnboardingPreferencesDataSource, UsageAndDiagnosticsPreferencesDataSource {
     val dataStore : DataStore<Preferences> = context.commonDataStore
     private val scope = CoroutineScope(SupervisorJob() + ioDispatcher)
 
@@ -165,51 +166,51 @@ open class CommonDataStore(
 
     // Usage and Diagnostics
     private val usageAndDiagnosticsKey : Preferences.Key<Boolean> = booleanPreferencesKey(name = DataStoreNamesConstants.DATA_STORE_USAGE_AND_DIAGNOSTICS)
-    fun usageAndDiagnostics(default : Boolean) : Flow<Boolean> = dataStore.data.map { preferences : Preferences ->
+    override fun usageAndDiagnostics(default : Boolean) : Flow<Boolean> = dataStore.data.map { preferences : Preferences ->
         preferences[usageAndDiagnosticsKey] ?: default
     }
 
-    suspend fun saveUsageAndDiagnostics(isChecked : Boolean) {
+    override suspend fun saveUsageAndDiagnostics(isChecked : Boolean) {
         dataStore.edit { preferences : MutablePreferences -> preferences[usageAndDiagnosticsKey] = isChecked }
     }
 
     // Analytics Consent
     private val analyticsConsentKey : Preferences.Key<Boolean> = booleanPreferencesKey(name = DataStoreNamesConstants.DATA_STORE_ANALYTICS_CONSENT)
-    fun analyticsConsent(default : Boolean) : Flow<Boolean> = dataStore.data.map { preferences : Preferences ->
+    override fun analyticsConsent(default : Boolean) : Flow<Boolean> = dataStore.data.map { preferences : Preferences ->
         preferences[analyticsConsentKey] ?: default
     }
 
-    suspend fun saveAnalyticsConsent(isGranted : Boolean) {
+    override suspend fun saveAnalyticsConsent(isGranted : Boolean) {
         dataStore.edit { preferences : MutablePreferences -> preferences[analyticsConsentKey] = isGranted }
     }
 
     // Ad Storage Consent
     private val adStorageConsentKey : Preferences.Key<Boolean> = booleanPreferencesKey(name = DataStoreNamesConstants.DATA_STORE_AD_STORAGE_CONSENT)
-    fun adStorageConsent(default : Boolean) : Flow<Boolean> = dataStore.data.map { preferences : Preferences ->
+    override fun adStorageConsent(default : Boolean) : Flow<Boolean> = dataStore.data.map { preferences : Preferences ->
         preferences[adStorageConsentKey] ?: default
     }
 
-    suspend fun saveAdStorageConsent(isGranted : Boolean) {
+    override suspend fun saveAdStorageConsent(isGranted : Boolean) {
         dataStore.edit { preferences : MutablePreferences -> preferences[adStorageConsentKey] = isGranted }
     }
 
     // Ad User Data Consent
     private val adUserDataConsentKey : Preferences.Key<Boolean> = booleanPreferencesKey(name = DataStoreNamesConstants.DATA_STORE_AD_USER_DATA_CONSENT)
-    fun adUserDataConsent(default : Boolean) : Flow<Boolean> = dataStore.data.map { preferences : Preferences ->
+    override fun adUserDataConsent(default : Boolean) : Flow<Boolean> = dataStore.data.map { preferences : Preferences ->
         preferences[adUserDataConsentKey] ?: default
     }
 
-    suspend fun saveAdUserDataConsent(isGranted : Boolean) {
+    override suspend fun saveAdUserDataConsent(isGranted : Boolean) {
         dataStore.edit { preferences : MutablePreferences -> preferences[adUserDataConsentKey] = isGranted }
     }
 
     // Ad Personalization Consent
     private val adPersonalizationConsentKey : Preferences.Key<Boolean> = booleanPreferencesKey(name = DataStoreNamesConstants.DATA_STORE_AD_PERSONALIZATION_CONSENT)
-    fun adPersonalizationConsent(default : Boolean) : Flow<Boolean> = dataStore.data.map { preferences : Preferences ->
+    override fun adPersonalizationConsent(default : Boolean) : Flow<Boolean> = dataStore.data.map { preferences : Preferences ->
         preferences[adPersonalizationConsentKey] ?: default
     }
 
-    suspend fun saveAdPersonalizationConsent(isGranted : Boolean) {
+    override suspend fun saveAdPersonalizationConsent(isGranted : Boolean) {
         dataStore.edit { preferences : MutablePreferences -> preferences[adPersonalizationConsentKey] = isGranted }
     }
 

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/data/repository/DefaultUsageAndDiagnosticsRepositoryTest.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/data/repository/DefaultUsageAndDiagnosticsRepositoryTest.kt
@@ -36,9 +36,10 @@ private class FakeUsageAndDiagnosticsPreferencesDataSource : UsageAndDiagnostics
 }
 
 private class FakeBuildInfoProvider : BuildInfoProvider {
+    override val appVersion: String = ""
+    override val appVersionCode: Int = 0
+    override val packageName: String = ""
     override val isDebugBuild: Boolean = false
-    override val versionName: String = ""
-    override val versionCode: Int = 0
 }
 
 @OptIn(ExperimentalCoroutinesApi::class)

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/data/repository/DefaultUsageAndDiagnosticsRepositoryTest.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/data/repository/DefaultUsageAndDiagnosticsRepositoryTest.kt
@@ -1,0 +1,71 @@
+package com.d4rk.android.libs.apptoolkit.app.diagnostics.data.repository
+
+import com.d4rk.android.libs.apptoolkit.app.diagnostics.data.datasource.UsageAndDiagnosticsPreferencesDataSource
+import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoProvider
+import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.UnconfinedDispatcherExtension
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+
+private class FakeUsageAndDiagnosticsPreferencesDataSource : UsageAndDiagnosticsPreferencesDataSource {
+    private val usage = MutableStateFlow(true)
+    private val analytics = MutableStateFlow(true)
+    private val adStorage = MutableStateFlow(true)
+    private val adUserData = MutableStateFlow(true)
+    private val adPersonalization = MutableStateFlow(true)
+
+    override fun usageAndDiagnostics(default: Boolean) = usage
+    override suspend fun saveUsageAndDiagnostics(isChecked: Boolean) { usage.emit(isChecked) }
+
+    override fun analyticsConsent(default: Boolean) = analytics
+    override suspend fun saveAnalyticsConsent(isGranted: Boolean) { analytics.emit(isGranted) }
+
+    override fun adStorageConsent(default: Boolean) = adStorage
+    override suspend fun saveAdStorageConsent(isGranted: Boolean) { adStorage.emit(isGranted) }
+
+    override fun adUserDataConsent(default: Boolean) = adUserData
+    override suspend fun saveAdUserDataConsent(isGranted: Boolean) { adUserData.emit(isGranted) }
+
+    override fun adPersonalizationConsent(default: Boolean) = adPersonalization
+    override suspend fun saveAdPersonalizationConsent(isGranted: Boolean) { adPersonalization.emit(isGranted) }
+}
+
+private class FakeBuildInfoProvider : BuildInfoProvider {
+    override val isDebugBuild: Boolean = false
+    override val versionName: String = ""
+    override val versionCode: Int = 0
+}
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class DefaultUsageAndDiagnosticsRepositoryTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val dispatcherExtension = UnconfinedDispatcherExtension()
+    }
+
+    @Test
+    fun `observeSettings reflects data source updates`() = runTest(dispatcherExtension.testDispatcher) {
+        val dataSource = FakeUsageAndDiagnosticsPreferencesDataSource()
+        val repository = DefaultUsageAndDiagnosticsRepository(
+            dataSource = dataSource,
+            configProvider = FakeBuildInfoProvider(),
+            ioDispatcher = dispatcherExtension.testDispatcher,
+        )
+
+        // Initial state should reflect default true values
+        assertThat(repository.observeSettings().first().usageAndDiagnostics).isTrue()
+
+        repository.setUsageAndDiagnostics(false)
+        advanceUntilIdle()
+
+        assertThat(repository.observeSettings().first().usageAndDiagnostics).isFalse()
+    }
+}
+


### PR DESCRIPTION
## Summary
- add UsageAndDiagnosticsPreferencesDataSource and repository to separate UI from data access
- refactor UsageAndDiagnosticsViewModel to consume repository
- wire new repository in Koin settings module and cover with unit tests

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2c68cf5f4832dac8fea9ebef0e591