### PR TITLE
test: add MainViewModel tests

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsViewModel.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsViewModel.kt
@@ -18,6 +18,7 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.updateState
 import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.emitAll
@@ -28,6 +29,7 @@ import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 
+@OptIn(ExperimentalCoroutinesApi::class)
 class FavoriteAppsViewModel(
     private val observeFavoriteAppsUseCase: ObserveFavoriteAppsUseCase,
     observeFavoritesUseCase: ObserveFavoritesUseCase,

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainViewModelTest.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainViewModelTest.kt
@@ -1,0 +1,78 @@
+package com.d4rk.android.apps.apptoolkit.app.main.ui
+
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.dp
+import app.cash.turbine.test
+import com.d4rk.android.libs.apptoolkit.app.main.domain.repository.MainRepository
+import com.d4rk.android.libs.apptoolkit.core.domain.model.navigation.NavigationDrawerItem
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.flatMapConcat
+import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import kotlin.test.assertEquals
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class MainViewModelTest {
+
+    private class FakeMainRepository : MainRepository {
+        val itemsFlow = MutableSharedFlow<List<NavigationDrawerItem>>()
+        private val errorFlow = MutableSharedFlow<Throwable>()
+
+        override fun getNavigationDrawerItems(): Flow<List<NavigationDrawerItem>> =
+            merge(
+                itemsFlow,
+                errorFlow.flatMapConcat { throwable -> flow { throw throwable } }
+            )
+
+        suspend fun emitItems(items: List<NavigationDrawerItem>) {
+            itemsFlow.emit(items)
+        }
+
+        suspend fun emitError(throwable: Throwable) {
+            errorFlow.emit(throwable)
+        }
+    }
+
+    @Test
+    fun `emitting items updates navigation drawer items`() = runTest {
+        val repository = FakeMainRepository()
+        val viewModel = MainViewModel(repository)
+        val icon = ImageVector.Builder(
+            name = "test",
+            defaultWidth = 24.dp,
+            defaultHeight = 24.dp,
+            viewportWidth = 24f,
+            viewportHeight = 24f
+        ).build()
+        val items = listOf(NavigationDrawerItem(title = 1, selectedIcon = icon, route = "route"))
+
+        viewModel.uiState.test {
+            awaitItem() // initial state
+            repository.emitItems(items)
+            val updated = awaitItem()
+            assertEquals(items, updated.data?.navigationDrawerItems)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `emitting error shows snackbar`() = runTest {
+        val repository = FakeMainRepository()
+        val viewModel = MainViewModel(repository)
+        val error = RuntimeException("boom")
+
+        viewModel.uiState.test {
+            awaitItem() // initial state
+            repository.emitError(error)
+            val updated = awaitItem()
+            assertEquals(true, updated.data?.showSnackbar)
+            assertEquals("boom", updated.data?.snackbarMessage)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+}
+

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainViewModelTest.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainViewModelTest.kt
@@ -11,6 +11,7 @@ import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flatMapConcat
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 import kotlin.test.assertEquals
@@ -19,8 +20,8 @@ import kotlin.test.assertEquals
 class MainViewModelTest {
 
     private class FakeMainRepository : MainRepository {
-        val itemsFlow = MutableSharedFlow<List<NavigationDrawerItem>>()
-        private val errorFlow = MutableSharedFlow<Throwable>()
+        val itemsFlow = MutableSharedFlow<List<NavigationDrawerItem>>(replay = 1)
+        private val errorFlow = MutableSharedFlow<Throwable>(replay = 1)
 
         override fun getNavigationDrawerItems(): Flow<List<NavigationDrawerItem>> =
             merge(
@@ -41,6 +42,7 @@ class MainViewModelTest {
     fun `emitting items updates navigation drawer items`() = runTest {
         val repository = FakeMainRepository()
         val viewModel = MainViewModel(repository)
+        advanceUntilIdle()
         val icon = ImageVector.Builder(
             name = "test",
             defaultWidth = 24.dp,
@@ -63,6 +65,7 @@ class MainViewModelTest {
     fun `emitting error shows snackbar`() = runTest {
         val repository = FakeMainRepository()
         val viewModel = MainViewModel(repository)
+        advanceUntilIdle()
         val error = RuntimeException("boom")
 
         viewModel.uiState.test {


### PR DESCRIPTION
## Summary
- add fake MainRepository and MainViewModel tests
- verify navigation items and snackbar error with Turbine

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b36a6c4db4832d842cfe79ac80c212