### PR TITLE
refactor: hoist state for apps screens

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsScreen.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsScreen.kt
@@ -15,6 +15,7 @@ import com.d4rk.android.apps.apptoolkit.app.apps.list.ui.components.AppsList
 import com.d4rk.android.apps.apptoolkit.app.apps.list.ui.components.rememberAdsConfig
 import com.d4rk.android.apps.apptoolkit.app.apps.list.ui.components.rememberAdsEnabled
 import com.d4rk.android.apps.apptoolkit.app.apps.list.ui.components.screens.loading.HomeLoadingScreen
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.NoDataScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.ScreenStateHandler
@@ -23,7 +24,7 @@ import org.koin.compose.getKoin
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
-fun FavoriteAppsScreen(paddingValues: PaddingValues) {
+fun FavoriteAppsRoute(paddingValues: PaddingValues) {
     val viewModel: FavoriteAppsViewModel = koinViewModel()
     val screenState: UiStateScreen<UiHomeScreen> by viewModel.uiState.collectAsStateWithLifecycle()
     val favorites by viewModel.favorites.collectAsStateWithLifecycle()
@@ -33,7 +34,29 @@ fun FavoriteAppsScreen(paddingValues: PaddingValues) {
     val adsConfig = rememberAdsConfig(koin, isTabletOrLandscape)
     val adsEnabled = rememberAdsEnabled(koin)
     val onFavoriteToggle: (String) -> Unit = remember(viewModel) { { pkg -> viewModel.toggleFavorite(pkg) } }
+    val onRetry: () -> Unit = remember(viewModel) { { viewModel.onEvent(FavoriteAppsEvent.LoadFavorites) } }
 
+    FavoriteAppsScreen(
+        screenState = screenState,
+        favorites = favorites,
+        paddingValues = paddingValues,
+        adsConfig = adsConfig,
+        adsEnabled = adsEnabled,
+        onFavoriteToggle = onFavoriteToggle,
+        onRetry = onRetry
+    )
+}
+
+@Composable
+fun FavoriteAppsScreen(
+    screenState: UiStateScreen<UiHomeScreen>,
+    favorites: Set<String>,
+    paddingValues: PaddingValues,
+    adsConfig: AdsConfig,
+    adsEnabled: Boolean,
+    onFavoriteToggle: (String) -> Unit,
+    onRetry: () -> Unit,
+) {
     ScreenStateHandler(
         screenState = screenState,
         onLoading = { HomeLoadingScreen(paddingValues = paddingValues) },
@@ -56,7 +79,7 @@ fun FavoriteAppsScreen(paddingValues: PaddingValues) {
         onError = {
             NoDataScreen(
                 showRetry = true,
-                onRetry = { viewModel.onEvent(FavoriteAppsEvent.LoadFavorites) },
+                onRetry = onRetry,
                 isError = true
             )
         }

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListScreen.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListScreen.kt
@@ -12,6 +12,7 @@ import com.d4rk.android.apps.apptoolkit.app.apps.list.ui.components.AppsList
 import com.d4rk.android.apps.apptoolkit.app.apps.list.ui.components.rememberAdsConfig
 import com.d4rk.android.apps.apptoolkit.app.apps.list.ui.components.rememberAdsEnabled
 import com.d4rk.android.apps.apptoolkit.app.apps.list.ui.components.screens.loading.HomeLoadingScreen
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.NoDataScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.ScreenStateHandler
@@ -20,7 +21,7 @@ import org.koin.compose.getKoin
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable
-fun AppsListScreen(paddingValues: PaddingValues) {
+fun AppsListRoute(paddingValues: PaddingValues) {
     val viewModel: AppsListViewModel = koinViewModel()
     val screenState: UiStateScreen<UiHomeScreen> by viewModel.uiState.collectAsStateWithLifecycle()
     val favorites by viewModel.favorites.collectAsStateWithLifecycle()
@@ -29,14 +30,34 @@ fun AppsListScreen(paddingValues: PaddingValues) {
     val koin = getKoin()
     val adsConfig = rememberAdsConfig(koin, isTabletOrLandscape)
     val adsEnabled = rememberAdsEnabled(koin)
+    val onFavoriteToggle: (String) -> Unit = remember(viewModel) { { pkg -> viewModel.toggleFavorite(pkg) } }
+    val onRetry: () -> Unit = remember(viewModel) { { viewModel.onEvent(HomeEvent.FetchApps) } }
 
+    AppsListScreen(
+        screenState = screenState,
+        favorites = favorites,
+        paddingValues = paddingValues,
+        adsConfig = adsConfig,
+        adsEnabled = adsEnabled,
+        onFavoriteToggle = onFavoriteToggle,
+        onRetry = onRetry
+    )
+}
+
+@Composable
+fun AppsListScreen(
+    screenState: UiStateScreen<UiHomeScreen>,
+    favorites: Set<String>,
+    paddingValues: PaddingValues,
+    adsConfig: AdsConfig,
+    adsEnabled: Boolean,
+    onFavoriteToggle: (String) -> Unit,
+    onRetry: () -> Unit,
+) {
     ScreenStateHandler(
-        screenState = screenState, onLoading = {
-            HomeLoadingScreen(paddingValues = paddingValues)
-        },
-        onEmpty = {
-            NoDataScreen()
-        },
+        screenState = screenState,
+        onLoading = { HomeLoadingScreen(paddingValues = paddingValues) },
+        onEmpty = { NoDataScreen() },
         onSuccess = { uiHomeScreen ->
             AppsList(
                 uiHomeScreen = uiHomeScreen,
@@ -44,13 +65,15 @@ fun AppsListScreen(paddingValues: PaddingValues) {
                 paddingValues = paddingValues,
                 adsConfig = adsConfig,
                 adsEnabled = adsEnabled,
-                onFavoriteToggle = { pkg -> viewModel.toggleFavorite(pkg) }
+                onFavoriteToggle = onFavoriteToggle
             )
         },
         onError = {
-            NoDataScreen(showRetry = true, onRetry = {
-                viewModel.onEvent(HomeEvent.FetchApps)
-            }, isError = true)
+            NoDataScreen(
+                showRetry = true,
+                onRetry = onRetry,
+                isError = true
+            )
         }
     )
 }

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/components/navigation/AppNavigationHost.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/components/navigation/AppNavigationHost.kt
@@ -9,8 +9,8 @@ import androidx.compose.runtime.getValue
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.composable
-import com.d4rk.android.apps.apptoolkit.app.apps.favorites.ui.FavoriteAppsScreen
-import com.d4rk.android.apps.apptoolkit.app.apps.list.ui.AppsListScreen
+import com.d4rk.android.apps.apptoolkit.app.apps.favorites.ui.FavoriteAppsRoute
+import com.d4rk.android.apps.apptoolkit.app.apps.list.ui.AppsListRoute
 import com.d4rk.android.apps.apptoolkit.app.main.utils.constants.NavigationRoutes
 import com.d4rk.android.apps.apptoolkit.core.data.datastore.DataStore
 import com.d4rk.android.libs.apptoolkit.app.help.ui.HelpActivity
@@ -34,10 +34,10 @@ fun AppNavigationHost(
         navController = navController , startDestination = startupRoute.ifBlank { NavigationRoutes.ROUTE_APPS_LIST }
     ) {
         composable(route = NavigationRoutes.ROUTE_APPS_LIST) {
-            AppsListScreen(paddingValues = paddingValues)
+            AppsListRoute(paddingValues = paddingValues)
         }
         composable(route = NavigationRoutes.ROUTE_FAVORITE_APPS) {
-            FavoriteAppsScreen(paddingValues = paddingValues)
+            FavoriteAppsRoute(paddingValues = paddingValues)
         }
     }
 }


### PR DESCRIPTION
## Summary
- hoist state from list and favorites screens into route composables
- keep screen composables stateless and pass events up via callbacks
- update navigation host to use the new routes

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b34487853c832d98b23cacdea56f68