### PR TITLE
refactor: use runCatching in ads settings test

### DIFF
--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/ads/data/TestDefaultAdsSettingsRepository.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/ads/data/TestDefaultAdsSettingsRepository.kt
@@ -74,12 +74,7 @@ class TestDefaultAdsSettingsRepository {
         every { dataStore.ads(default = true) } returns flow { throw CancellationException("boom") }
         val repository = createRepository(dataStore, debugBuild = false)
 
-        var thrown: Throwable? = null
-        try {
-            repository.observeAdsEnabled().collect()
-        } catch (e: Throwable) {
-            thrown = e
-        }
+        val thrown = runCatching { repository.observeAdsEnabled().collect() }.exceptionOrNull()
 
         assertThat(thrown).isInstanceOf(CancellationException::class.java)
     }


### PR DESCRIPTION
## Summary
- refactor tests to use `runCatching` instead of `try/catch`

## Testing
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2cbaf78a8832d985234b4327362b2