### PR TITLE
feat(ads): use compose-based native ad banner

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/AppsList.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/AppsList.kt
@@ -150,7 +150,6 @@ private fun AppCardItem(
 private fun AdListItem(adsConfig: AdsConfig) {
     NativeAdBanner(
         modifier = Modifier.fillMaxWidth(),
-        adsConfig = adsConfig
     )
 }
 

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/AppsList.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/AppsList.kt
@@ -22,7 +22,7 @@ import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppListItem
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.ui.UiHomeScreen
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
-import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.AdBanner
+import com.d4rk.android.apps.apptoolkit.core.ads.ui.NativeAdBanner
 import com.d4rk.android.libs.apptoolkit.core.ui.components.animations.rememberAnimatedVisibilityStateForGrids
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.animateVisibility
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
@@ -148,7 +148,7 @@ private fun AppCardItem(
 
 @Composable
 private fun AdListItem(adsConfig: AdsConfig) {
-    AdBanner(
+    NativeAdBanner(
         modifier = Modifier.fillMaxWidth(),
         adsConfig = adsConfig
     )

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/ads/ui/NativeAdView.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/ads/ui/NativeAdView.kt
@@ -22,6 +22,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/ads/ui/NativeAdView.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/ads/ui/NativeAdView.kt
@@ -42,12 +42,14 @@ import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.google.android.gms.ads.AdLoader
 import com.google.android.gms.ads.AdRequest
 import com.google.android.gms.ads.nativead.NativeAd
+import org.koin.compose.koinInject
+import org.koin.core.qualifier.named
 import com.google.android.gms.ads.nativead.NativeAdView as GoogleNativeAdView
 
 @Composable
 fun NativeAdBanner(
     modifier: Modifier = Modifier,
-    adsConfig: AdsConfig,
+    adsConfig: AdsConfig = koinInject(qualifier = named("native_ad")) ,
 ) {
     if (LocalInspectionMode.current) {
         Card(

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/ads/ui/NativeAdView.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/ads/ui/NativeAdView.kt
@@ -1,0 +1,159 @@
+package com.d4rk.android.apps.apptoolkit.core.ads.ui
+
+import android.view.View
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.graphics.drawable.toBitmap
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
+import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeHorizontalSpacer
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
+import com.google.android.gms.ads.AdLoader
+import com.google.android.gms.ads.AdRequest
+import com.google.android.gms.ads.nativead.NativeAd
+import com.google.android.gms.ads.nativead.NativeAdView as GoogleNativeAdView
+
+@Composable
+fun NativeAdBanner(
+    modifier: Modifier = Modifier,
+    adsConfig: AdsConfig,
+) {
+    if (LocalInspectionMode.current) {
+        Card(
+            modifier = modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(size = SizeConstants.ExtraLargeSize)
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(80.dp)
+                    .background(Color.LightGray)
+            ) {
+                Text(text = "Native Ad", modifier = Modifier.align(Alignment.Center))
+            }
+        }
+        return
+    }
+
+    val context = LocalContext.current
+    var nativeAd by remember { mutableStateOf<NativeAd?>(null) }
+
+    DisposableEffect(key1 = nativeAd) {
+        onDispose { nativeAd?.destroy() }
+    }
+
+    LaunchedEffect(key1 = adsConfig.bannerAdUnitId) {
+        val loader = AdLoader.Builder(context, adsConfig.bannerAdUnitId)
+            .forNativeAd { ad -> nativeAd = ad }
+            .build()
+        loader.loadAd(AdRequest.Builder().build())
+    }
+
+    nativeAd?.let { ad ->
+        NativeAdView(ad = ad) { loadedAd, view ->
+            Card(
+                modifier = modifier.fillMaxWidth(),
+                shape = RoundedCornerShape(size = SizeConstants.ExtraLargeSize)
+            ) {
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(SizeConstants.LargeSize),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    loadedAd.icon?.drawable?.let { drawable ->
+                        Image(
+                            painter = remember(drawable) {
+                                BitmapPainter(drawable.toBitmap().asImageBitmap())
+                            },
+                            contentDescription = loadedAd.headline,
+                            modifier = Modifier
+                                .size(SizeConstants.ExtraLargeIncreasedSize)
+                                .clip(RoundedCornerShape(size = SizeConstants.SmallSize))
+                        )
+                        LargeHorizontalSpacer()
+                    }
+                    Column(
+                        modifier = Modifier.weight(1f),
+                        verticalArrangement = androidx.compose.foundation.layout.Arrangement.Center
+                    ) {
+                        Text(
+                            text = loadedAd.headline ?: "",
+                            fontWeight = FontWeight.Bold
+                        )
+                        loadedAd.body?.let { body ->
+                            Text(
+                                text = body,
+                                style = MaterialTheme.typography.bodySmall
+                            )
+                        }
+                    }
+                    loadedAd.callToAction?.let { cta ->
+                        LargeHorizontalSpacer()
+                        Button(onClick = { view.performClick() }) {
+                            Text(text = cta)
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun NativeAdView(
+    ad: NativeAd,
+    adContent: @Composable (ad: NativeAd, contentView: View) -> Unit,
+) {
+    val contentViewId by remember { mutableIntStateOf(View.generateViewId()) }
+    val adViewId by remember { mutableIntStateOf(View.generateViewId()) }
+
+    AndroidView(
+        factory = { context ->
+            val contentView = ComposeView(context).apply { id = contentViewId }
+            GoogleNativeAdView(context).apply {
+                id = adViewId
+                addView(contentView)
+            }
+        },
+        update = { view ->
+            val adView = view.findViewById<GoogleNativeAdView>(adViewId)
+            val contentView = view.findViewById<ComposeView>(contentViewId)
+
+            adView.setNativeAd(ad)
+            adView.callToActionView = contentView
+            contentView.setContent { adContent(ad, contentView) }
+        }
+    )
+}
+

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/KoinModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/KoinModule.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.d4rk.android.apps.apptoolkit.core.di.modules.adsModule
 import com.d4rk.android.apps.apptoolkit.core.di.modules.appModule
 import com.d4rk.android.apps.apptoolkit.core.di.modules.appToolkitModule
+import com.d4rk.android.apps.apptoolkit.core.di.modules.dispatchersModule
 import com.d4rk.android.apps.apptoolkit.core.di.modules.settingsModule
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.context.startKoin
@@ -11,6 +12,6 @@ import org.koin.core.context.startKoin
 fun initializeKoin(context : Context) {
     startKoin {
         androidContext(androidContext = context)
-        modules(modules = listOf(appModule , settingsModule , adsModule , appToolkitModule))
+        modules(modules = listOf(appModule , settingsModule , adsModule , appToolkitModule, dispatchersModule))
     }
 }

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AdsModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AdsModule.kt
@@ -28,6 +28,10 @@ val adsModule : Module = module {
         AdsSettingsViewModel(repository = get())
     }
 
+    single<AdsConfig>(named(name = "native_ad")) {
+        AdsConfig(bannerAdUnitId = AdsConstants.NATIVE_AD_UNIT_ID)
+    }
+
     single<AdsConfig> {
         AdsConfig(bannerAdUnitId = AdsConstants.BANNER_AD_UNIT_ID , adSize = AdSize.BANNER)
     }

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/DispatchersModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/DispatchersModule.kt
@@ -2,9 +2,17 @@ package com.d4rk.android.apps.apptoolkit.core.di.modules
 
 import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import com.d4rk.android.libs.apptoolkit.core.di.StandardDispatchers
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
 import org.koin.core.module.Module
+import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 val dispatchersModule: Module = module {
+
+    single<CoroutineDispatcher>(named("io")) { Dispatchers.IO }
+    single<CoroutineDispatcher>(named("main")) { Dispatchers.Main }
+    single<CoroutineDispatcher>(named("default")) { Dispatchers.Default }
+
     single<DispatcherProvider> { StandardDispatchers() }
 }

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/utils/constants/ads/AdsConstants.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/utils/constants/ads/AdsConstants.kt
@@ -20,4 +20,11 @@ object AdsConstants {
         else {
             "ca-app-pub-5294151573817700/8339177528"
         }
+
+    val NATIVE_AD_UNIT_ID: String
+        get() = if (BuildConfig.DEBUG) {
+            DebugAdsConstants.NATIVE_AD_UNIT_ID
+        } else {
+            "ca-app-pub-5294151573817700/5578142927"
+        }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/constants/ads/DebugAdsConstants.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/constants/ads/DebugAdsConstants.kt
@@ -8,4 +8,5 @@ package com.d4rk.android.libs.apptoolkit.core.utils.constants.ads
 object DebugAdsConstants {
     const val BANNER_AD_UNIT_ID = "ca-app-pub-3940256099942544/6300978111"
     const val APP_OPEN_AD_UNIT_ID = "ca-app-pub-3940256099942544/9257395921"
+    const val NATIVE_AD_UNIT_ID = "ca-app-pub-3940256099942544/2247696110"
 }


### PR DESCRIPTION
## Summary
- add `NativeAdBanner` and `NativeAdView` composables for displaying AdMob native ads in Compose
- replace banner ad usage in AppsList with the new native ad banner
- style the native ad banner with rounded Card, icon, and CTA to match app design

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9539fff7c832daa71e0d44837cd31