### PR TITLE
Use expressive IconButton shapes

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/AppCard.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/AppCard.kt
@@ -45,8 +45,10 @@ import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.AppInfoHelper
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.IntentsHelper
 import kotlinx.coroutines.launch
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 
 @Composable
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 fun AppCard(
     appInfo: AppInfo,
     isFavorite: Boolean,

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/ui/components/ExpandableConsentSectionHeader.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/ui/components/ExpandableConsentSectionHeader.kt
@@ -27,7 +27,9 @@ import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.IconButton
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun ExpandableConsentSectionHeader(
     title: String,

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/buttons/AnimatedIconButtonDirection.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/buttons/AnimatedIconButtonDirection.kt
@@ -8,8 +8,10 @@ import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
 import androidx.compose.animation.slideInHorizontally
 import androidx.compose.animation.slideOutHorizontally
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.MutableState
@@ -45,6 +47,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
  *  AnimatedButtonDirection(
  *      modifier = Modifier.padding(16.dp),
  *      visible = is */
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun AnimatedIconButtonDirection(
     modifier: Modifier = Modifier,
@@ -85,7 +88,7 @@ fun AnimatedIconButtonDirection(
                 hapticFeedback.performHapticFeedback(hapticFeedbackType = HapticFeedbackType.ContextClick)
             }
             onClick()
-        }) {
+        }, shapes = IconButtonDefaults.shapes()) {
             Icon(imageVector = icon, contentDescription = contentDescription)
         }
     }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/buttons/IconButton.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/buttons/IconButton.kt
@@ -4,9 +4,12 @@ import android.view.SoundEffectConstants
 import android.view.View
 import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
+import androidx.compose.material3.IconButtonShapes
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.OutlinedIconButton
 import androidx.compose.material3.Text
