### PR TITLE
Normalize string capitalization

### DIFF
--- a/apptoolkit/src/main/res/values-de-rDE/strings.xml
+++ b/apptoolkit/src/main/res/values-de-rDE/strings.xml
@@ -41,7 +41,7 @@
     <string name="consent_ad_personalization_description_short">Ermöglicht personalisierte Werbung.</string>
     <string name="onboarding_crashlytics_show_details_button">Detaillierte informationen anzeigen</string>
     <string name="onboarding_crashlytics_show_details_button_cd">Detaillierte Informationen zu Nutzung und Diagnose anzeigen</string>
-    <string name="button_acknowledge_consents">Speichern und Fortfahren</string>
+    <string name="button_acknowledge_consents">Speichern und fortfahren</string>
     <string name="button_continue">Fortfahren</string>
     <string name="onboarding_complete_icon_desc">Onboarding abgeschlossen</string>
     <string name="onboarding_final_title">Alles ist bereit!</string>
@@ -280,7 +280,7 @@
     <string name="support_us">Unterstützen sie uns</string>
     <string name="paid_support">Bezahlte unterstützung</string>
     <string name="summary_donations">Unabhängig vom Betrag Ihrer Spende helfen Sie uns, die App am Laufen zu halten und die Funktionen zu verbessern. Vielen Dank für Ihre Großzügigkeit!</string>
-    <string name="non_paid_support">Unbezahlte Unterstützung</string>
+    <string name="non_paid_support">Unbezahlte unterstützung</string>
     <string name="web_ad">Webanzeige</string>
     <string name="error_failed_to_load_sku_details">Fehler beim Laden der SKU-Details</string>
     <string name="purchase_pending">Ihre Spende wird von Google verarbeitet. Wir werden Sie benachrichtigen, wenn es abgeschlossen ist. Danke schön!</string>

--- a/apptoolkit/src/main/res/values-es-rGQ/strings.xml
+++ b/apptoolkit/src/main/res/values-es-rGQ/strings.xml
@@ -41,7 +41,7 @@
     <string name="consent_ad_personalization_description_short">Habilita la publicidad personalizada.</string>
     <string name="onboarding_crashlytics_show_details_button">Mostrar información detallada</string>
     <string name="onboarding_crashlytics_show_details_button_cd">Mostrar información detallada sobre el uso y los diagnósticos</string>
-    <string name="button_acknowledge_consents">Guardar y Continuar</string>
+    <string name="button_acknowledge_consents">Guardar y continuar</string>
     <string name="button_continue">Continuar</string>
     <string name="onboarding_complete_icon_desc">Proceso de incorporación completado</string>
     <string name="onboarding_final_title">¡todo listo!</string>

--- a/apptoolkit/src/main/res/values-es-rMX/strings.xml
+++ b/apptoolkit/src/main/res/values-es-rMX/strings.xml
@@ -7,7 +7,7 @@
     <string name="default_notification_summary">Hay muchas funciones esperándote. ¡Abre la aplicación!</string>
 
     <string name="welcome">Bienvenido</string>
-    <string name="summary_browse_terms_of_service_and_privacy_policy">Lee y acepta nuestros Términos de Servicio y Política de Privacidad para continuar</string>
+    <string name="summary_browse_terms_of_service_and_privacy_policy">Lee y acepta nuestros Términos de servicio y Política de Privacidad para continuar</string>
     <string name="agree">Aceptar</string>
     <string name="error_loading_consent_info">Error al cargar la información de consentimiento</string>
     <string name="loading">Cargando…</string>
@@ -165,9 +165,9 @@
     <string name="privacy">Privacidad</string>
     <string name="privacy_policy">Política de privacidad</string>
     <string name="summary_preference_settings_privacy_policy">Consulta la política que rige cómo manejamos tus datos</string>
-    <string name="terms_of_service">Términos de Servicio</string>
+    <string name="terms_of_service">Términos de servicio</string>
     <string name="summary_preference_settings_terms_of_service">Revisa los términos que aceptas al usar nuestro servicio</string>
-    <string name="code_of_conduct">Código de Conducta</string>
+    <string name="code_of_conduct">Código de conducta</string>
     <string name="summary_preference_settings_code_of_conduct">Comprende las reglas y directrices de comportamiento dentro de nuestro servicio</string>
 
     <string name="permissions">Permisos</string>

