### PR TITLE
Refine favorites and list ViewModels

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsViewModel.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsViewModel.kt
@@ -41,7 +41,7 @@ class FavoriteAppsViewModel(
 
     val favorites = flow { emitAll(observeFavoritesUseCase()) }.stateIn(
         scope = viewModelScope,
-        started = SharingStarted.Eagerly,
+        started = SharingStarted.WhileSubscribed(5_000),
         initialValue = emptySet()
     )
 
@@ -89,6 +89,12 @@ class FavoriteAppsViewModel(
     fun toggleFavorite(packageName: String) {
         viewModelScope.launch(ioDispatcher) {
             runCatching { toggleFavoriteUseCase(packageName) }
+                .onFailure { error ->
+                    error.printStackTrace()
+                    screenState.update { current ->
+                        current.copy(screenState = Error("Failed to update favorite"))
+                    }
+                }
         }
     }
 }

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListViewModel.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListViewModel.kt
@@ -99,7 +99,7 @@ class AppsListViewModel(
     }
 
     fun toggleFavorite(packageName: String) {
-        viewModelScope.launch {
+        viewModelScope.launch(ioDispatcher) {
             runCatching { toggleFavoriteUseCase(packageName) }
                 .onFailure { error ->
                     error.printStackTrace()

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModel.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModel.kt
@@ -27,7 +27,8 @@ class TestFavoriteAppsViewModel : TestFavoriteAppsViewModelBase() {
         setup(
             fetchApps = apps,
             initialFavorites = emptySet(),
-            toggleError = RuntimeException("fail")
+            toggleError = RuntimeException("fail"),
+            ioDispatcher = dispatcherExtension.testDispatcher,
         )
 
         viewModel.favorites.test {
@@ -49,7 +50,8 @@ class TestFavoriteAppsViewModel : TestFavoriteAppsViewModelBase() {
         )
         setup(
             fetchApps = apps,
-            initialFavorites = setOf("pkg1")
+            initialFavorites = setOf("pkg1"),
+            ioDispatcher = dispatcherExtension.testDispatcher,
         )
 
         viewModel.uiState.test {
@@ -66,7 +68,7 @@ class TestFavoriteAppsViewModel : TestFavoriteAppsViewModelBase() {
     @Test
     fun `toggle favorite updates favorites flow`() = runTest(dispatcherExtension.testDispatcher) {
         val apps = listOf(AppInfo("App", "pkg", "url"))
-        setup(fetchApps = apps)
+        setup(fetchApps = apps, ioDispatcher = dispatcherExtension.testDispatcher)
 
         viewModel.favorites.test {
             assertThat(awaitItem()).isEmpty()
@@ -81,7 +83,7 @@ class TestFavoriteAppsViewModel : TestFavoriteAppsViewModelBase() {
     @Test
     fun `load favorites with no saved apps shows no data`() = runTest(dispatcherExtension.testDispatcher) {
         val apps = listOf(AppInfo("App", "pkg", "url"))
-        setup(fetchApps = apps, initialFavorites = emptySet())
+        setup(fetchApps = apps, initialFavorites = emptySet(), ioDispatcher = dispatcherExtension.testDispatcher)
 
         viewModel.uiState.test {
             awaitItem() // Initial loading

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModelBase.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModelBase.kt
@@ -8,6 +8,8 @@ import com.d4rk.android.apps.apptoolkit.app.apps.favorites.ui.FavoriteAppsViewMo
 import com.d4rk.android.apps.apptoolkit.app.apps.list.FakeDeveloperAppsRepository
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.usecases.FetchDeveloperAppsUseCase
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
@@ -21,7 +23,8 @@ open class TestFavoriteAppsViewModelBase {
         fetchApps: List<AppInfo>,
         initialFavorites: Set<String> = emptySet(),
         favoritesFlow: Flow<Set<String>>? = null,
-        toggleError: Throwable? = null
+        toggleError: Throwable? = null,
+        ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
     ) {
         println("\uD83E\uDDEA [SETUP] Initial favorites: $initialFavorites")
         val developerAppsRepository = FakeDeveloperAppsRepository(fetchApps)
@@ -34,6 +37,7 @@ open class TestFavoriteAppsViewModelBase {
             observeFavoriteAppsUseCase = observeFavoriteAppsUseCase,
             observeFavoritesUseCase = observeFavoritesUseCase,
             toggleFavoriteUseCase = toggleFavoriteUseCase,
+            ioDispatcher = ioDispatcher,
         )
         println("\u2705 [SETUP] ViewModel initialized")
     }

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModel.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModel.kt
@@ -17,14 +17,14 @@ class TestAppsListViewModel : TestAppsListViewModelBase() {
     @Test
     fun `fetch apps - large list`() = runTest(dispatcherExtension.testDispatcher) {
         val apps = (1..10_000).map { AppInfo("App$it", "pkg$it", "url$it") }
-        setup(fetchApps = apps)
+        setup(fetchApps = apps, ioDispatcher = dispatcherExtension.testDispatcher)
         viewModel.uiState.testSuccess(expectedSize = apps.size)
     }
 
     @Test
     fun `toggle favorite updates state`() = runTest(dispatcherExtension.testDispatcher) {
         val apps = listOf(AppInfo("App", "pkg", "url"))
-        setup(fetchApps = apps)
+        setup(fetchApps = apps, ioDispatcher = dispatcherExtension.testDispatcher)
         toggleAndAssert(packageName = "pkg", expected = true)
         toggleAndAssert(packageName = "pkg", expected = false)
     }

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModelBase.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModelBase.kt
@@ -15,6 +15,8 @@ import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertTrue
 
@@ -28,6 +30,7 @@ open class TestAppsListViewModelBase {
         favoritesFlow: Flow<Set<String>>? = null,
         toggleError: Throwable? = null,
         fetchThrows: Throwable? = null,
+        ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
     ) {
         println("\uD83E\uDDEA [SETUP] Initial favorites: $initialFavorites")
         val developerAppsRepository = FakeDeveloperAppsRepository(fetchApps, fetchThrows)
@@ -35,7 +38,12 @@ open class TestAppsListViewModelBase {
         val favoritesRepository = FakeFavoritesRepository(initialFavorites, favoritesFlow, toggleError)
         val observeFavoritesUseCase = ObserveFavoritesUseCase(favoritesRepository)
         val toggleFavoriteUseCase = ToggleFavoriteUseCase(favoritesRepository)
-        viewModel = AppsListViewModel(fetchUseCase, observeFavoritesUseCase, toggleFavoriteUseCase)
+        viewModel = AppsListViewModel(
+            fetchUseCase,
+            observeFavoritesUseCase,
+            toggleFavoriteUseCase,
+            ioDispatcher,
+        )
         println("\u2705 [SETUP] ViewModel initialized")
     }
 


### PR DESCRIPTION
## Summary
- avoid eager sharing for favorites by using `WhileSubscribed`
- handle favorite toggle errors
- run favorite toggles on IO dispatcher

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `./gradlew lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b33620a3a8832db3de931897f1b0c5