### PR TITLE
refactor: derive orientation state from configuration

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsScreen.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsScreen.kt
@@ -4,9 +4,11 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Android
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.d4rk.android.apps.apptoolkit.R
@@ -34,7 +36,10 @@ fun FavoriteAppsRoute(paddingValues: PaddingValues) {
     val screenState: UiStateScreen<UiHomeScreen> by viewModel.uiState.collectAsStateWithLifecycle()
     val favorites by viewModel.favorites.collectAsStateWithLifecycle()
     val context = LocalContext.current
-    val isTabletOrLandscape = remember(context) { ScreenHelper.isLandscapeOrTablet(context) }
+    val configuration = LocalConfiguration.current
+    val isTabletOrLandscape by remember(configuration) {
+        derivedStateOf { ScreenHelper.isLandscapeOrTablet(context) }
+    }
     val koin = getKoin()
     val adsConfig = rememberAdsConfig(koin, isTabletOrLandscape)
     val adsEnabled = rememberAdsEnabled(koin)

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListScreen.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListScreen.kt
@@ -2,9 +2,11 @@ package com.d4rk.android.apps.apptoolkit.app.apps.list.ui
 
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.actions.HomeEvent
@@ -31,7 +33,10 @@ fun AppsListRoute(paddingValues: PaddingValues) {
     val screenState: UiStateScreen<UiHomeScreen> by viewModel.uiState.collectAsStateWithLifecycle()
     val favorites by viewModel.favorites.collectAsStateWithLifecycle()
     val context = LocalContext.current
-    val isTabletOrLandscape = remember(context) { ScreenHelper.isLandscapeOrTablet(context) }
+    val configuration = LocalConfiguration.current
+    val isTabletOrLandscape by remember(configuration) {
+        derivedStateOf { ScreenHelper.isLandscapeOrTablet(context) }
+    }
     val koin = getKoin()
     val adsConfig = rememberAdsConfig(koin, isTabletOrLandscape)
     val adsEnabled = rememberAdsEnabled(koin)

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/core/utils/dispatchers/StandardDispatcherExtension.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/core/utils/dispatchers/StandardDispatcherExtension.kt
@@ -12,9 +12,10 @@ import org.junit.jupiter.api.extension.ExtensionContext
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class StandardDispatcherExtension : BeforeEachCallback, AfterEachCallback {
-    val testDispatcher: TestDispatcher = StandardTestDispatcher()
+    lateinit var testDispatcher: TestDispatcher
 
     override fun beforeEach(context: ExtensionContext?) {
+        testDispatcher = StandardTestDispatcher()
         Dispatchers.setMain(testDispatcher)
     }
 

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/dispatchers/StandardDispatcherExtension.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/dispatchers/StandardDispatcherExtension.kt
@@ -12,9 +12,10 @@ import org.junit.jupiter.api.extension.ExtensionContext
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class StandardDispatcherExtension : BeforeEachCallback, AfterEachCallback {
-    val testDispatcher: TestDispatcher = StandardTestDispatcher()
+    lateinit var testDispatcher: TestDispatcher
 
     override fun beforeEach(context: ExtensionContext?) {
+        testDispatcher = StandardTestDispatcher()
         Dispatchers.setMain(testDispatcher)
     }
 


### PR DESCRIPTION
## Summary
- derive tablet/landscape flag from `LocalConfiguration` for app list screens

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b3688fa104832d92d4ede4a224c541