### PR TITLE
Refactor favorites view model to follow layered architecture

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/domain/usecases/ObserveFavoriteAppsUseCase.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/domain/usecases/ObserveFavoriteAppsUseCase.kt
@@ -1,0 +1,38 @@
+package com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases
+
+import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
+import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.usecases.FetchDeveloperAppsUseCase
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.RootError
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.flowOn
+
+/**
+ * Use case that combines the list of developer apps with the current set of
+ * favorites and emits only those apps that are marked as favorite.
+ */
+class ObserveFavoriteAppsUseCase(
+    private val fetchDeveloperAppsUseCase: FetchDeveloperAppsUseCase,
+    private val observeFavoritesUseCase: ObserveFavoritesUseCase,
+    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+) {
+    operator fun invoke(): Flow<DataState<List<AppInfo>, RootError>> {
+        return combine(
+            fetchDeveloperAppsUseCase().flowOn(ioDispatcher),
+            observeFavoritesUseCase()
+        ) { dataState, favorites ->
+            when (dataState) {
+                is DataState.Success -> {
+                    val apps = dataState.data.filter { favorites.contains(it.packageName) }
+                    DataState.Success(apps)
+                }
+                is DataState.Error -> dataState
+                is DataState.Loading -> DataState.Loading()
+            }
+        }.flowOn(ioDispatcher)
+    }
+}
+

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsViewModel.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsViewModel.kt
@@ -3,10 +3,10 @@ package com.d4rk.android.apps.apptoolkit.app.apps.favorites.ui
 import androidx.lifecycle.viewModelScope
 import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.actions.FavoriteAppsAction
 import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.actions.FavoriteAppsEvent
+import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases.ObserveFavoriteAppsUseCase
 import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases.ObserveFavoritesUseCase
 import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases.ToggleFavoriteUseCase
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.ui.UiHomeScreen
-import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.usecases.FetchDeveloperAppsUseCase
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState.Error
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState.IsLoading
@@ -16,110 +16,79 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.updateData
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.updateState
 import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
