### PR TITLE
Fix support screen stuck on loading when revisiting

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportViewModel.kt
@@ -134,6 +134,12 @@ class SupportViewModel(
                         DonationProductIds.EXTREME_DONATION
                     )
                 )
+            }.onSuccess {
+                // When product details are already cached, querying again won't emit
+                // a new value. Ensure the UI exits the loading state in that case.
+                if (screenData?.products?.isNotEmpty() == true) {
+                    screenState.updateState(ScreenState.Success())
+                }
             }.onFailure { e ->
                 screenState.updateData(newState = ScreenState.Error()) { current ->
                     current.copy(error = e.message)
@@ -163,6 +169,10 @@ class SupportViewModel(
                             DonationProductIds.EXTREME_DONATION
                         )
                     )
+                }.onSuccess {
+                    if (screenData?.products?.isNotEmpty() == true) {
+                        screenState.updateState(ScreenState.Success())
+                    }
                 }.onFailure { e ->
                     screenState.updateData(newState = ScreenState.Error()) { current ->
                         current.copy(error = e.message)


### PR DESCRIPTION
## Summary
- ensure support screen exits loading when product details are already cached

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2e80b69f8832d84b4e9f3be2685b6