@@ -22,6 +25,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.ButtonIconSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun IconButton(
     modifier: Modifier = Modifier,
@@ -29,16 +33,22 @@ fun IconButton(
     enabled: Boolean = true,
     iconContentDescription: String? = null,
     icon: ImageVector? = null,
-    painter: Painter? = null
+    painter: Painter? = null,
+    shapes: IconButtonShapes = IconButtonDefaults.shapes()
 ) {
-    val hapticFeedback : HapticFeedback = LocalHapticFeedback.current
-    val view : View = LocalView.current
+    val hapticFeedback: HapticFeedback = LocalHapticFeedback.current
+    val view: View = LocalView.current
 
-    IconButton(onClick = {
-        view.playSoundEffect(SoundEffectConstants.CLICK)
-        hapticFeedback.performHapticFeedback(hapticFeedbackType = HapticFeedbackType.ContextClick)
-        onClick()
-    }, enabled = enabled, modifier = modifier.bounceClick()) {
+    IconButton(
+        onClick = {
+            view.playSoundEffect(SoundEffectConstants.CLICK)
+            hapticFeedback.performHapticFeedback(hapticFeedbackType = HapticFeedbackType.ContextClick)
+            onClick()
+        },
+        enabled = enabled,
+        modifier = modifier.bounceClick(),
+        shapes = shapes
+    ) {
         icon?.let {
             Icon(
                 modifier = Modifier.size(size = SizeConstants.ButtonIconSize),
@@ -49,7 +59,8 @@ fun IconButton(
             Icon(
                 modifier = Modifier.size(size = SizeConstants.ButtonIconSize),
                 painter = it,
-                contentDescription = iconContentDescription)
+                contentDescription = iconContentDescription
+            )
         }
     }
 }
@@ -124,6 +135,7 @@ fun TonalIconButtonWithText(
     }
 }
 
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun OutlinedIconButton(
     modifier: Modifier = Modifier,
@@ -131,16 +143,22 @@ fun OutlinedIconButton(
     enabled: Boolean = true,
     iconContentDescription: String? = null,
     icon: ImageVector? = null,
-    painter: Painter? = null
+    painter: Painter? = null,
+    shapes: IconButtonShapes = IconButtonDefaults.shapes()
 ) {
-    val hapticFeedback : HapticFeedback = LocalHapticFeedback.current
-    val view : View = LocalView.current
+    val hapticFeedback: HapticFeedback = LocalHapticFeedback.current
+    val view: View = LocalView.current
 
-    OutlinedIconButton(onClick = {
-        view.playSoundEffect(SoundEffectConstants.CLICK)
-        hapticFeedback.performHapticFeedback(hapticFeedbackType = HapticFeedbackType.ContextClick)
-        onClick()
-    }, enabled = enabled, modifier = modifier.bounceClick()) {
+    OutlinedIconButton(
+        onClick = {
+            view.playSoundEffect(SoundEffectConstants.CLICK)
+            hapticFeedback.performHapticFeedback(hapticFeedbackType = HapticFeedbackType.ContextClick)
+            onClick()
+        },
+        enabled = enabled,
+        modifier = modifier.bounceClick(),
+        shapes = shapes
+    ) {
         icon?.let {
             Icon(
                 modifier = Modifier.size(size = SizeConstants.ButtonIconSize),
@@ -151,7 +169,8 @@ fun OutlinedIconButton(
             Icon(
                 modifier = Modifier.size(size = SizeConstants.ButtonIconSize),
                 painter = it,
-                contentDescription = iconContentDescription)
+                contentDescription = iconContentDescription
+            )
         }
     }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/buttons/IconButton.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/buttons/IconButton.kt
@@ -65,6 +65,86 @@ fun IconButton(
     }
 }
 
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun FilledIconButton(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+    enabled: Boolean = true,
+    iconContentDescription: String? = null,
+    icon: ImageVector? = null,
+    painter: Painter? = null,
+    shapes: IconButtonShapes = IconButtonDefaults.shapes()
+) {
+    val hapticFeedback: HapticFeedback = LocalHapticFeedback.current
+    val view: View = LocalView.current
+
+    androidx.compose.material3.FilledIconButton(
+        onClick = {
+            view.playSoundEffect(SoundEffectConstants.CLICK)
+            hapticFeedback.performHapticFeedback(hapticFeedbackType = HapticFeedbackType.ContextClick)
+            onClick()
+        },
+        enabled = enabled,
+        modifier = modifier.bounceClick(),
+        shapes = shapes
+    ) {
+        icon?.let {
+            Icon(
+                modifier = Modifier.size(size = SizeConstants.ButtonIconSize),
+                imageVector = it,
+                contentDescription = iconContentDescription
+            )
+        } ?: painter?.let {
+            Icon(
+                modifier = Modifier.size(size = SizeConstants.ButtonIconSize),
+                painter = it,
+                contentDescription = iconContentDescription
+            )
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@Composable
+fun FilledTonalIconButton(
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+    enabled: Boolean = true,
+    iconContentDescription: String? = null,
+    icon: ImageVector? = null,
+    painter: Painter? = null,
+    shapes: IconButtonShapes = IconButtonDefaults.shapes()
+) {
+    val hapticFeedback: HapticFeedback = LocalHapticFeedback.current
+    val view: View = LocalView.current
+
+    androidx.compose.material3.FilledTonalIconButton(
+        onClick = {
+            view.playSoundEffect(SoundEffectConstants.CLICK)
+            hapticFeedback.performHapticFeedback(hapticFeedbackType = HapticFeedbackType.ContextClick)
+            onClick()
+        },
+        enabled = enabled,
+        modifier = modifier.bounceClick(),
+        shapes = shapes
+    ) {
+        icon?.let {
+            Icon(
+                modifier = Modifier.size(size = SizeConstants.ButtonIconSize),
+                imageVector = it,
+                contentDescription = iconContentDescription
+            )
+        } ?: painter?.let {
+            Icon(
+                modifier = Modifier.size(size = SizeConstants.ButtonIconSize),
+                painter = it,
+                contentDescription = iconContentDescription
+            )
+        }
+    }
+}
+
 @Composable
 fun IconButtonWithText(
     modifier: Modifier = Modifier,

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/dialogs/BasicFullScreenDialog.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/dialogs/BasicFullScreenDialog.kt
@@ -14,6 +14,7 @@ import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.Close
 import androidx.compose.material3.CenterAlignedTopAppBar
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -30,7 +31,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.IconButton
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun BasicFullScreenDialog(title : String , onDismiss : () -> Unit , onConfirm : () -> Unit , confirmEnabled : Boolean = true , confirmButtonText : String = stringResource(id = android.R.string.ok) , content : @Composable ColumnScope.() -> Unit) {
     val hapticFeedback : HapticFeedback = LocalHapticFeedback.current

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/snackbar/DefaultSnackbarHost.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/snackbar/DefaultSnackbarHost.kt
@@ -6,8 +6,10 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Close
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
+import androidx.compose.material3.IconButtonDefaults
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarData
@@ -25,6 +27,7 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.CustomSnackbarVisua
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun DefaultSnackbarHost(snackbarState : SnackbarHostState , modifier : Modifier = Modifier) {
     val hapticFeedback : HapticFeedback = LocalHapticFeedback.current
@@ -41,7 +44,7 @@ fun DefaultSnackbarHost(snackbarState : SnackbarHostState , modifier : Modifier 
                         view.playSoundEffect(SoundEffectConstants.CLICK)
                         hapticFeedback.performHapticFeedback(hapticFeedbackType = HapticFeedbackType.ContextClick)
                         snackbarData.dismiss()
-                    }, modifier = modifier.bounceClick()) {
+                    }, modifier = modifier.bounceClick(), shapes = IconButtonDefaults.shapes()) {
                         Icon(
                             modifier = Modifier.size(size = SizeConstants.ButtonIconSize),
                             imageVector =  Icons.Outlined.Close,

--- a/docs/wiki/UI-Components.md
+++ b/docs/wiki/UI-Components.md
@@ -6,6 +6,9 @@ This page groups common Jetpack Compose components available in AppToolkit.
 
 Use buttons to trigger actions. Compose offers `Button`, `OutlinedButton`, and `IconButton`.
 
+`IconButton` in AppToolkit adopts Material 3's expressive shape morphing via `IconButtonDefaults.shapes()`,
+providing round-to-square transitions in response to interaction states.
+
 ```kotlin
 Button(onClick = { /* handle action */ }) {
     Text("Submit")

--- a/docs/wiki/UI-Components.md
+++ b/docs/wiki/UI-Components.md
@@ -6,8 +6,9 @@ This page groups common Jetpack Compose components available in AppToolkit.
 
 Use buttons to trigger actions. Compose offers `Button`, `OutlinedButton`, and `IconButton`.
 
-`IconButton` in AppToolkit adopts Material 3's expressive shape morphing via `IconButtonDefaults.shapes()`,
-providing round-to-square transitions in response to interaction states.
+AppToolkit wraps `IconButton`, `FilledIconButton`, `FilledTonalIconButton`, and `OutlinedIconButton` with
+Material 3's expressive shape morphing via `IconButtonDefaults.shapes()`, providing round-to-square
+transitions in response to interaction states.
 
 ```kotlin
 Button(onClick = { /* handle action */ }) {


### PR DESCRIPTION
## Summary
- adopt Material3 expressive shape-morphing for IconButton and OutlinedIconButton
- ensure custom animated buttons and snackbars use expressive IconButton shapes
- document expressive IconButton usage

## Testing
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b30bbbae64832d85e21c9b65466e59