### PR TITLE
test: add flow unit tests

### DIFF
--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/settings/settings/utils/providers/PermissionsSettingsRepositoryTest.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/settings/settings/utils/providers/PermissionsSettingsRepositoryTest.kt
@@ -1,0 +1,29 @@
+package com.d4rk.android.apps.apptoolkit.app.settings.settings.utils.providers
+
+import android.content.Context
+import com.d4rk.android.apps.apptoolkit.app.settings.settings.utils.providers.PermissionsSettingsRepository
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class PermissionsSettingsRepositoryTest {
+
+    @Test
+    fun getPermissionsConfig_emitsExpectedStructure() = runTest {
+        val context = mockk<Context>()
+        every { context.getString(any()) } returns ""
+
+        val repository = PermissionsSettingsRepository(context, UnconfinedTestDispatcher(testScheduler))
+        val config = repository.getPermissionsConfig().first()
+
+        assertEquals(3, config.categories.size)
+        assertEquals(7, config.categories[0].preferences.size)
+        assertEquals(1, config.categories[1].preferences.size)
+        assertEquals(1, config.categories[2].preferences.size)
+    }
+}
+

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/settings/settings/utils/providers/PermissionsSettingsRepositoryTest.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/settings/settings/utils/providers/PermissionsSettingsRepositoryTest.kt
@@ -4,12 +4,14 @@ import android.content.Context
 import com.d4rk.android.apps.apptoolkit.app.settings.settings.utils.providers.PermissionsSettingsRepository
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class PermissionsSettingsRepositoryTest {
 
     @Test

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/core/data/favorites/FavoritesRepositoryImplTest.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/core/data/favorites/FavoritesRepositoryImplTest.kt
@@ -9,7 +9,6 @@ import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
 import io.mockk.mockkConstructor
-import io.mockk.Runs
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -41,7 +40,7 @@ class FavoritesRepositoryImplTest {
         justRun { context.sendBroadcast(any()) }
 
         mockkConstructor(Intent::class)
-        every { anyConstructed<Intent>().component = any() } just Runs
+        every { anyConstructed<Intent>().component = any() } returns Unit
         every { anyConstructed<Intent>().putExtra(any<String>(), any<String>()) } returns mockk()
 
         val dispatcher = UnconfinedTestDispatcher(testScheduler)

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/core/data/favorites/FavoritesRepositoryImplTest.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/core/data/favorites/FavoritesRepositoryImplTest.kt
@@ -1,11 +1,15 @@
 package com.d4rk.android.apps.apptoolkit.core.data.favorites
 
 import android.content.Context
+import android.content.Intent
 import app.cash.turbine.test
 import com.d4rk.android.apps.apptoolkit.core.data.datastore.DataStore
 import io.mockk.coEvery
 import io.mockk.every
+import io.mockk.justRun
 import io.mockk.mockk
+import io.mockk.mockkConstructor
+import io.mockk.Runs
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
@@ -34,6 +38,12 @@ class FavoritesRepositoryImplTest {
 
         val context = mockk<Context>(relaxed = true)
         every { context.packageName } returns "com.test"
+        justRun { context.sendBroadcast(any()) }
+
+        mockkConstructor(Intent::class)
+        every { anyConstructed<Intent>().component = any() } just Runs
+        every { anyConstructed<Intent>().putExtra(any<String>(), any<String>()) } returns mockk()
+
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val repository = FavoritesRepositoryImpl(context, dataStore, dispatcher)
 

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/core/data/favorites/FavoritesRepositoryImplTest.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/core/data/favorites/FavoritesRepositoryImplTest.kt
@@ -6,12 +6,14 @@ import com.d4rk.android.apps.apptoolkit.core.data.datastore.DataStore
 import io.mockk.coEvery
 import io.mockk.every
 import io.mockk.mockk
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Test
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class FavoritesRepositoryImplTest {
 
     @Test
@@ -31,6 +33,7 @@ class FavoritesRepositoryImplTest {
         }
 
         val context = mockk<Context>(relaxed = true)
+        every { context.packageName } returns "com.test"
         val dispatcher = UnconfinedTestDispatcher(testScheduler)
         val repository = FavoritesRepositoryImpl(context, dataStore, dispatcher)
 

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/core/data/favorites/FavoritesRepositoryImplTest.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/core/data/favorites/FavoritesRepositoryImplTest.kt
@@ -1,0 +1,51 @@
+package com.d4rk.android.apps.apptoolkit.core.data.favorites
+
+import android.content.Context
+import app.cash.turbine.test
+import com.d4rk.android.apps.apptoolkit.core.data.datastore.DataStore
+import io.mockk.coEvery
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class FavoritesRepositoryImplTest {
+
+    @Test
+    fun observeFavorites_emitsUpdatedSetOnToggle() = runTest {
+        val favoriteAppsFlow = MutableSharedFlow<Set<String>>(replay = 1)
+        favoriteAppsFlow.tryEmit(emptySet())
+
+        val dataStore = mockk<DataStore>()
+        every { dataStore.favoriteApps } returns favoriteAppsFlow
+        coEvery { dataStore.toggleFavoriteApp(any()) } coAnswers {
+            val pkg = firstArg<String>()
+            val current = favoriteAppsFlow.replayCache.firstOrNull()?.toMutableSet() ?: mutableSetOf()
+            if (!current.add(pkg)) {
+                current.remove(pkg)
+            }
+            favoriteAppsFlow.emit(current)
+        }
+
+        val context = mockk<Context>(relaxed = true)
+        val dispatcher = UnconfinedTestDispatcher(testScheduler)
+        val repository = FavoritesRepositoryImpl(context, dataStore, dispatcher)
+
+        repository.observeFavorites().test {
+            assertEquals(emptySet<String>(), awaitItem())
+
+            repository.toggleFavorite("pkg1")
+            assertEquals(setOf("pkg1"), awaitItem())
+
+            repository.toggleFavorite("pkg2")
+            assertEquals(setOf("pkg1", "pkg2"), awaitItem())
+
+            repository.toggleFavorite("pkg1")
+            assertEquals(setOf("pkg2"), awaitItem())
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add FavoritesRepositoryImpl test verifying flow updates on toggle
- add PermissionsSettingsRepository test ensuring flow emits expected categories

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b369830d5c832d91a714634e49e156