### PR TITLE
Skip product loading screen when cached

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportViewModel.kt
@@ -38,7 +38,13 @@ class SupportViewModel(
 
     init {
         billingRepository.productDetails
-            .onStart { screenState.updateState(ScreenState.IsLoading()) }
+            .onStart {
+                if (screenData?.products?.isNotEmpty() == true) {
+                    screenState.updateState(ScreenState.Success())
+                } else {
+                    screenState.updateState(ScreenState.IsLoading())
+                }
+            }
             .map { it.values.toList() }
             .onEach { products ->
                 if (products.isEmpty()) {


### PR DESCRIPTION
## Summary
- Avoid showing loading state if product details are already cached

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2eaa91ce0832dbe03b224bc7528af