--- a/apptoolkit/src/main/res/values-fil-rPH/strings.xml
+++ b/apptoolkit/src/main/res/values-fil-rPH/strings.xml
@@ -7,7 +7,7 @@
     <string name="default_notification_summary">Napakaraming feature ang naghihintay sa iyo. Buksan ang app!</string>
 
     <string name="welcome">Maligayang pagdating</string>
-    <string name="summary_browse_terms_of_service_and_privacy_policy">Basahin at sumang-ayon sa aming Mga Tuntunin ng Serbisyo at Patakaran sa Privacy upang magpatuloy</string>
+    <string name="summary_browse_terms_of_service_and_privacy_policy">Basahin at sumang-ayon sa aming Mga tuntunin ng serbisyo at Patakaran sa Privacy upang magpatuloy</string>
     <string name="agree">Sumang-ayon</string>
     <string name="error_loading_consent_info">Nabigong i-load ang impormasyon ng pahintulot</string>
     <string name="loading">Naglo-load…</string>
@@ -41,7 +41,7 @@
     <string name="consent_ad_personalization_description_short">Pinapagana ang personalized na advertising.</string>
     <string name="onboarding_crashlytics_show_details_button">Ipakita ang detalyadong impormasyon</string>
     <string name="onboarding_crashlytics_show_details_button_cd">Ipakita ang detalyadong impormasyon tungkol sa paggamit at diagnostics</string>
-    <string name="button_acknowledge_consents">I-save at Magpatuloy</string>
+    <string name="button_acknowledge_consents">I-save at magpatuloy</string>
     <string name="button_continue">Magpatuloy</string>
     <string name="onboarding_complete_icon_desc">Kumpleto na ang onboarding</string>
     <string name="onboarding_final_title">Handa ka na!</string>
@@ -165,9 +165,9 @@
     <string name="privacy">Pribasya</string>
     <string name="privacy_policy">Patakaran sa privacy</string>
     <string name="summary_preference_settings_privacy_policy">Tingnan ang patakaran na namamahala kung paano namin hinahawakan ang iyong data</string>
-    <string name="terms_of_service">Mga Tuntunin ng Serbisyo</string>
+    <string name="terms_of_service">Mga tuntunin ng serbisyo</string>
     <string name="summary_preference_settings_terms_of_service">Suriin ang mga tuntunin na sinasang-ayunan mo kapag ginagamit ang aming serbisyo</string>
-    <string name="code_of_conduct">Kodigo ng Pag-uugali</string>
+    <string name="code_of_conduct">Kodigo ng pag-uugali</string>
     <string name="summary_preference_settings_code_of_conduct">Unawain ang mga patakaran at alituntunin para sa pag-uugali sa loob ng aming serbisyo</string>
 
     <string name="permissions">Mga Pahintulot</string>
@@ -280,7 +280,7 @@
     <string name="support_us">Suportahan kami</string>
     <string name="paid_support">Bayad na suporta</string>
     <string name="summary_donations">Gaano man kalaki ang iyong ido-donate, matutulungan mo kaming panatilihing tumatakbo ang aming app at mapabuti ang aming mga feature. Pinahahalagahan namin ang iyong kabutihang-loob at kabaitan!</string>
-    <string name="non_paid_support">Hindi Bayad na Suporta</string>
+    <string name="non_paid_support">Hindi bayad na suporta</string>
     <string name="web_ad">Web ad</string>
     <string name="error_failed_to_load_sku_details">Nabigong i-load ang mga detalye ng SKU</string>
     <string name="purchase_pending">Ang iyong donasyon ay pinoproseso ng Google. Sasabihan ka namin kapag kumpleto na ito. Salamat!</string>

--- a/apptoolkit/src/main/res/values-in-rID/strings.xml
+++ b/apptoolkit/src/main/res/values-in-rID/strings.xml
@@ -7,7 +7,7 @@
     <string name="default_notification_summary">Ada banyak fitur yang menunggu Anda. Buka aplikasinya!</string>
 
     <string name="welcome">Selamat datang</string>
-    <string name="summary_browse_terms_of_service_and_privacy_policy">Baca dan setujui Ketentuan Layanan dan Kebijakan Privasi kami untuk melanjutkan</string>
+    <string name="summary_browse_terms_of_service_and_privacy_policy">Baca dan setujui Ketentuan layanan dan Kebijakan Privasi kami untuk melanjutkan</string>
     <string name="agree">Setuju</string>
     <string name="error_loading_consent_info">Gagal memuat informasi persetujuan</string>
     <string name="loading">Memuat…</string>