-import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
-import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.collect
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.filter
-import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.flatMapLatest
+import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.stateIn
-import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
 class FavoriteAppsViewModel(
-    private val fetchDeveloperAppsUseCase: FetchDeveloperAppsUseCase,
-    private val observeFavoritesUseCase: ObserveFavoritesUseCase,
+    private val observeFavoriteAppsUseCase: ObserveFavoriteAppsUseCase,
+    observeFavoritesUseCase: ObserveFavoritesUseCase,
     private val toggleFavoriteUseCase: ToggleFavoriteUseCase,
     private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
 ) : ScreenViewModel<UiHomeScreen, FavoriteAppsEvent, FavoriteAppsAction>(
     initialState = UiStateScreen(screenState = IsLoading(), data = UiHomeScreen())
 ) {
 
-    private val _favorites = MutableStateFlow<Set<String>>(emptySet())
-    private val favoritesLoaded = MutableStateFlow(false)
+    private val loadFavoritesTrigger = MutableSharedFlow<Unit>(replay = 1)
 
-    val favorites = _favorites.stateIn(
+    val favorites = flow { emitAll(observeFavoritesUseCase()) }.stateIn(
         scope = viewModelScope,
         started = SharingStarted.Eagerly,
         initialValue = emptySet()
     )
 
     init {
-        viewModelScope.launch(start = CoroutineStart.UNDISPATCHED) {
-            observeFavoritesUseCase()
-                .onEach {
-                    _favorites.value = it
-                    favoritesLoaded.value = true
-                }
-                .catch { e ->
-                    if (e is CancellationException) throw e
-                }
-                .collect()
-        }
+        viewModelScope.launch {
+            loadFavoritesTrigger
+                .flatMapLatest { observeFavoriteAppsUseCase().flowOn(ioDispatcher) }
+                .collect { result ->
+                    when (result) {
+                        is DataState.Success -> {
+                            val apps = result.data
+                            if (apps.isEmpty()) {
+                                screenState.update { current ->
+                                    current.copy(
+                                        screenState = NoData(),
+                                        data = UiHomeScreen(apps = emptyList())
+                                    )
+                                }
+                            } else {
+                                screenState.updateData(Success()) { current ->
+                                    current.copy(apps = apps)
+                                }
+                            }
+                        }
 
-        viewModelScope.launch(start = CoroutineStart.UNDISPATCHED) {
-            favoritesLoaded
-                .filter { it }
-                .first()
-            onEvent(FavoriteAppsEvent.LoadFavorites)
+                        is DataState.Loading -> screenState.updateState(IsLoading())
+
+                        is DataState.Error -> {
+                            screenState.update { current ->
+                                current.copy(screenState = Error("An error occurred"), data = null)
+                            }
+                        }
+                    }
+                }
         }
+        loadFavoritesTrigger.tryEmit(Unit)
     }
 
     override fun onEvent(event: FavoriteAppsEvent) {
         when (event) {
-            FavoriteAppsEvent.LoadFavorites -> loadFavorites()
-        }
-    }
-
-    private fun loadFavorites() {
-        viewModelScope.launch(start = CoroutineStart.UNDISPATCHED) {
-            combine(
-                flow = fetchDeveloperAppsUseCase().flowOn(ioDispatcher),
-                flow2 = favorites
-            ) { dataState, favsSet ->
-                dataState to favsSet
-            }.collect { (result, savedFavs) ->
-                when (result) {
-                    is DataState.Success -> {
-                        val apps = result.data.filter { appInfo -> savedFavs.contains(appInfo.packageName) }
-                        println("[ViewModel logic] Filtered apps size: ${apps.size}, savedFavs: $savedFavs, result.data size: ${result.data.size}")
-                        if (apps.isEmpty()) {
-                            screenState.update { current ->
-                                current.copy(screenState = NoData(), data = current.data?.copy(apps = emptyList()))
-                            }
-                        } else {
-                            screenState.updateData(Success()) { current ->
-                                current.copy(apps = apps)
-                            }
-                        }
-                    }
-
-                    is DataState.Loading -> {
-                        screenState.updateState(IsLoading())
-                    }
-
-                    is DataState.Error -> {
-                        screenState.update { current ->
-                            current.copy(screenState = Error("An error occurred"), data = null)
-                        }
-                    }
-                }
-            }
+            FavoriteAppsEvent.LoadFavorites -> loadFavoritesTrigger.tryEmit(Unit)
         }
     }
 
     fun toggleFavorite(packageName: String) {
         viewModelScope.launch(ioDispatcher) {
-            runCatching {
-                toggleFavoriteUseCase(packageName)
-            }
+            runCatching { toggleFavoriteUseCase(packageName) }
         }
     }
 }
+

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppModule.kt
@@ -6,6 +6,7 @@ import com.d4rk.android.apps.apptoolkit.R
 import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.repository.FavoritesRepository
 import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases.ObserveFavoritesUseCase
 import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases.ToggleFavoriteUseCase
+import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases.ObserveFavoriteAppsUseCase
 import com.d4rk.android.apps.apptoolkit.app.apps.favorites.ui.FavoriteAppsViewModel
 import com.d4rk.android.apps.apptoolkit.app.apps.list.data.repository.DeveloperAppsRepositoryImpl
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.repository.DeveloperAppsRepository
@@ -38,6 +39,7 @@ val appModule : Module = module {
     single<FavoritesRepository> { FavoritesRepositoryImpl(context = get(), dataStore = get(), ioDispatcher = get(named("io"))) }
     single { ObserveFavoritesUseCase(repository = get()) }
     single { ToggleFavoriteUseCase(repository = get()) }
+    single { ObserveFavoriteAppsUseCase(fetchDeveloperAppsUseCase = get(), observeFavoritesUseCase = get()) }
 
     single<List<String>>(qualifier = named(name = "startup_entries")) {
         get<Context>().resources.getStringArray(R.array.preference_startup_entries).toList()
@@ -64,7 +66,7 @@ val appModule : Module = module {
     }
     viewModel {
         FavoriteAppsViewModel(
-            fetchDeveloperAppsUseCase = get(),
+            observeFavoriteAppsUseCase = get(),
             observeFavoritesUseCase = get(),
             toggleFavoriteUseCase = get()
         )

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModelBase.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModelBase.kt
@@ -3,6 +3,7 @@ package com.d4rk.android.apps.apptoolkit.app.apps.favorites
 import androidx.lifecycle.viewModelScope
 import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases.ObserveFavoritesUseCase
 import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases.ToggleFavoriteUseCase
+import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases.ObserveFavoriteAppsUseCase
 import com.d4rk.android.apps.apptoolkit.app.apps.favorites.ui.FavoriteAppsViewModel
 import com.d4rk.android.apps.apptoolkit.app.apps.list.FakeDeveloperAppsRepository
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
@@ -28,8 +29,9 @@ open class TestFavoriteAppsViewModelBase {
         val favoritesRepository = FakeFavoritesRepository(initialFavorites, favoritesFlow, toggleError)
         val observeFavoritesUseCase = ObserveFavoritesUseCase(favoritesRepository)
         val toggleFavoriteUseCase = ToggleFavoriteUseCase(favoritesRepository)
+        val observeFavoriteAppsUseCase = ObserveFavoriteAppsUseCase(fetchUseCase, observeFavoritesUseCase)
         viewModel = FavoriteAppsViewModel(
-            fetchDeveloperAppsUseCase = fetchUseCase,
+            observeFavoriteAppsUseCase = observeFavoriteAppsUseCase,
             observeFavoritesUseCase = observeFavoritesUseCase,
             toggleFavoriteUseCase = toggleFavoriteUseCase,
         )


### PR DESCRIPTION
## Summary
- add ObserveFavoriteAppsUseCase to combine app and favorite data
- refactor FavoriteAppsViewModel to use new use case and load trigger
- wire up use case in DI and adjust tests

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b2f45a726c832d9ceded5714875283