### PR TITLE
Refactor app interactions for composable architecture

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsScreen.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsScreen.kt
@@ -6,6 +6,7 @@ import androidx.compose.material.icons.outlined.Android
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.d4rk.android.apps.apptoolkit.R
@@ -23,6 +24,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.ScreenStateHa
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.AppInfoHelper
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.IntentsHelper
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.ScreenHelper
+import kotlinx.coroutines.launch
 import org.koin.compose.getKoin
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -39,15 +41,18 @@ fun FavoriteAppsRoute(paddingValues: PaddingValues) {
     val onFavoriteToggle: (String) -> Unit = remember(viewModel) { { pkg -> viewModel.toggleFavorite(pkg) } }
     val onRetry: () -> Unit = remember(viewModel) { { viewModel.onEvent(FavoriteAppsEvent.LoadFavorites) } }
     val appInfoHelper = remember { AppInfoHelper() }
-    val onAppClick: (AppInfo) -> Unit = remember(context) {
-        {
-            if (it.packageName.isNotEmpty()) {
-                if (appInfoHelper.isAppInstalled(context, it.packageName)) {
-                    if (!appInfoHelper.openApp(context, it.packageName)) {
-                        IntentsHelper.openPlayStoreForApp(context, it.packageName)
+    val coroutineScope = rememberCoroutineScope()
+    val onAppClick: (AppInfo) -> Unit = remember(context, coroutineScope) {
+        { appInfo ->
+            coroutineScope.launch {
+                if (appInfo.packageName.isNotEmpty()) {
+                    if (appInfoHelper.isAppInstalled(context, appInfo.packageName)) {
+                        if (!appInfoHelper.openApp(context, appInfo.packageName)) {
+                            IntentsHelper.openPlayStoreForApp(context, appInfo.packageName)
+                        }
+                    } else {
+                        IntentsHelper.openPlayStoreForApp(context, appInfo.packageName)
                     }
-                } else {
-                    IntentsHelper.openPlayStoreForApp(context, it.packageName)
                 }
             }
         }

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListScreen.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.actions.HomeEvent
@@ -20,6 +21,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.ScreenStateHa
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.AppInfoHelper
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.IntentsHelper
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.ScreenHelper
+import kotlinx.coroutines.launch
 import org.koin.compose.getKoin
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -36,15 +38,18 @@ fun AppsListRoute(paddingValues: PaddingValues) {
     val onFavoriteToggle: (String) -> Unit = remember(viewModel) { { pkg -> viewModel.toggleFavorite(pkg) } }
     val onRetry: () -> Unit = remember(viewModel) { { viewModel.onEvent(HomeEvent.FetchApps) } }
     val appInfoHelper = remember { AppInfoHelper() }
-    val onAppClick: (AppInfo) -> Unit = remember(context) {
-        {
-            if (it.packageName.isNotEmpty()) {
-                if (appInfoHelper.isAppInstalled(context, it.packageName)) {
-                    if (!appInfoHelper.openApp(context, it.packageName)) {
-                        IntentsHelper.openPlayStoreForApp(context, it.packageName)
+    val coroutineScope = rememberCoroutineScope()
+    val onAppClick: (AppInfo) -> Unit = remember(context, coroutineScope) {
+        { appInfo ->
+            coroutineScope.launch {
+                if (appInfo.packageName.isNotEmpty()) {
+                    if (appInfoHelper.isAppInstalled(context, appInfo.packageName)) {
+                        if (!appInfoHelper.openApp(context, appInfo.packageName)) {
+                            IntentsHelper.openPlayStoreForApp(context, appInfo.packageName)
+                        }
+                    } else {
+                        IntentsHelper.openPlayStoreForApp(context, appInfo.packageName)
                     }
-                } else {
-                    IntentsHelper.openPlayStoreForApp(context, it.packageName)
                 }
             }
         }

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/AppCard.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/AppCard.kt
@@ -1,8 +1,6 @@
 package com.d4rk.android.apps.apptoolkit.app.apps.list.ui.components
 
-import android.content.Context
 import android.view.SoundEffectConstants
-import android.view.View
 import androidx.compose.animation.animateContentSize
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
@@ -23,15 +21,12 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.font.FontWeight
@@ -43,9 +38,6 @@ import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.IconButton
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
-import com.d4rk.android.libs.apptoolkit.core.utils.helpers.AppInfoHelper
-import com.d4rk.android.libs.apptoolkit.core.utils.helpers.IntentsHelper
-import kotlinx.coroutines.launch
 
 @Composable
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
@@ -53,13 +45,12 @@ fun AppCard(
     appInfo: AppInfo,
     isFavorite: Boolean,
     onFavoriteToggle: () -> Unit,
+    onAppClick: (AppInfo) -> Unit,
+    onShareClick: (AppInfo) -> Unit,
     modifier: Modifier
 ) {
-    val context: Context = LocalContext.current
     val hapticFeedback: HapticFeedback = LocalHapticFeedback.current
-    val view: View = LocalView.current
-    val coroutineScope = rememberCoroutineScope()
-    val appInfoHelper = remember { AppInfoHelper() }
+    val view = LocalView.current
     Card(
         modifier = modifier
             .bounceClick()
@@ -69,31 +60,7 @@ fun AppCard(
             .clickable {
                 view.playSoundEffect(SoundEffectConstants.CLICK)
                 hapticFeedback.performHapticFeedback(hapticFeedbackType = HapticFeedbackType.ContextClick)
-                if (appInfo.packageName.isNotEmpty()) {
-                    coroutineScope.launch {
-                        if (appInfoHelper.isAppInstalled(
-                                context = context,
-                                packageName = appInfo.packageName
-                            )
-                        ) {
-                            if (!appInfoHelper.openApp(
-                                    context = context,
-                                    packageName = appInfo.packageName
-                                )
-                            ) {
-                                IntentsHelper.openPlayStoreForApp(
-                                    context = context,
-                                    packageName = appInfo.packageName
-                                )
-                            }
-                        } else {
-                            IntentsHelper.openPlayStoreForApp(
-                                context = context,
-                                packageName = appInfo.packageName
-                            )
-                        }
-                    }
-                }
+                onAppClick(appInfo)
             }) {
         Box(modifier = Modifier.fillMaxSize()) {
             Row(
@@ -106,13 +73,7 @@ fun AppCard(
                     iconContentDescription = null
                 )
                 IconButton(
-                    onClick = {
-                        IntentsHelper.shareApp(
-                            context = context,
-                            shareMessageFormat = com.d4rk.android.libs.apptoolkit.R.string.summary_share_message,
-                            packageName = appInfo.packageName
-                        )
-                    },
+                    onClick = { onShareClick(appInfo) },
                     icon = Icons.Outlined.Share,
                     iconContentDescription = null
                 )

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/AppsList.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/AppsList.kt
@@ -36,6 +36,8 @@ fun AppsList(
     adsConfig: AdsConfig,
     adsEnabled: Boolean,
     onFavoriteToggle: (String) -> Unit,
+    onAppClick: (AppInfo) -> Unit,
+    onShareClick: (AppInfo) -> Unit,
 ) {
     val apps: List<AppInfo> = uiHomeScreen.apps
     val context = LocalContext.current
@@ -58,7 +60,9 @@ fun AppsList(
         columnCount = columnCount,
         listState = listState,
         adsConfig = adsConfig,
-        onFavoriteToggle = onFavoriteToggle
+        onFavoriteToggle = onFavoriteToggle,
+        onAppClick = onAppClick,
+        onShareClick = onShareClick
     )
 }
 
@@ -70,7 +74,9 @@ private fun AppsGrid(
     columnCount: Int,
     listState: LazyGridState,
     adsConfig: AdsConfig,
-    onFavoriteToggle: (String) -> Unit
+    onFavoriteToggle: (String) -> Unit,
+    onAppClick: (AppInfo) -> Unit,
+    onShareClick: (AppInfo) -> Unit
 ) {
     val (visibilityStates: SnapshotStateList<Boolean>) = rememberAnimatedVisibilityStateForGrids(
         gridState = listState,
@@ -105,7 +111,9 @@ private fun AppsGrid(
                     isFavorite = favorites.contains(item.appInfo.packageName),
                     visibilityStates = visibilityStates,
                     index = index,
-                    onFavoriteToggle = onFavoriteToggle
+                    onFavoriteToggle = onFavoriteToggle,
+                    onAppClick = onAppClick,
+                    onShareClick = onShareClick
                 )
 
                 AppListItem.Ad -> AdListItem(adsConfig = adsConfig)
@@ -120,13 +128,17 @@ private fun AppCardItem(
     isFavorite: Boolean,
     visibilityStates: SnapshotStateList<Boolean>,
     index: Int,
-    onFavoriteToggle: (String) -> Unit
+    onFavoriteToggle: (String) -> Unit,
+    onAppClick: (AppInfo) -> Unit,
+    onShareClick: (AppInfo) -> Unit
 ) {
     val appInfo = item.appInfo
     AppCard(
         appInfo = appInfo,
         isFavorite = isFavorite,
         onFavoriteToggle = { onFavoriteToggle(appInfo.packageName) },
+        onAppClick = onAppClick,
+        onShareClick = onShareClick,
         modifier = Modifier.animateVisibility(
             visible = visibilityStates.getOrElse(index = index) { false },
             index = index


### PR DESCRIPTION
## Summary
- Refactor `AppCard` to surface app click and share callbacks instead of launching intents directly
- Propagate new callbacks through `AppsList` and list/favorites screens for cleaner layering

## Testing
- `./gradlew :app:testDebugUnitTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b34b4e0178832d927f4e27b0b8fd7f