@@ -41,7 +41,7 @@
     <string name="consent_ad_personalization_description_short">Mengaktifkan iklan yang dipersonalisasi.</string>
     <string name="onboarding_crashlytics_show_details_button">Tampilkan informasi detail</string>
     <string name="onboarding_crashlytics_show_details_button_cd">Tampilkan informasi detail tentang penggunaan dan diagnostik</string>
-    <string name="button_acknowledge_consents">Simpan dan Lanjutkan</string>
+    <string name="button_acknowledge_consents">Simpan dan lanjutkan</string>
     <string name="button_continue">Lanjutkan</string>
     <string name="onboarding_complete_icon_desc">Orientasi selesai</string>
     <string name="onboarding_final_title">Anda siap!</string>
@@ -165,9 +165,9 @@
     <string name="privacy">Privasi</string>
     <string name="privacy_policy">Kebijakan privasi</string>
     <string name="summary_preference_settings_privacy_policy">Lihat kebijakan yang mengatur bagaimana kami menangani data Anda</string>
-    <string name="terms_of_service">Ketentuan Layanan</string>
+    <string name="terms_of_service">Ketentuan layanan</string>
     <string name="summary_preference_settings_terms_of_service">Tinjau ketentuan yang Anda setujui saat menggunakan layanan kami</string>
-    <string name="code_of_conduct">Kode Etik</string>
+    <string name="code_of_conduct">Kode etik</string>
     <string name="summary_preference_settings_code_of_conduct">Pahami aturan dan pedoman perilaku dalam layanan kami</string>
 
     <string name="permissions">Izin</string>

--- a/apptoolkit/src/main/res/values-it-rIT/strings.xml
+++ b/apptoolkit/src/main/res/values-it-rIT/strings.xml
@@ -7,7 +7,7 @@
     <string name="default_notification_summary">Ci sono molte funzionalità che ti aspettano. Apri l\'app!</string>
 
     <string name="welcome">Benvenuto</string>
-    <string name="summary_browse_terms_of_service_and_privacy_policy">Leggi e accetta i nostri Termini di Servizio e la Politica sulla Privacy per continuare</string>
+    <string name="summary_browse_terms_of_service_and_privacy_policy">Leggi e accetta i nostri Termini di servizio e la Politica sulla Privacy per continuare</string>
     <string name="agree">Accetto</string>
     <string name="error_loading_consent_info">Caricamento delle informazioni sul consenso non riuscito</string>
     <string name="loading">Caricamento…</string>
@@ -165,9 +165,9 @@
     <string name="privacy">Privacy</string>
     <string name="privacy_policy">Politica sulla privacy</string>
     <string name="summary_preference_settings_privacy_policy">Visualizza la politica che regola come trattiamo i tuoi dati</string>
-    <string name="terms_of_service">Termini di Servizio</string>
+    <string name="terms_of_service">Termini di servizio</string>
     <string name="summary_preference_settings_terms_of_service">Esamina i termini che accetti utilizzando il nostro servizio</string>
-    <string name="code_of_conduct">Codice di Condotta</string>
+    <string name="code_of_conduct">Codice di condotta</string>
     <string name="summary_preference_settings_code_of_conduct">Comprendi le regole di comportamento previste dal nostro servizio</string>
 
     <string name="permissions">Permessi</string>

--- a/apptoolkit/src/main/res/values-pt-rBR/strings.xml
+++ b/apptoolkit/src/main/res/values-pt-rBR/strings.xml
@@ -7,7 +7,7 @@
     <string name="default_notification_summary">Há muitos recursos esperando por você. Abra o aplicativo!</string>
 
     <string name="welcome">Bem-vindo</string>
-    <string name="summary_browse_terms_of_service_and_privacy_policy">Leia e concorde com nossos Termos de Serviço e Política de Privacidade para continuar</string>
+    <string name="summary_browse_terms_of_service_and_privacy_policy">Leia e concorde com nossos Termos de serviço e Política de Privacidade para continuar</string>
     <string name="agree">Concordo</string>
     <string name="error_loading_consent_info">Falha ao carregar as informações de consentimento</string>
     <string name="loading">Carregando…</string>
