### PR TITLE
Add tests for FavoriteAppsViewModel flow and error handling

### DIFF
--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/FavoriteAppsViewModelTest.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/FavoriteAppsViewModelTest.kt
@@ -1,0 +1,119 @@
+package com.d4rk.android.apps.apptoolkit.app.apps.favorites
+
+import app.cash.turbine.test
+import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases.ObserveFavoriteAppsUseCase
+import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases.ObserveFavoritesUseCase
+import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases.ToggleFavoriteUseCase
+import com.d4rk.android.apps.apptoolkit.app.apps.favorites.ui.FavoriteAppsViewModel
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.toList
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.RegisterExtension
+import com.d4rk.android.apps.apptoolkit.app.core.utils.dispatchers.StandardDispatcherExtension
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class FavoriteAppsViewModelTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val dispatcherExtension = StandardDispatcherExtension()
+    }
+
+    @Test
+    fun `favorites flow starts empty and updates`() = runTest(dispatcherExtension.testDispatcher) {
+        val observeFavorites = ObserveFavoritesUseCase()
+        val observeFavoriteApps = ObserveFavoriteAppsUseCase()
+        val toggleFavorite = ToggleFavoriteUseCase()
+        val viewModel = FavoriteAppsViewModel(
+            observeFavoriteAppsUseCase = observeFavoriteApps,
+            observeFavoritesUseCase = observeFavorites,
+            toggleFavoriteUseCase = toggleFavorite,
+            ioDispatcher = dispatcherExtension.testDispatcher,
+        )
+
+        viewModel.favorites.test {
+            assertThat(awaitItem()).isEmpty()
+            observeFavorites.flow.emit(setOf("pkg"))
+            assertThat(awaitItem()).containsExactly("pkg")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `screen state reflects DataState emissions`() = runTest(dispatcherExtension.testDispatcher) {
+        val observeFavorites = ObserveFavoritesUseCase()
+        val observeFavoriteApps = ObserveFavoriteAppsUseCase()
+        val toggleFavorite = ToggleFavoriteUseCase()
+        val viewModel = FavoriteAppsViewModel(
+            observeFavoriteAppsUseCase = observeFavoriteApps,
+            observeFavoritesUseCase = observeFavorites,
+            toggleFavoriteUseCase = toggleFavorite,
+            ioDispatcher = dispatcherExtension.testDispatcher,
+        )
+
+        viewModel.uiState.test {
+            assertThat(awaitItem().screenState).isInstanceOf(ScreenState.IsLoading::class.java)
+
+            observeFavoriteApps.flow.emit(DataState.Loading())
+            assertThat(awaitItem().screenState).isInstanceOf(ScreenState.IsLoading::class.java)
+
+            observeFavoriteApps.flow.emit(DataState.Error(error = Error("boom")))
+            assertThat(awaitItem().screenState).isInstanceOf(ScreenState.Error::class.java)
+
+            observeFavoriteApps.flow.emit(DataState.Success(emptyList()))
+            assertThat(awaitItem().screenState).isInstanceOf(ScreenState.NoData::class.java)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `toggle favorite failure updates screen state with error`() = runTest(dispatcherExtension.testDispatcher) {
+        val observeFavorites = ObserveFavoritesUseCase()
+        val observeFavoriteApps = ObserveFavoriteAppsUseCase()
+        val toggleFavorite = ToggleFavoriteUseCase().apply { shouldFail = RuntimeException("fail") }
+        val viewModel = FavoriteAppsViewModel(
+            observeFavoriteAppsUseCase = observeFavoriteApps,
+            observeFavoritesUseCase = observeFavorites,
+            toggleFavoriteUseCase = toggleFavorite,
+            ioDispatcher = dispatcherExtension.testDispatcher,
+        )
+
+        viewModel.uiState.test {
+            awaitItem() // initial loading
+            viewModel.toggleFavorite("pkg")
+            assertThat(awaitItem().screenState).isInstanceOf(ScreenState.Error::class.java)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `continuous favorites collection via background launch`() = runTest(dispatcherExtension.testDispatcher) {
+        val observeFavorites = ObserveFavoritesUseCase()
+        val observeFavoriteApps = ObserveFavoriteAppsUseCase()
+        val toggleFavorite = ToggleFavoriteUseCase()
+        val viewModel = FavoriteAppsViewModel(
+            observeFavoriteAppsUseCase = observeFavoriteApps,
+            observeFavoritesUseCase = observeFavorites,
+            toggleFavoriteUseCase = toggleFavorite,
+            ioDispatcher = dispatcherExtension.testDispatcher,
+        )
+
+        val collected = mutableListOf<Set<String>>()
+        val job = backgroundScope.launch { viewModel.favorites.toList(collected) }
+
+        observeFavorites.flow.emit(setOf("a"))
+        observeFavorites.flow.emit(setOf("a", "b"))
+
+        assertThat(collected[0]).isEmpty()
+        assertThat(collected[1]).containsExactly("a")
+        assertThat(collected[2]).containsExactly("a", "b")
+
+        job.cancel()
+    }
+}

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/domain/usecases/ObserveFavoriteAppsUseCase.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/domain/usecases/ObserveFavoriteAppsUseCase.kt
@@ -1,0 +1,12 @@
+package com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases
+
+import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.RootError
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+
+class ObserveFavoriteAppsUseCase {
+    val flow = MutableSharedFlow<DataState<List<AppInfo>, RootError>>()
+    suspend operator fun invoke(): Flow<DataState<List<AppInfo>, RootError>> = flow
+}

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/domain/usecases/ObserveFavoritesUseCase.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/domain/usecases/ObserveFavoritesUseCase.kt
@@ -1,0 +1,9 @@
+package com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+
+class ObserveFavoritesUseCase {
+    val flow = MutableSharedFlow<Set<String>>(replay = 1)
+    suspend operator fun invoke(): Flow<Set<String>> = flow
+}

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/domain/usecases/ToggleFavoriteUseCase.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/domain/usecases/ToggleFavoriteUseCase.kt
@@ -1,0 +1,12 @@
+package com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases
+
+import kotlinx.coroutines.flow.MutableSharedFlow
+
+class ToggleFavoriteUseCase {
+    val toggles = MutableSharedFlow<String>()
+    var shouldFail: Throwable? = null
+    suspend operator fun invoke(pkg: String) {
+        toggles.emit(pkg)
+        shouldFail?.let { throw it }
+    }
+}


### PR DESCRIPTION
## Summary
- add fakes for favorite-apps use cases backed by MutableSharedFlow
- verify FavoriteAppsViewModel favorites stream and screen-state transitions with Turbine
- cover toggle-favorite error path and continuous collection scenario

## Testing
- `./gradlew :app:testDebugUnitTest --tests com.d4rk.android.apps.apptoolkit.app.apps.favorites.FavoriteAppsViewModelTest` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b4026f2e10832d966ab1009ba21f16