@@ -41,7 +41,7 @@
     <string name="consent_ad_personalization_description_short">Ativa publicidade personalizada.</string>
     <string name="onboarding_crashlytics_show_details_button">Mostrar informações detalhadas</string>
     <string name="onboarding_crashlytics_show_details_button_cd">Mostrar informações detalhadas sobre uso e diagnósticos</string>
-    <string name="button_acknowledge_consents">Salvar e Continuar</string>
+    <string name="button_acknowledge_consents">Salvar e continuar</string>
     <string name="button_continue">Continuar</string>
     <string name="onboarding_complete_icon_desc">Onboarding concluído</string>
     <string name="onboarding_final_title">Está tudo pronto!</string>
@@ -165,9 +165,9 @@
     <string name="privacy">Privacidade</string>
     <string name="privacy_policy">Política de privacidade</string>
     <string name="summary_preference_settings_privacy_policy">Veja a política que rege o tratamento dos seus dados</string>
-    <string name="terms_of_service">Termos de Serviço</string>
+    <string name="terms_of_service">Termos de serviço</string>
     <string name="summary_preference_settings_terms_of_service">Revise os termos que você aceita ao usar nosso serviço</string>
-    <string name="code_of_conduct">Código de Conduta</string>
+    <string name="code_of_conduct">Código de conduta</string>
     <string name="summary_preference_settings_code_of_conduct">Compreenda as regras e diretrizes de comportamento dentro do nosso serviço</string>
 
     <string name="permissions">Permissões</string>

--- a/apptoolkit/src/main/res/values-ro-rRO/strings.xml
+++ b/apptoolkit/src/main/res/values-ro-rRO/strings.xml
@@ -165,9 +165,9 @@
     <string name="privacy">Confidențialitate</string>
     <string name="privacy_policy">Politica de confidențialitate</string>
     <string name="summary_preference_settings_privacy_policy">Vezi politica care reglementează modul în care gestionăm datele tale</string>
-    <string name="terms_of_service">Termeni de Serviciu</string>
+    <string name="terms_of_service">Termeni de serviciu</string>
     <string name="summary_preference_settings_terms_of_service">Revizuiește termenii pe care îi accepți utilizând serviciul nostru</string>
-    <string name="code_of_conduct">Cod de Conduită</string>
+    <string name="code_of_conduct">Cod de conduită</string>
     <string name="summary_preference_settings_code_of_conduct">Înțelege regulile și liniile directoare pentru comportament în cadrul serviciului nostru</string>
 
     <string name="permissions">Permisiuni</string>

--- a/apptoolkit/src/main/res/values-tr-rTR/strings.xml
+++ b/apptoolkit/src/main/res/values-tr-rTR/strings.xml
@@ -7,7 +7,7 @@
     <string name="default_notification_summary">Sizi bekleyen birçok özellik var. Uygulamayı açın!</string>
 
     <string name="welcome">Hoş geldiniz</string>
-    <string name="summary_browse_terms_of_service_and_privacy_policy">Devam etmek için Hizmet Şartlarımızı ve Gizlilik Politikamızı okuyun ve kabul edin</string>
+    <string name="summary_browse_terms_of_service_and_privacy_policy">Devam etmek için Hizmet şartlarımızı ve Gizlilik Politikamızı okuyun ve kabul edin</string>
     <string name="agree">Kabul et</string>
     <string name="error_loading_consent_info">Onay bilgileri yüklenemedi</string>
     <string name="loading">Yükleniyor…</string>
@@ -41,7 +41,7 @@
     <string name="consent_ad_personalization_description_short">Kişiselleştirilmiş reklamları etkinleştirir.</string>
     <string name="onboarding_crashlytics_show_details_button">Ayrıntılı bilgileri göster</string>
     <string name="onboarding_crashlytics_show_details_button_cd">Kullanım ve tanılama hakkında ayrıntılı bilgileri göster</string>
-    <string name="button_acknowledge_consents">Kaydet ve Devam Et</string>
+    <string name="button_acknowledge_consents">Kaydet ve devam et</string>
     <string name="button_continue">Devam Et</string>
     <string name="onboarding_complete_icon_desc">Başlangıç tamamlandı</string>
     <string name="onboarding_final_title">Her şey hazır!</string>
@@ -165,9 +165,9 @@
     <string name="privacy">Gizlilik</string>
     <string name="privacy_policy">Gizlilik politikası</string>
     <string name="summary_preference_settings_privacy_policy">Verilerinizi nasıl ele aldığımızı açıklayan politikayı görüntüleyin</string>
-    <string name="terms_of_service">Hizmet Şartları</string>
+    <string name="terms_of_service">Hizmet şartları</string>
     <string name="summary_preference_settings_terms_of_service">Hizmetimizi kullanırken kabul ettiğiniz şartları gözden geçirin</string>
-    <string name="code_of_conduct">Davranış Kuralları</string>
+    <string name="code_of_conduct">Davranış kuralları</string>
     <string name="summary_preference_settings_code_of_conduct">Hizmetimizdeki davranış kurallarını ve yönergelerini anlayın</string>
 
     <string name="permissions">İzinler</string>

--- a/apptoolkit/src/main/res/values-vi-rVN/strings.xml
+++ b/apptoolkit/src/main/res/values-vi-rVN/strings.xml
@@ -41,7 +41,7 @@
     <string name="consent_ad_personalization_description_short">Bật quảng cáo được cá nhân hóa.</string>
     <string name="onboarding_crashlytics_show_details_button">Hiển thị thông tin chi tiết</string>
     <string name="onboarding_crashlytics_show_details_button_cd">Hiển thị thông tin chi tiết về việc sử dụng và chẩn đoán</string>
-    <string name="button_acknowledge_consents">Lưu và Tiếp tục</string>
+    <string name="button_acknowledge_consents">Lưu và tiếp tục</string>
     <string name="button_continue">Tiếp tục</string>
     <string name="onboarding_complete_icon_desc">Hoàn tất giới thiệu</string>
     <string name="onboarding_final_title">Bạn đã sẵn sàng!</string>

--- a/apptoolkit/src/main/res/values/strings.xml
+++ b/apptoolkit/src/main/res/values/strings.xml
@@ -7,7 +7,7 @@
     <string name="default_notification_summary">There are so many features waiting for you. Open the app!</string>
 
     <string name="welcome">Welcome</string>
-    <string name="summary_browse_terms_of_service_and_privacy_policy">Read and agree to our Terms of Service and Privacy Policy to continue</string>
+    <string name="summary_browse_terms_of_service_and_privacy_policy">Read and agree to our Terms of service and Privacy Policy to continue</string>
     <string name="agree">Agree</string>
     <string name="error_loading_consent_info">Failed to load consent information</string>
 
@@ -41,7 +41,7 @@
     <string name="consent_ad_personalization_description_short">Enables personalized advertising.</string>
     <string name="onboarding_crashlytics_show_details_button">Show detailed information</string>
     <string name="onboarding_crashlytics_show_details_button_cd">Show detailed information about usage and diagnostics</string>
-    <string name="button_acknowledge_consents">Save and Continue</string>
+    <string name="button_acknowledge_consents">Save and continue</string>
     <string name="button_continue">Continue</string>
     <string name="onboarding_complete_icon_desc">Onboarding complete</string>
     <string name="onboarding_final_title">You\'re all set!</string>
@@ -168,9 +168,9 @@
     <string name="privacy">Privacy</string>
     <string name="privacy_policy">Privacy policy</string>
     <string name="summary_preference_settings_privacy_policy">View the policy that governs how we handle your data</string>
-    <string name="terms_of_service">Terms of Service</string>
+    <string name="terms_of_service">Terms of service</string>
     <string name="summary_preference_settings_terms_of_service">Review the terms you agree to when using our service</string>
-    <string name="code_of_conduct">Code of Conduct</string>
+    <string name="code_of_conduct">Code of conduct</string>
     <string name="summary_preference_settings_code_of_conduct">Understand the rules and guidelines for behavior within our service</string>
 
     <string name="permissions">Permissions</string>
@@ -283,7 +283,7 @@
     <string name="support_us">Support us</string>
     <string name="paid_support">Paid support</string>
     <string name="summary_donations">No matter how much you donate, you will help us keep our app running and improve our features. We appreciate your generosity and kindness!</string>
-    <string name="non_paid_support">Non-Paid Support</string>
+    <string name="non_paid_support">Non-paid support</string>
     <string name="web_ad">Web ad</string>
     <string name="error_failed_to_load_sku_details">Failed to load SKU details</string>
     <string name="purchase_pending">Your donation is being processed by Google. We will notify you when it\'s complete. Thank you!</string>


### PR DESCRIPTION
## Summary
- Normalize capitalization for core onboarding and settings strings
- Apply sentence casing across localized string resources

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b561c2b150832d97b6a4afe10db3ee