### PR TITLE
refactor: use StandardDispatchers

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/domain/usecases/ObserveFavoriteAppsUseCase.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/domain/usecases/ObserveFavoriteAppsUseCase.kt
@@ -4,8 +4,7 @@ import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.usecases.FetchDeveloperAppsUseCase
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.RootError
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
+import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOn
@@ -17,11 +16,11 @@ import kotlinx.coroutines.flow.flowOn
 class ObserveFavoriteAppsUseCase(
     private val fetchDeveloperAppsUseCase: FetchDeveloperAppsUseCase,
     private val observeFavoritesUseCase: ObserveFavoritesUseCase,
-    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val dispatchers: DispatcherProvider,
 ) {
     suspend operator fun invoke(): Flow<DataState<List<AppInfo>, RootError>> {
         return combine(
-            fetchDeveloperAppsUseCase().flowOn(ioDispatcher),
+            fetchDeveloperAppsUseCase().flowOn(dispatchers.io),
             observeFavoritesUseCase()
         ) { dataState, favorites ->
             when (dataState) {
@@ -32,7 +31,7 @@ class ObserveFavoriteAppsUseCase(
                 is DataState.Error -> dataState
                 is DataState.Loading -> DataState.Loading()
             }
-        }.flowOn(ioDispatcher)
+        }.flowOn(dispatchers.io)
     }
 }
 

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsScreen.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsScreen.kt
@@ -26,6 +26,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.ScreenStateHa
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.AppInfoHelper
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.IntentsHelper
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.ScreenHelper
+import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import kotlinx.coroutines.launch
 import org.koin.compose.getKoin
 import org.koin.compose.viewmodel.koinViewModel
@@ -45,7 +46,8 @@ fun FavoriteAppsRoute(paddingValues: PaddingValues) {
     val adsEnabled = rememberAdsEnabled(koin)
     val onFavoriteToggle: (String) -> Unit = remember(viewModel) { { pkg -> viewModel.toggleFavorite(pkg) } }
     val onRetry: () -> Unit = remember(viewModel) { { viewModel.onEvent(FavoriteAppsEvent.LoadFavorites) } }
-    val appInfoHelper = remember { AppInfoHelper() }
+    val dispatchers: DispatcherProvider = koinInject()
+    val appInfoHelper = remember { AppInfoHelper(dispatchers) }
     val coroutineScope = rememberCoroutineScope()
     val onAppClick: (AppInfo) -> Unit = remember(context, coroutineScope) {
         { appInfo ->

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsScreen.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsScreen.kt
@@ -29,6 +29,7 @@ import com.d4rk.android.libs.apptoolkit.core.utils.helpers.ScreenHelper
 import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import kotlinx.coroutines.launch
 import org.koin.compose.getKoin
+import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListScreen.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListScreen.kt
@@ -26,6 +26,7 @@ import com.d4rk.android.libs.apptoolkit.core.utils.helpers.ScreenHelper
 import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import kotlinx.coroutines.launch
 import org.koin.compose.getKoin
+import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 
 @Composable

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListScreen.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListScreen.kt
@@ -23,6 +23,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.ScreenStateHa
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.AppInfoHelper
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.IntentsHelper
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.ScreenHelper
+import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import kotlinx.coroutines.launch
 import org.koin.compose.getKoin
 import org.koin.compose.viewmodel.koinViewModel
@@ -42,7 +43,8 @@ fun AppsListRoute(paddingValues: PaddingValues) {
     val adsEnabled = rememberAdsEnabled(koin)
     val onFavoriteToggle: (String) -> Unit = remember(viewModel) { { pkg -> viewModel.toggleFavorite(pkg) } }
     val onRetry: () -> Unit = remember(viewModel) { { viewModel.onEvent(HomeEvent.FetchApps) } }
-    val appInfoHelper = remember { AppInfoHelper() }
+    val dispatchers: DispatcherProvider = koinInject()
+    val appInfoHelper = remember { AppInfoHelper(dispatchers) }
     val coroutineScope = rememberCoroutineScope()
     val onAppClick: (AppInfo) -> Unit = remember(context, coroutineScope) {
         { appInfo ->

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainScreen.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainScreen.kt
@@ -51,6 +51,7 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.navigation.NavigationD
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.snackbar.DefaultSnackbarHost
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.ScreenHelper
+import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
@@ -129,6 +130,7 @@ fun MainScaffoldTabletContent() {
     val snackBarHostState: SnackbarHostState = remember { SnackbarHostState() }
     val changelogUrl: String = koinInject(qualifier = named("github_changelog"))
     val buildInfoProvider: BuildInfoProvider = koinInject()
+    val dispatchers: DispatcherProvider = koinInject()
     var showChangelog by rememberSaveable { mutableStateOf(false) }
 
     val viewModel: MainViewModel = koinViewModel()
@@ -201,7 +203,8 @@ fun MainScaffoldTabletContent() {
         ChangelogDialog(
             changelogUrl = changelogUrl,
             buildInfoProvider = buildInfoProvider,
-            onDismiss = { showChangelog = false }
+            onDismiss = { showChangelog = false },
+            dispatchers = dispatchers
         )
     }
 }

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/components/navigation/NavigationDrawer.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/components/navigation/NavigationDrawer.kt
@@ -23,6 +23,7 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.navigation.NavigationD
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.hapticDrawerSwipe
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeVerticalSpacer
+import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import kotlinx.coroutines.CoroutineScope
 import org.koin.compose.koinInject
 import org.koin.core.qualifier.named
@@ -34,6 +35,7 @@ fun NavigationDrawer(screenState : UiStateScreen<UiMainScreen>) {
     val context : Context = LocalContext.current
     val changelogUrl: String = koinInject(qualifier = named("github_changelog"))
     val buildInfoProvider: BuildInfoProvider = koinInject()
+    val dispatchers: DispatcherProvider = koinInject()
     var showChangelog by rememberSaveable { mutableStateOf(false) }
     val uiState : UiMainScreen = screenState.data ?: UiMainScreen()
 
@@ -61,7 +63,8 @@ fun NavigationDrawer(screenState : UiStateScreen<UiMainScreen>) {
         ChangelogDialog(
             changelogUrl = changelogUrl,
             buildInfoProvider = buildInfoProvider,
-            onDismiss = { showChangelog = false }
+            onDismiss = { showChangelog = false },
+            dispatchers = dispatchers
         )
     }
 }

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/settings/settings/utils/providers/PermissionsSettingsRepository.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/settings/settings/utils/providers/PermissionsSettingsRepository.kt
@@ -6,8 +6,7 @@ import com.d4rk.android.libs.apptoolkit.app.permissions.domain.repository.Permis
 import com.d4rk.android.libs.apptoolkit.app.settings.settings.domain.model.SettingsCategory
 import com.d4rk.android.libs.apptoolkit.app.settings.settings.domain.model.SettingsConfig
 import com.d4rk.android.libs.apptoolkit.app.settings.settings.domain.model.SettingsPreference
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
+import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
@@ -18,7 +17,7 @@ import kotlinx.coroutines.flow.flowOn
  */
 class PermissionsSettingsRepository(
     private val context: Context,
-    private val dispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val dispatchers: DispatcherProvider,
 ) : PermissionsRepository {
 
     override fun getPermissionsConfig(): Flow<SettingsConfig> =
@@ -81,6 +80,6 @@ class PermissionsSettingsRepository(
                     ),
                 ),
             )
-        }.flowOn(dispatcher)
+        }.flowOn(dispatchers.io)
 }
 

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/data/datastore/DataStore.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/data/datastore/DataStore.kt
@@ -1,6 +1,7 @@
 package com.d4rk.android.apps.apptoolkit.core.data.datastore
 
 import android.content.Context
+import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
 
-class DataStore(context: Context) : CommonDataStore(context)
+class DataStore(context: Context, dispatchers: DispatcherProvider) : CommonDataStore(context, dispatchers)

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/data/favorites/FavoritesRepositoryImpl.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/data/favorites/FavoritesRepositoryImpl.kt
@@ -7,8 +7,7 @@ import android.util.Log
 import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.repository.FavoritesRepository
 import com.d4rk.android.apps.apptoolkit.core.broadcast.FavoritesChangedReceiver
 import com.d4rk.android.apps.apptoolkit.core.data.datastore.DataStore
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
+import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.withContext
@@ -16,12 +15,12 @@ import kotlinx.coroutines.withContext
 class FavoritesRepositoryImpl(
     private val context: Context,
     private val dataStore: DataStore,
-    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+    private val dispatchers: DispatcherProvider
 ) : FavoritesRepository {
-    override fun observeFavorites(): Flow<Set<String>> = dataStore.favoriteApps.flowOn(ioDispatcher)
+    override fun observeFavorites(): Flow<Set<String>> = dataStore.favoriteApps.flowOn(dispatchers.io)
 
     override suspend fun toggleFavorite(packageName: String) {
-        withContext(ioDispatcher) {
+        withContext(dispatchers.io) {
             dataStore.toggleFavoriteApp(packageName)
             val intent = Intent(FavoritesChangedReceiver.ACTION_FAVORITES_CHANGED).apply {
                 component = ComponentName(context, FavoritesChangedReceiver::class.java)

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AdsModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AdsModule.kt
@@ -5,8 +5,8 @@ import com.d4rk.android.libs.apptoolkit.app.ads.data.DefaultAdsSettingsRepositor
 import com.d4rk.android.libs.apptoolkit.app.ads.domain.repository.AdsSettingsRepository
 import com.d4rk.android.libs.apptoolkit.app.ads.ui.AdsSettingsViewModel
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoProvider
-import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
 import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
 import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
 import com.google.android.gms.ads.AdSize
 import org.koin.core.module.Module
@@ -20,7 +20,7 @@ val adsModule : Module = module {
         DefaultAdsSettingsRepository(
             dataStore = CommonDataStore.getInstance(get()),
             buildInfoProvider = get<BuildInfoProvider>(),
-            ioDispatcher = get<DispatcherProvider>().io
+            dispatchers = get()
         )
     }
 

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppModule.kt
@@ -21,25 +21,24 @@ import com.d4rk.android.libs.apptoolkit.app.main.domain.repository.NavigationRep
 import com.d4rk.android.libs.apptoolkit.app.onboarding.utils.interfaces.providers.OnboardingProvider
 import com.d4rk.android.libs.apptoolkit.data.client.KtorClient
 import com.d4rk.android.libs.apptoolkit.data.core.ads.AdsCoreManager
-import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.viewModel
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 val appModule : Module = module {
-    single<DataStore> { DataStore(context = get()) }
-    single<AdsCoreManager> { AdsCoreManager(context = get(), buildInfoProvider = get(), ioDispatcher = get<DispatcherProvider>().io) }
+    single<DataStore> { DataStore(context = get(), dispatchers = get()) }
+    single<AdsCoreManager> { AdsCoreManager(context = get(), buildInfoProvider = get(), dispatchers = get()) }
     single { KtorClient().createClient(enableLogging = BuildConfig.DEBUG) }
 
-    single<FavoritesRepository> { FavoritesRepositoryImpl(context = get(), dataStore = get(), ioDispatcher = get<DispatcherProvider>().io) }
+    single<FavoritesRepository> { FavoritesRepositoryImpl(context = get(), dataStore = get(), dispatchers = get()) }
     single { ObserveFavoritesUseCase(repository = get()) }
     single { ToggleFavoriteUseCase(repository = get()) }
     single {
         ObserveFavoriteAppsUseCase(
             fetchDeveloperAppsUseCase = get(),
             observeFavoritesUseCase = get(),
-            ioDispatcher = get<DispatcherProvider>().io,
+            dispatchers = get(),
         )
     }
 
@@ -53,7 +52,7 @@ val appModule : Module = module {
 
     single<OnboardingProvider> { AppOnboardingProvider() }
 
-    single<NavigationRepository> { MainRepositoryImpl(ioDispatcher = get<DispatcherProvider>().io) }
+    single<NavigationRepository> { MainRepositoryImpl(dispatchers = get()) }
 
     viewModel { MainViewModel(navigationRepository = get()) }
 

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppToolkitModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppToolkitModule.kt
@@ -18,8 +18,8 @@ import com.d4rk.android.libs.apptoolkit.app.startup.utils.interfaces.providers.S
 import com.d4rk.android.libs.apptoolkit.app.support.billing.BillingRepository
 import com.d4rk.android.libs.apptoolkit.app.support.ui.SupportViewModel
 import com.d4rk.android.libs.apptoolkit.core.di.GithubToken
-import com.d4rk.android.libs.apptoolkit.core.utils.constants.github.GithubConstants
 import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.github.GithubConstants
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import org.koin.core.module.Module
@@ -32,11 +32,11 @@ val appToolkitModule : Module = module {
     single<StartupProvider> { AppStartupProvider() }
 
     single(createdAtStart = true) {
-        val ioDispatcher = get<DispatcherProvider>().io
+        val dispatchers = get<DispatcherProvider>()
         BillingRepository.getInstance(
             context = get(),
-            ioDispatcher = ioDispatcher,
-            externalScope = CoroutineScope(SupervisorJob() + ioDispatcher)
+            dispatchers = dispatchers,
+            externalScope = CoroutineScope(SupervisorJob() + dispatchers.io)
         )
     }
     viewModel {
@@ -44,7 +44,7 @@ val appToolkitModule : Module = module {
     }
     viewModel { StartupViewModel() }
 
-    single<HelpRepository> { DefaultHelpRepository(context = get(), ioDispatcher = get<DispatcherProvider>().io) }
+    single<HelpRepository> { DefaultHelpRepository(context = get(), dispatchers = get()) }
     viewModel { HelpViewModel(helpRepository = get()) }
 
     single<DeviceInfoProvider> { DeviceInfoProviderImpl(get(), get()) }

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/DispatchersModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/DispatchersModule.kt
@@ -2,17 +2,10 @@ package com.d4rk.android.apps.apptoolkit.core.di.modules
 
 import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import com.d4rk.android.libs.apptoolkit.core.di.StandardDispatchers
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import org.koin.core.module.Module
-import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 val dispatchersModule: Module = module {
-
-    single<CoroutineDispatcher>(named("io")) { Dispatchers.IO }
-    single<CoroutineDispatcher>(named("main")) { Dispatchers.Main }
-    single<CoroutineDispatcher>(named("default")) { Dispatchers.Default }
-
     single<DispatcherProvider> { StandardDispatchers() }
 }
+

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/SettingsModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/SettingsModule.kt
@@ -32,7 +32,6 @@ import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.DisplaySett
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.GeneralSettingsContentProvider
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.PrivacySettingsProvider
 import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
-import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
 
@@ -52,26 +51,25 @@ val settingsModule = module {
     single<PrivacySettingsProvider> { AppPrivacySettingsProvider(context = get()) }
     single<BuildInfoProvider> { AppBuildInfoProvider(context = get()) }
     single<GeneralSettingsContentProvider> { GeneralSettingsContentProvider(displayProvider = get(), privacyProvider = get()) }
-    single<CacheRepository> { DefaultCacheRepository(context = get(), ioDispatcher = get<DispatcherProvider>().io) }
+    single<CacheRepository> { DefaultCacheRepository(context = get(), dispatchers = get()) }
     single<AboutRepository> {
         DefaultAboutRepository(
             deviceProvider = get(),
             configProvider = get(),
             context = get(),
-            ioDispatcher = get<DispatcherProvider>().io,
-            mainDispatcher = get<DispatcherProvider>().main,
+            dispatchers = get(),
         )
     }
     single { ObserveAboutInfoUseCase(repository = get()) }
     single { CopyDeviceInfoUseCase(repository = get()) }
     single<GeneralSettingsRepository> {
-        DefaultGeneralSettingsRepository(dispatcher = get<DispatcherProvider>().default)
+        DefaultGeneralSettingsRepository(dispatchers = get())
     }
     viewModel {
         GeneralSettingsViewModel(repository = get())
     }
 
-    single<PermissionsRepository> { PermissionsSettingsRepository(context = get(), dispatcher = get<DispatcherProvider>().io) }
+    single<PermissionsRepository> { PermissionsSettingsRepository(context = get(), dispatchers = get()) }
     viewModel {
         PermissionsViewModel(
             permissionsRepository = get(),
@@ -91,7 +89,7 @@ val settingsModule = module {
         DefaultUsageAndDiagnosticsRepository(
             dataSource = CommonDataStore.getInstance(get()),
             configProvider = get(),
-            ioDispatcher = get<DispatcherProvider>().io,
+            dispatchers = get(),
         )
     }
 

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModelBase.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModelBase.kt
@@ -32,7 +32,11 @@ open class TestFavoriteAppsViewModelBase {
         val favoritesRepository = FakeFavoritesRepository(initialFavorites, favoritesFlow, toggleError)
         val observeFavoritesUseCase = ObserveFavoritesUseCase(favoritesRepository)
         val toggleFavoriteUseCase = ToggleFavoriteUseCase(favoritesRepository)
-        val observeFavoriteAppsUseCase = ObserveFavoriteAppsUseCase(fetchUseCase, observeFavoritesUseCase)
+        val observeFavoriteAppsUseCase = ObserveFavoriteAppsUseCase(
+            fetchUseCase,
+            observeFavoritesUseCase,
+            dispatchers,
+        )
         viewModel = FavoriteAppsViewModel(
             observeFavoriteAppsUseCase = observeFavoriteAppsUseCase,
             observeFavoritesUseCase = observeFavoritesUseCase,

--- a/app/src/test/java/com/d4rk/android/libs/apptoolkit/app/main/data/repository/MainRepositoryImplTest.kt
+++ b/app/src/test/java/com/d4rk/android/libs/apptoolkit/app/main/data/repository/MainRepositoryImplTest.kt
@@ -3,7 +3,7 @@ package com.d4rk.android.libs.apptoolkit.app.main.data.repository
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.main.utils.constants.NavigationDrawerRoutes
 import com.d4rk.android.libs.apptoolkit.core.domain.model.navigation.NavigationDrawerItem
-import com.d4rk.android.libs.apptoolkit.core.di.TestDispatchers
+import com.d4rk.android.apps.apptoolkit.app.core.utils.dispatchers.TestDispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher

--- a/app/src/test/java/com/d4rk/android/libs/apptoolkit/app/main/data/repository/MainRepositoryImplTest.kt
+++ b/app/src/test/java/com/d4rk/android/libs/apptoolkit/app/main/data/repository/MainRepositoryImplTest.kt
@@ -3,6 +3,7 @@ package com.d4rk.android.libs.apptoolkit.app.main.data.repository
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.main.utils.constants.NavigationDrawerRoutes
 import com.d4rk.android.libs.apptoolkit.core.domain.model.navigation.NavigationDrawerItem
+import com.d4rk.android.libs.apptoolkit.core.di.TestDispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -16,7 +17,7 @@ class MainRepositoryImplTest {
     @Test
     fun `getNavigationDrawerItems emits expected items`() = runTest {
         val dispatcher = StandardTestDispatcher(testScheduler)
-        val repository = MainRepositoryImpl(dispatcher)
+        val repository = MainRepositoryImpl(TestDispatchers(dispatcher))
 
         val items = repository.getNavigationDrawerItems().first()
 

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/data/DefaultAboutRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/about/data/DefaultAboutRepository.kt
@@ -5,9 +5,8 @@ import com.d4rk.android.libs.apptoolkit.app.about.domain.model.ui.UiAboutScreen
 import com.d4rk.android.libs.apptoolkit.app.about.domain.repository.AboutRepository
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.AboutSettingsProvider
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoProvider
+import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.ClipboardHelper
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
@@ -21,8 +20,7 @@ class DefaultAboutRepository(
     private val deviceProvider: AboutSettingsProvider,
     private val configProvider: BuildInfoProvider,
     private val context: Context,
-    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
-    private val mainDispatcher: CoroutineDispatcher = Dispatchers.Main,
+    private val dispatchers: DispatcherProvider,
 ) : AboutRepository {
 
     override fun getAboutInfoStream(): Flow<UiAboutScreen> =
@@ -34,10 +32,10 @@ class DefaultAboutRepository(
                     deviceInfo = deviceProvider.deviceInfo,
                 ),
             )
-        }.flowOn(ioDispatcher)
+        }.flowOn(dispatchers.io)
 
     override suspend fun copyDeviceInfo(label: String, deviceInfo: String) {
-        withContext(mainDispatcher) {
+        withContext(dispatchers.main) {
             ClipboardHelper.copyTextToClipboard(
                 context = context,
                 label = label,

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/data/DefaultAdsSettingsRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/ads/data/DefaultAdsSettingsRepository.kt
@@ -2,11 +2,10 @@ package com.d4rk.android.libs.apptoolkit.app.ads.data
 
 import com.d4rk.android.libs.apptoolkit.app.ads.domain.repository.AdsSettingsRepository
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoProvider
+import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import com.d4rk.android.libs.apptoolkit.core.domain.model.Result
 import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flowOn
@@ -18,7 +17,7 @@ import kotlinx.coroutines.withContext
 class DefaultAdsSettingsRepository(
     private val dataStore: CommonDataStore,
     buildInfoProvider: BuildInfoProvider,
-    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val dispatchers: DispatcherProvider,
 ) : AdsSettingsRepository {
 
     override val defaultAdsEnabled: Boolean = !buildInfoProvider.isDebugBuild
@@ -29,11 +28,11 @@ class DefaultAdsSettingsRepository(
                 if (throwable is CancellationException) throw throwable
                 emit(defaultAdsEnabled)
             }
-            .flowOn(ioDispatcher)
+            .flowOn(dispatchers.io)
 
     override suspend fun setAdsEnabled(enabled: Boolean): Result<Unit> =
         runCatching {
-            withContext(ioDispatcher) {
+            withContext(dispatchers.io) {
                 dataStore.saveAds(isChecked = enabled)
             }
         }.fold(

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/advanced/data/DefaultCacheRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/advanced/data/DefaultCacheRepository.kt
@@ -1,9 +1,8 @@
 package com.d4rk.android.libs.apptoolkit.app.advanced.data
 
 import android.content.Context
+import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import com.d4rk.android.libs.apptoolkit.core.domain.model.Result
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -18,7 +17,7 @@ import java.io.File
  */
 class DefaultCacheRepository(
     private val context: Context,
-    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val dispatchers: DispatcherProvider,
 ) : CacheRepository {
 
     override fun clearCache(): Flow<Result<Unit>> = flow {
@@ -45,5 +44,5 @@ class DefaultCacheRepository(
         ))
     }
         .catch { e -> emit(Result.Error(e as Exception)) }
-        .flowOn(ioDispatcher)
+        .flowOn(dispatchers.io)
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/data/repository/DefaultUsageAndDiagnosticsRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/data/repository/DefaultUsageAndDiagnosticsRepository.kt
@@ -4,8 +4,7 @@ import com.d4rk.android.libs.apptoolkit.app.diagnostics.data.datasource.UsageAnd
 import com.d4rk.android.libs.apptoolkit.app.diagnostics.domain.model.UsageAndDiagnosticsSettings
 import com.d4rk.android.libs.apptoolkit.app.diagnostics.domain.repository.UsageAndDiagnosticsRepository
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoProvider
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
+import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flowOn
@@ -18,7 +17,7 @@ import kotlinx.coroutines.withContext
 class DefaultUsageAndDiagnosticsRepository(
     private val dataSource: UsageAndDiagnosticsPreferencesDataSource,
     private val configProvider: BuildInfoProvider,
-    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val dispatchers: DispatcherProvider,
 ) : UsageAndDiagnosticsRepository {
 
     override fun observeSettings(): Flow<UsageAndDiagnosticsSettings> =
@@ -36,21 +35,21 @@ class DefaultUsageAndDiagnosticsRepository(
                 adUserDataConsent = adUserData,
                 adPersonalizationConsent = adPersonalization,
             )
-        }.flowOn(ioDispatcher)
+        }.flowOn(dispatchers.io)
 
     override suspend fun setUsageAndDiagnostics(enabled: Boolean) =
-        withContext(ioDispatcher) { dataSource.saveUsageAndDiagnostics(isChecked = enabled) }
+        withContext(dispatchers.io) { dataSource.saveUsageAndDiagnostics(isChecked = enabled) }
 
     override suspend fun setAnalyticsConsent(granted: Boolean) =
-        withContext(ioDispatcher) { dataSource.saveAnalyticsConsent(isGranted = granted) }
+        withContext(dispatchers.io) { dataSource.saveAnalyticsConsent(isGranted = granted) }
 
     override suspend fun setAdStorageConsent(granted: Boolean) =
-        withContext(ioDispatcher) { dataSource.saveAdStorageConsent(isGranted = granted) }
+        withContext(dispatchers.io) { dataSource.saveAdStorageConsent(isGranted = granted) }
 
     override suspend fun setAdUserDataConsent(granted: Boolean) =
-        withContext(ioDispatcher) { dataSource.saveAdUserDataConsent(isGranted = granted) }
+        withContext(dispatchers.io) { dataSource.saveAdUserDataConsent(isGranted = granted) }
 
     override suspend fun setAdPersonalizationConsent(granted: Boolean) =
-        withContext(ioDispatcher) { dataSource.saveAdPersonalizationConsent(isGranted = granted) }
+        withContext(dispatchers.io) { dataSource.saveAdPersonalizationConsent(isGranted = granted) }
 }
 

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/data/DefaultHelpRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/data/DefaultHelpRepository.kt
@@ -4,14 +4,14 @@ import android.content.Context
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.help.domain.data.model.UiHelpQuestion
 import com.d4rk.android.libs.apptoolkit.app.help.domain.repository.HelpRepository
-import kotlinx.coroutines.CoroutineDispatcher
+import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 
 class DefaultHelpRepository(
     private val context: Context,
-    private val ioDispatcher: CoroutineDispatcher
+    private val dispatchers: DispatcherProvider
 ) : HelpRepository {
 
     override fun fetchFaq(): Flow<List<UiHelpQuestion>> = flow {
@@ -32,5 +32,5 @@ class DefaultHelpRepository(
             )
         }.filter { it.question.isNotBlank() && it.answer.isNotBlank() }
         emit(faq)
-    }.flowOn(ioDispatcher)
+    }.flowOn(dispatchers.io)
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/main/data/repository/MainRepositoryImpl.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/main/data/repository/MainRepositoryImpl.kt
@@ -8,14 +8,14 @@ import androidx.compose.material.icons.outlined.Share
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.main.domain.repository.NavigationRepository
 import com.d4rk.android.libs.apptoolkit.app.main.utils.constants.NavigationDrawerRoutes
+import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import com.d4rk.android.libs.apptoolkit.core.domain.model.navigation.NavigationDrawerItem
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 
 class MainRepositoryImpl(
-    private val ioDispatcher: CoroutineDispatcher
+    private val dispatchers: DispatcherProvider
 ) : NavigationRepository {
     override fun getNavigationDrawerItems(): Flow<List<NavigationDrawerItem>> =
         flow {
@@ -43,6 +43,6 @@ class MainRepositoryImpl(
                     )
                 )
             )
-        }.flowOn(ioDispatcher)
+        }.flowOn(dispatchers.io)
 }
 

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/main/ui/components/dialogs/ChangelogDialog.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/main/ui/components/dialogs/ChangelogDialog.kt
@@ -22,12 +22,11 @@ import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoProvider
 import com.d4rk.android.libs.apptoolkit.core.ui.components.dialogs.BasicAlertDialog
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeHorizontalSpacer
+import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import dev.jeziellago.compose.markdowntext.MarkdownText
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.request.get
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.koin.compose.koinInject
@@ -37,7 +36,7 @@ fun ChangelogDialog(
     changelogUrl: String,
     buildInfoProvider: BuildInfoProvider,
     onDismiss: () -> Unit,
-    ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    dispatchers: DispatcherProvider,
 ) {
     val context = LocalContext.current
     val changelogText: MutableState<String?> = remember {
@@ -48,7 +47,7 @@ fun ChangelogDialog(
     val httpClient: HttpClient = koinInject()
 
     suspend fun loadChangelog() {
-        withContext(ioDispatcher) {
+        withContext(dispatchers.io) {
             runCatching {
                 val content: String = httpClient.get(changelogUrl).body()
                 val section = extractChangesForVersion(content, buildInfoProvider.appVersion)

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/data/repository/DefaultOnboardingRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/data/repository/DefaultOnboardingRepository.kt
@@ -2,8 +2,7 @@ package com.d4rk.android.libs.apptoolkit.app.onboarding.data.repository
 
 import com.d4rk.android.libs.apptoolkit.app.onboarding.data.datasource.OnboardingPreferencesDataSource
 import com.d4rk.android.libs.apptoolkit.app.onboarding.domain.repository.OnboardingRepository
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
+import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
@@ -14,15 +13,15 @@ import kotlinx.coroutines.withContext
  */
 class DefaultOnboardingRepository(
     private val dataStore: OnboardingPreferencesDataSource,
-    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+    private val dispatchers: DispatcherProvider
 ) : OnboardingRepository {
 
     override fun observeOnboardingCompletion(): Flow<Boolean> =
         dataStore.startup
             .map { isFirstTime -> !isFirstTime }
-            .flowOn(ioDispatcher)
+            .flowOn(dispatchers.io)
 
-    override suspend fun setOnboardingCompleted() = withContext(ioDispatcher) {
+    override suspend fun setOnboardingCompleted() = withContext(dispatchers.io) {
         dataStore.saveStartup(isFirstTime = false)
     }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingScreen.kt
@@ -35,6 +35,7 @@ import com.d4rk.android.libs.apptoolkit.app.onboarding.ui.components.pages.Onboa
 import com.d4rk.android.libs.apptoolkit.app.onboarding.utils.interfaces.providers.OnboardingProvider
 import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.OutlinedIconButtonWithText
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.hapticPagerSwipe
+import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -47,7 +48,8 @@ fun OnboardingScreen() {
     val onboardingProvider: OnboardingProvider = koinInject()
     val pages: List<OnboardingPage> = remember { onboardingProvider.getOnboardingPages(context = context) }
     val coroutineScope: CoroutineScope = rememberCoroutineScope()
-    val repository = remember { DefaultOnboardingRepository(CommonDataStore.getInstance(context)) }
+    val dispatchers: DispatcherProvider = koinInject()
+    val repository = remember { DefaultOnboardingRepository(CommonDataStore.getInstance(context), dispatchers) }
     val viewModel: OnboardingViewModel = viewModel(factory = OnboardingViewModel.provideFactory(repository))
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val pagerState: PagerState = rememberPagerState(initialPage = uiState.currentTabIndex) { pages.size }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/settings/general/data/DefaultGeneralSettingsRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/settings/general/data/DefaultGeneralSettingsRepository.kt
@@ -1,7 +1,7 @@
 package com.d4rk.android.libs.apptoolkit.app.settings.general.data
 
 import com.d4rk.android.libs.apptoolkit.app.settings.general.domain.repository.GeneralSettingsRepository
-import kotlinx.coroutines.CoroutineDispatcher
+import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
@@ -14,7 +14,7 @@ import kotlinx.coroutines.flow.flowOn
  * thread.
  */
 class DefaultGeneralSettingsRepository(
-    private val dispatcher: CoroutineDispatcher,
+    private val dispatchers: DispatcherProvider,
 ) : GeneralSettingsRepository {
 
     override fun getContentKey(contentKey: String?): Flow<String> = flow {
@@ -22,6 +22,6 @@ class DefaultGeneralSettingsRepository(
             throw IllegalArgumentException("Invalid content key")
         }
         emit(contentKey)
-    }.flowOn(dispatcher)
+    }.flowOn(dispatchers.default)
 }
 

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/AppInfoHelper.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/AppInfoHelper.kt
@@ -5,19 +5,18 @@ import android.content.Context
 import android.content.Intent
 import android.widget.Toast
 import com.d4rk.android.libs.apptoolkit.R
-import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.Dispatchers
+import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import kotlinx.coroutines.withContext
 
 open class AppInfoHelper(
-    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val dispatchers: DispatcherProvider,
 ) {
 
     /**
      * Checks if a specific app is installed on the device.
      * @return True if the app is installed, false otherwise.
      */
-    suspend fun isAppInstalled(context : Context , packageName : String) : Boolean = withContext(ioDispatcher) {
+    suspend fun isAppInstalled(context : Context , packageName : String) : Boolean = withContext(dispatchers.io) {
         runCatching { context.packageManager.getApplicationInfo(packageName , 0) }.isSuccess
     }
 
@@ -38,7 +37,7 @@ open class AppInfoHelper(
      *         the launch intent could not be obtained or starting the activity failed.
      */
     suspend fun openAppResult(context : Context , packageName : String) : Result<Boolean> {
-        val launchIntent = withContext(ioDispatcher) {
+        val launchIntent = withContext(dispatchers.io) {
             runCatching { context.packageManager.getLaunchIntentForPackage(packageName) }.getOrNull()
         }
 

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/core/BaseCoreManager.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/core/BaseCoreManager.kt
@@ -6,15 +6,15 @@ import android.os.Bundle
 import androidx.lifecycle.LifecycleObserver
 import androidx.multidex.MultiDexApplication
 import com.d4rk.android.libs.apptoolkit.app.support.billing.BillingRepository
+import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
+import com.d4rk.android.libs.apptoolkit.core.di.StandardDispatchers
 import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
 import com.google.firebase.Firebase
 import com.google.firebase.appcheck.appCheck
 import com.google.firebase.appcheck.playintegrity.PlayIntegrityAppCheckProviderFactory
 import com.google.firebase.initialize
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Deferred
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.cancel
@@ -25,8 +25,8 @@ import org.koin.android.ext.android.inject
 open class BaseCoreManager : MultiDexApplication(), Application.ActivityLifecycleCallbacks, LifecycleObserver {
 
     protected val billingRepository: BillingRepository by inject()
-    protected open val ioDispatcher: CoroutineDispatcher = Dispatchers.IO
-    private val applicationScope = CoroutineScope(SupervisorJob() + ioDispatcher)
+    protected open val dispatchers: DispatcherProvider = StandardDispatchers()
+    private val applicationScope = CoroutineScope(SupervisorJob() + dispatchers.io)
 
     companion object {
         var isAppLoaded : Boolean = false

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/core/ads/AdsCoreManager.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/core/ads/AdsCoreManager.kt
@@ -3,6 +3,7 @@ package com.d4rk.android.libs.apptoolkit.data.core.ads
 import android.app.Activity
 import android.content.Context
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoProvider
+import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import com.d4rk.android.libs.apptoolkit.core.utils.interfaces.OnShowAdCompleteListener
 import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
 import com.google.android.gms.ads.AdError
@@ -11,9 +12,7 @@ import com.google.android.gms.ads.FullScreenContentCallback
 import com.google.android.gms.ads.LoadAdError
 import com.google.android.gms.ads.MobileAds
 import com.google.android.gms.ads.appopen.AppOpenAd
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -22,17 +21,17 @@ import java.util.Date
 open class AdsCoreManager(
     protected val context : Context,
     val buildInfoProvider : BuildInfoProvider,
-    private val ioDispatcher: CoroutineDispatcher = Dispatchers.IO,
+    private val dispatchers: DispatcherProvider,
 ) {
     private var dataStore : CommonDataStore = CommonDataStore.getInstance(context = context)
     private var appOpenAdManager : AppOpenAdManager? = null
 
     suspend fun initializeAds(appOpenUnitId : String) {
-        val isAdsChecked : Boolean = withContext(ioDispatcher) {
+        val isAdsChecked : Boolean = withContext(dispatchers.io) {
             dataStore.ads(default = !buildInfoProvider.isDebugBuild).first()
         }
         if (isAdsChecked) {
-            withContext(ioDispatcher) { MobileAds.initialize(context) }
+            withContext(dispatchers.io) { MobileAds.initialize(context) }
             appOpenAdManager = AppOpenAdManager(appOpenUnitId)
         }
     }
@@ -89,7 +88,7 @@ open class AdsCoreManager(
         suspend fun showAdIfAvailable(
             activity : Activity , onShowAdCompleteListener : OnShowAdCompleteListener
         ) {
-            val isAdsChecked : Boolean = withContext(ioDispatcher) {
+            val isAdsChecked : Boolean = withContext(dispatchers.io) {
                 dataStore.ads(default = !buildInfoProvider.isDebugBuild).first()
             }
 

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/datastore/CommonDataStore.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/datastore/CommonDataStore.kt
@@ -13,10 +13,10 @@ import androidx.datastore.preferences.core.stringSetPreferencesKey
 import androidx.datastore.preferences.preferencesDataStore
 import com.d4rk.android.libs.apptoolkit.app.diagnostics.data.datasource.UsageAndDiagnosticsPreferencesDataSource
 import com.d4rk.android.libs.apptoolkit.app.onboarding.data.datasource.OnboardingPreferencesDataSource
+import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
+import com.d4rk.android.libs.apptoolkit.core.di.StandardDispatchers
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.datastore.DataStoreNamesConstants
-import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
@@ -39,10 +39,10 @@ val Context.commonDataStore : DataStore<Preferences> by preferencesDataStore(nam
  */
 open class CommonDataStore(
     context : Context,
-    ioDispatcher: CoroutineDispatcher = Dispatchers.IO
+    private val dispatchers: DispatcherProvider = StandardDispatchers(),
 ) : OnboardingPreferencesDataSource, UsageAndDiagnosticsPreferencesDataSource {
     val dataStore : DataStore<Preferences> = context.commonDataStore
-    private val scope = CoroutineScope(SupervisorJob() + ioDispatcher)
+    private val scope = CoroutineScope(SupervisorJob() + dispatchers.io)
 
     companion object {
         @Volatile

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/about/data/TestDefaultAboutRepository.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/about/data/TestDefaultAboutRepository.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import com.d4rk.android.libs.apptoolkit.app.about.domain.model.ui.UiAboutScreen
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.AboutSettingsProvider
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoProvider
+import com.d4rk.android.libs.apptoolkit.core.di.TestDispatchers
 import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.UnconfinedDispatcherExtension
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.ClipboardHelper
 import com.google.common.truth.Truth.assertThat
@@ -41,8 +42,7 @@ class TestDefaultAboutRepository {
             deviceProvider = deviceProvider,
             configProvider = buildInfoProvider,
             context = context,
-            ioDispatcher = dispatcherExtension.testDispatcher,
-            mainDispatcher = dispatcherExtension.testDispatcher,
+            dispatchers = TestDispatchers(dispatcherExtension.testDispatcher),
         )
 
     @Test

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/ads/data/TestDefaultAdsSettingsRepository.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/ads/data/TestDefaultAdsSettingsRepository.kt
@@ -2,6 +2,7 @@ package com.d4rk.android.libs.apptoolkit.app.ads.data
 
 import app.cash.turbine.test
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoProvider
+import com.d4rk.android.libs.apptoolkit.core.di.TestDispatchers
 import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.UnconfinedDispatcherExtension
 import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
 import com.d4rk.android.libs.apptoolkit.core.domain.model.Result
@@ -37,7 +38,7 @@ class TestDefaultAdsSettingsRepository {
         return DefaultAdsSettingsRepository(
             dataStore = dataStore,
             buildInfoProvider = buildInfoProvider,
-            ioDispatcher = dispatcherExtension.testDispatcher,
+            dispatchers = TestDispatchers(dispatcherExtension.testDispatcher),
         )
     }
 

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/advanced/data/TestDefaultCacheRepository.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/advanced/data/TestDefaultCacheRepository.kt
@@ -11,6 +11,7 @@ import kotlin.test.assertFalse
 import kotlinx.coroutines.flow.single
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.runTest
+import com.d4rk.android.libs.apptoolkit.core.di.TestDispatchers
 import org.junit.Test
 
 class TestDefaultCacheRepository {
@@ -26,7 +27,7 @@ class TestDefaultCacheRepository {
         every { context.codeCacheDir } returns dir2
         every { context.filesDir } returns dir3
 
-        val repository = DefaultCacheRepository(context)
+        val repository = DefaultCacheRepository(context, TestDispatchers())
         val result = repository.clearCache().single()
 
         assertThat(result).isInstanceOf(Result.Success::class.java)
@@ -48,7 +49,7 @@ class TestDefaultCacheRepository {
         every { context.codeCacheDir } returns failing
         every { context.filesDir } returns dir3
 
-        val repository = DefaultCacheRepository(context)
+        val repository = DefaultCacheRepository(context, TestDispatchers())
         val result = repository.clearCache().single()
 
         assertThat(result).isInstanceOf(Result.Error::class.java)
@@ -61,7 +62,7 @@ class TestDefaultCacheRepository {
         val context = mockk<Context>()
         every { context.cacheDir } throws SecurityException("denied")
 
-        val repository = DefaultCacheRepository(context)
+        val repository = DefaultCacheRepository(context, TestDispatchers())
         val result = repository.clearCache().single()
         assertThat(result).isInstanceOf(Result.Error::class.java)
     }
@@ -77,7 +78,7 @@ class TestDefaultCacheRepository {
         every { context.codeCacheDir } returns dir2
         every { context.filesDir } returns dir3
 
-        val repository = DefaultCacheRepository(context)
+        val repository = DefaultCacheRepository(context, TestDispatchers())
         val result = repository.clearCache().single()
 
         assertThat(result).isInstanceOf(Result.Success::class.java)
@@ -96,7 +97,7 @@ class TestDefaultCacheRepository {
         every { context.codeCacheDir } returns failing
         every { context.filesDir } returns dir3
 
-        val repository = DefaultCacheRepository(context)
+        val repository = DefaultCacheRepository(context, TestDispatchers())
         val result = repository.clearCache().single()
         assertThat(result).isInstanceOf(Result.Error::class.java)
     }
@@ -113,7 +114,7 @@ class TestDefaultCacheRepository {
         every { context.filesDir } returns dir3
 
         val dispatcher = StandardTestDispatcher(testScheduler)
-        val repository = DefaultCacheRepository(context, dispatcher)
+        val repository = DefaultCacheRepository(context, TestDispatchers(dispatcher))
 
         repository.clearCache().test {
             assertThat(awaitItem()).isInstanceOf(Result.Success::class.java)

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/data/repository/DefaultUsageAndDiagnosticsRepositoryTest.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/diagnostics/data/repository/DefaultUsageAndDiagnosticsRepositoryTest.kt
@@ -2,6 +2,7 @@ package com.d4rk.android.libs.apptoolkit.app.diagnostics.data.repository
 
 import com.d4rk.android.libs.apptoolkit.app.diagnostics.data.datasource.UsageAndDiagnosticsPreferencesDataSource
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoProvider
+import com.d4rk.android.libs.apptoolkit.core.di.TestDispatchers
 import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.UnconfinedDispatcherExtension
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -57,7 +58,7 @@ class DefaultUsageAndDiagnosticsRepositoryTest {
         val repository = DefaultUsageAndDiagnosticsRepository(
             dataSource = dataSource,
             configProvider = FakeBuildInfoProvider(),
-            ioDispatcher = dispatcherExtension.testDispatcher,
+            dispatchers = TestDispatchers(dispatcherExtension.testDispatcher),
         )
 
         // Initial state should reflect default true values

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/onboarding/data/repository/TestDefaultOnboardingRepository.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/onboarding/data/repository/TestDefaultOnboardingRepository.kt
@@ -1,6 +1,7 @@
 package com.d4rk.android.libs.apptoolkit.app.onboarding.data.repository
 
 import com.d4rk.android.libs.apptoolkit.app.onboarding.data.datasource.OnboardingPreferencesDataSource
+import com.d4rk.android.libs.apptoolkit.core.di.TestDispatchers
 import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.UnconfinedDispatcherExtension
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -31,7 +32,7 @@ class TestDefaultOnboardingRepository {
     @Test
     fun `observeOnboardingCompletion reflects data source state`() = runTest(dispatcherExtension.testDispatcher) {
         val dataSource = FakeOnboardingPreferencesDataSource()
-        val repository = DefaultOnboardingRepository(dataSource, dispatcherExtension.testDispatcher)
+        val repository = DefaultOnboardingRepository(dataSource, TestDispatchers(dispatcherExtension.testDispatcher))
 
         assertThat(repository.observeOnboardingCompletion().first()).isFalse()
 
@@ -42,7 +43,7 @@ class TestDefaultOnboardingRepository {
     @Test
     fun `setOnboardingCompleted updates data source`() = runTest(dispatcherExtension.testDispatcher) {
         val dataSource = FakeOnboardingPreferencesDataSource()
-        val repository = DefaultOnboardingRepository(dataSource, dispatcherExtension.testDispatcher)
+        val repository = DefaultOnboardingRepository(dataSource, TestDispatchers(dispatcherExtension.testDispatcher))
 
         repository.setOnboardingCompleted()
         advanceUntilIdle()

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/settings/general/domain/repository/TestGeneralSettingsRepository.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/settings/general/domain/repository/TestGeneralSettingsRepository.kt
@@ -1,6 +1,7 @@
 package com.d4rk.android.libs.apptoolkit.app.settings.general.domain.repository
 
 import com.d4rk.android.libs.apptoolkit.app.settings.general.data.DefaultGeneralSettingsRepository
+import com.d4rk.android.libs.apptoolkit.core.di.TestDispatchers
 import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.UnconfinedDispatcherExtension
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.flow.first
@@ -19,14 +20,14 @@ class TestGeneralSettingsRepository {
 
     @Test
     fun `getContentKey returns provided key`() = runTest(dispatcherExtension.testDispatcher) {
-        val repository = DefaultGeneralSettingsRepository(dispatcherExtension.testDispatcher)
+        val repository = DefaultGeneralSettingsRepository(TestDispatchers(dispatcherExtension.testDispatcher))
         val result = repository.getContentKey("valid").first()
         assertThat(result).isEqualTo("valid")
     }
 
     @Test
     fun `getContentKey throws on null key`() = runTest(dispatcherExtension.testDispatcher) {
-        val repository = DefaultGeneralSettingsRepository(dispatcherExtension.testDispatcher)
+        val repository = DefaultGeneralSettingsRepository(TestDispatchers(dispatcherExtension.testDispatcher))
         assertThrows<IllegalArgumentException> {
             repository.getContentKey(null).first()
         }
@@ -34,7 +35,7 @@ class TestGeneralSettingsRepository {
 
     @Test
     fun `getContentKey throws on blank key`() = runTest(dispatcherExtension.testDispatcher) {
-        val repository = DefaultGeneralSettingsRepository(dispatcherExtension.testDispatcher)
+        val repository = DefaultGeneralSettingsRepository(TestDispatchers(dispatcherExtension.testDispatcher))
         assertThrows<IllegalArgumentException> {
             repository.getContentKey("").first()
         }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/TestGeneralSettingsViewModel.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/TestGeneralSettingsViewModel.kt
@@ -3,6 +3,7 @@ package com.d4rk.android.libs.apptoolkit.app.settings.general.ui
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.settings.general.domain.actions.GeneralSettingsEvent
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
+import com.d4rk.android.libs.apptoolkit.core.di.TestDispatchers
 import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.UnconfinedDispatcherExtension
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
 import com.d4rk.android.libs.apptoolkit.app.settings.general.data.DefaultGeneralSettingsRepository
@@ -23,7 +24,7 @@ class TestGeneralSettingsViewModel {
     fun `load content success`() = runTest(dispatcherExtension.testDispatcher) {
         println("🚀 [TEST] load content success")
         val viewModel = GeneralSettingsViewModel(
-            repository = DefaultGeneralSettingsRepository(dispatcherExtension.testDispatcher)
+            repository = DefaultGeneralSettingsRepository(TestDispatchers(dispatcherExtension.testDispatcher))
         )
         viewModel.onEvent(GeneralSettingsEvent.Load("key"))
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
@@ -37,7 +38,7 @@ class TestGeneralSettingsViewModel {
     fun `load content invalid`() = runTest(dispatcherExtension.testDispatcher) {
         println("🚀 [TEST] load content invalid")
         val viewModel = GeneralSettingsViewModel(
-            repository = DefaultGeneralSettingsRepository(dispatcherExtension.testDispatcher)
+            repository = DefaultGeneralSettingsRepository(TestDispatchers(dispatcherExtension.testDispatcher))
         )
         viewModel.onEvent(GeneralSettingsEvent.Load(null))
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
@@ -52,7 +53,7 @@ class TestGeneralSettingsViewModel {
     fun `load content blank`() = runTest(dispatcherExtension.testDispatcher) {
         println("🚀 [TEST] load content blank")
         val viewModel = GeneralSettingsViewModel(
-            repository = DefaultGeneralSettingsRepository(dispatcherExtension.testDispatcher)
+            repository = DefaultGeneralSettingsRepository(TestDispatchers(dispatcherExtension.testDispatcher))
         )
         viewModel.onEvent(GeneralSettingsEvent.Load(""))
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
@@ -67,7 +68,7 @@ class TestGeneralSettingsViewModel {
     fun `multiple load calls update key`() = runTest(dispatcherExtension.testDispatcher) {
         println("🚀 [TEST] multiple load calls update key")
         val viewModel = GeneralSettingsViewModel(
-            repository = DefaultGeneralSettingsRepository(dispatcherExtension.testDispatcher)
+            repository = DefaultGeneralSettingsRepository(TestDispatchers(dispatcherExtension.testDispatcher))
         )
         viewModel.onEvent(GeneralSettingsEvent.Load("one"))
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
@@ -85,7 +86,7 @@ class TestGeneralSettingsViewModel {
     fun `errors cleared after successful load`() = runTest(dispatcherExtension.testDispatcher) {
         println("🚀 [TEST] errors cleared after successful load")
         val viewModel = GeneralSettingsViewModel(
-            repository = DefaultGeneralSettingsRepository(dispatcherExtension.testDispatcher)
+            repository = DefaultGeneralSettingsRepository(TestDispatchers(dispatcherExtension.testDispatcher))
         )
         viewModel.onEvent(GeneralSettingsEvent.Load(""))
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
@@ -104,7 +105,7 @@ class TestGeneralSettingsViewModel {
     fun `content persists across config changes`() = runTest(dispatcherExtension.testDispatcher) {
         println("🚀 [TEST] content persists across config changes")
         val viewModel = GeneralSettingsViewModel(
-            repository = DefaultGeneralSettingsRepository(dispatcherExtension.testDispatcher)
+            repository = DefaultGeneralSettingsRepository(TestDispatchers(dispatcherExtension.testDispatcher))
         )
         viewModel.onEvent(GeneralSettingsEvent.Load("rotate"))
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
@@ -120,7 +121,7 @@ class TestGeneralSettingsViewModel {
     fun `reload with same key retains state`() = runTest(dispatcherExtension.testDispatcher) {
         println("🚀 [TEST] reload with same key retains state")
         val viewModel = GeneralSettingsViewModel(
-            repository = DefaultGeneralSettingsRepository(dispatcherExtension.testDispatcher)
+            repository = DefaultGeneralSettingsRepository(TestDispatchers(dispatcherExtension.testDispatcher))
         )
         viewModel.onEvent(GeneralSettingsEvent.Load("keep"))
         dispatcherExtension.testDispatcher.scheduler.advanceUntilIdle()
@@ -137,7 +138,7 @@ class TestGeneralSettingsViewModel {
     fun `load extremely long content key`() = runTest(dispatcherExtension.testDispatcher) {
         println("🚀 [TEST] load extremely long content key")
         val viewModel = GeneralSettingsViewModel(
-            repository = DefaultGeneralSettingsRepository(dispatcherExtension.testDispatcher)
+            repository = DefaultGeneralSettingsRepository(TestDispatchers(dispatcherExtension.testDispatcher))
         )
         val longKey = "a".repeat(1000)
         viewModel.onEvent(GeneralSettingsEvent.Load(longKey))
@@ -152,7 +153,7 @@ class TestGeneralSettingsViewModel {
     fun `load content key with special characters`() = runTest(dispatcherExtension.testDispatcher) {
         println("🚀 [TEST] load content key with special characters")
         val viewModel = GeneralSettingsViewModel(
-            repository = DefaultGeneralSettingsRepository(dispatcherExtension.testDispatcher)
+            repository = DefaultGeneralSettingsRepository(TestDispatchers(dispatcherExtension.testDispatcher))
         )
         val key = "!@#$%^&*()_+漢字"
         viewModel.onEvent(GeneralSettingsEvent.Load(key))
@@ -167,7 +168,7 @@ class TestGeneralSettingsViewModel {
     fun `concurrent load events yield latest state`() = runTest(dispatcherExtension.testDispatcher) {
         println("🚀 [TEST] concurrent load events yield latest state")
         val viewModel = GeneralSettingsViewModel(
-            repository = DefaultGeneralSettingsRepository(dispatcherExtension.testDispatcher)
+            repository = DefaultGeneralSettingsRepository(TestDispatchers(dispatcherExtension.testDispatcher))
         )
         viewModel.onEvent(GeneralSettingsEvent.Load("first"))
         viewModel.onEvent(GeneralSettingsEvent.Load("second"))

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestAppInfoHelper.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestAppInfoHelper.kt
@@ -13,6 +13,7 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
 import io.mockk.verify
+import com.d4rk.android.libs.apptoolkit.core.di.TestDispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.UnconfinedTestDispatcher
 import kotlinx.coroutines.test.runTest
@@ -35,7 +36,7 @@ class TestAppInfoHelper {
         every { intent.resolveActivity(pm) } returns mockk<ComponentName>()
         justRun { context.startActivity(intent) }
 
-        AppInfoHelper(dispatcher).openApp(context, "pkg")
+        AppInfoHelper(TestDispatchers(dispatcher)).openApp(context, "pkg")
 
         verify { intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) }
         println("🏁 [TEST DONE] openApp adds new task flag when context not Activity")
@@ -51,7 +52,7 @@ class TestAppInfoHelper {
         every { context.packageManager } returns pm
         every { pm.getApplicationInfo("pkg", 0) } returns appInfo
 
-        val result = AppInfoHelper(dispatcher).isAppInstalled(context, "pkg")
+        val result = AppInfoHelper(TestDispatchers(dispatcher)).isAppInstalled(context, "pkg")
 
         assertEquals(true, result)
         println("🏁 [TEST DONE] isAppInstalled returns true when app exists")
@@ -66,7 +67,7 @@ class TestAppInfoHelper {
         every { context.packageManager } returns pm
         every { pm.getApplicationInfo("pkg", 0) } throws PackageManager.NameNotFoundException()
 
-        val result = AppInfoHelper(dispatcher).isAppInstalled(context, "pkg")
+        val result = AppInfoHelper(TestDispatchers(dispatcher)).isAppInstalled(context, "pkg")
 
         assertEquals(false, result)
         println("🏁 [TEST DONE] isAppInstalled returns false when app missing")
@@ -84,7 +85,7 @@ class TestAppInfoHelper {
         every { intent.resolveActivity(pm) } returns mockk<ComponentName>()
         justRun { context.startActivity(intent) }
 
-        AppInfoHelper(dispatcher).openApp(context, "pkg")
+        AppInfoHelper(TestDispatchers(dispatcher)).openApp(context, "pkg")
 
         verify(exactly = 0) { intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) }
         println("🏁 [TEST DONE] openApp does not add new task flag when context is Activity")
@@ -104,7 +105,7 @@ class TestAppInfoHelper {
             val toast = mockk<Toast>(relaxed = true)
             every { Toast.makeText(context, "not installed", Toast.LENGTH_SHORT) } returns toast
 
-            val result = AppInfoHelper(dispatcher).openApp(context, "pkg")
+        val result = AppInfoHelper(TestDispatchers(dispatcher)).openApp(context, "pkg")
 
             assertEquals(false, result)
             verify { Toast.makeText(context, "not installed", Toast.LENGTH_SHORT) }
@@ -126,7 +127,7 @@ class TestAppInfoHelper {
         every { intent.resolveActivity(pm) } returns mockk<ComponentName>()
         justRun { context.startActivity(intent) }
 
-        val result = AppInfoHelper(dispatcher).openAppResult(context, "pkg")
+        val result = AppInfoHelper(TestDispatchers(dispatcher)).openAppResult(context, "pkg")
 
         assertEquals(Result.success(true), result)
         println("🏁 [TEST DONE] openAppResult returns success when launch succeeds")
@@ -149,7 +150,7 @@ class TestAppInfoHelper {
             every { Toast.makeText(context, "not installed", Toast.LENGTH_SHORT) } returns toast
             every { context.startActivity(intent) } throws RuntimeException("fail")
 
-            val result = AppInfoHelper(dispatcher).openApp(context, "pkg")
+        val result = AppInfoHelper(TestDispatchers(dispatcher)).openApp(context, "pkg")
             assertEquals(false, result)
             verify { Toast.makeText(context, "not installed", Toast.LENGTH_SHORT) }
             println("🏁 [TEST DONE] openApp returns false on start failure")
@@ -175,7 +176,7 @@ class TestAppInfoHelper {
             every { Toast.makeText(context, "not installed", Toast.LENGTH_SHORT) } returns toast
             every { context.startActivity(intent) } throws RuntimeException("fail")
 
-            val result = AppInfoHelper(dispatcher).openAppResult(context, "pkg")
+            val result = AppInfoHelper(TestDispatchers(dispatcher)).openAppResult(context, "pkg")
             assertTrue(result.isFailure)
             verify { Toast.makeText(context, "not installed", Toast.LENGTH_SHORT) }
             println("🏁 [TEST DONE] openAppResult exposes failure")

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/data/core/ads/TestAdsCoreManager.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/data/core/ads/TestAdsCoreManager.kt
@@ -3,6 +3,7 @@ package com.d4rk.android.libs.apptoolkit.data.core.ads
 import android.app.Activity
 import android.content.Context
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoProvider
+import com.d4rk.android.libs.apptoolkit.core.di.TestDispatchers
 import com.d4rk.android.libs.apptoolkit.core.utils.interfaces.OnShowAdCompleteListener
 import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
 import com.google.android.gms.ads.FullScreenContentCallback
@@ -39,7 +40,7 @@ class TestAdsCoreManager {
         val context = mockk<Context>()
         every { context.applicationContext } returns context
         val provider = mockk<BuildInfoProvider>()
-        val manager = AdsCoreManager(context, provider)
+        val manager = AdsCoreManager(context, provider, TestDispatchers())
 
         val dataStore = mockk<CommonDataStore>()
         every { dataStore.ads(any()) } returns flowOf(true)
@@ -61,7 +62,7 @@ class TestAdsCoreManager {
         val context = mockk<Context>()
         every { context.applicationContext } returns context
         val provider = mockk<BuildInfoProvider>()
-        val manager = AdsCoreManager(context, provider)
+        val manager = AdsCoreManager(context, provider, TestDispatchers())
         val activity = mockk<Activity>()
 
         manager.showAdIfAvailable(activity, testScope)
@@ -74,7 +75,7 @@ class TestAdsCoreManager {
         val context = mockk<Context>()
         every { context.applicationContext } returns context
         val provider = mockk<BuildInfoProvider>()
-        val manager = AdsCoreManager(context, provider)
+        val manager = AdsCoreManager(context, provider, TestDispatchers())
         val dataStore = mockk<CommonDataStore>()
         every { dataStore.ads(any()) } returns flowOf(true)
         val storeField = AdsCoreManager::class.java.getDeclaredField("dataStore")
@@ -119,7 +120,7 @@ class TestAdsCoreManager {
         val context = mockk<Context>()
         every { context.applicationContext } returns context
         val provider = mockk<BuildInfoProvider>()
-        val manager = AdsCoreManager(context, provider)
+        val manager = AdsCoreManager(context, provider, TestDispatchers())
         val dataStore = mockk<CommonDataStore>()
         every { dataStore.ads(any()) } returns flowOf(true)
         val storeField = AdsCoreManager::class.java.getDeclaredField("dataStore")
@@ -155,7 +156,7 @@ class TestAdsCoreManager {
         val context = mockk<Context>(relaxed = true)
         every { context.applicationContext } returns context
         val provider = mockk<BuildInfoProvider>()
-        val manager = AdsCoreManager(context, provider)
+        val manager = AdsCoreManager(context, provider, TestDispatchers())
         val dataStore = mockk<CommonDataStore>()
         every { dataStore.ads(any()) } returns flowOf(true)
         val storeField = AdsCoreManager::class.java.getDeclaredField("dataStore")
@@ -203,7 +204,7 @@ class TestAdsCoreManager {
         val context = mockk<Context>()
         every { context.applicationContext } returns context
         val provider = mockk<BuildInfoProvider>()
-        val manager = AdsCoreManager(context, provider)
+        val manager = AdsCoreManager(context, provider, TestDispatchers())
         val dataStore = mockk<CommonDataStore>()
         every { dataStore.ads(any()) } returns flowOf(false)
         val storeField = AdsCoreManager::class.java.getDeclaredField("dataStore")
@@ -227,7 +228,7 @@ class TestAdsCoreManager {
         val context = mockk<Context>()
         every { context.applicationContext } returns context
         val provider = mockk<BuildInfoProvider>()
-        val manager = AdsCoreManager(context, provider)
+        val manager = AdsCoreManager(context, provider, TestDispatchers())
         val dataStore = mockk<CommonDataStore>()
         every { dataStore.ads(any()) } returns flowOf(true)
         val storeField = AdsCoreManager::class.java.getDeclaredField("dataStore")
@@ -264,7 +265,7 @@ class TestAdsCoreManager {
         val context = mockk<Context>()
         every { context.applicationContext } returns context
         val provider = mockk<BuildInfoProvider>()
-        val manager = AdsCoreManager(context, provider)
+        val manager = AdsCoreManager(context, provider, TestDispatchers())
         val dataStore = mockk<CommonDataStore>()
         every { dataStore.ads(any()) } returns flowOf(true)
         val storeField = AdsCoreManager::class.java.getDeclaredField("dataStore")
@@ -301,7 +302,7 @@ class TestAdsCoreManager {
         val context = mockk<Context>()
         every { context.applicationContext } returns context
         val provider = mockk<BuildInfoProvider>()
-        val manager = AdsCoreManager(context, provider)
+        val manager = AdsCoreManager(context, provider, TestDispatchers())
         val dataStore = mockk<CommonDataStore>()
         every { dataStore.ads(any()) } returns flowOf(true)
         val storeField = AdsCoreManager::class.java.getDeclaredField("dataStore")
@@ -345,7 +346,7 @@ class TestAdsCoreManager {
         val context = mockk<Context>()
         every { context.applicationContext } returns context
         val provider = mockk<BuildInfoProvider>()
-        val manager = AdsCoreManager(context, provider)
+        val manager = AdsCoreManager(context, provider, TestDispatchers())
         val dataStore = mockk<CommonDataStore>()
         every { dataStore.ads(any()) } returns flowOf(true)
         val storeField = AdsCoreManager::class.java.getDeclaredField("dataStore")
@@ -378,7 +379,7 @@ class TestAdsCoreManager {
         every { context.applicationContext } returns context
         val provider = mockk<BuildInfoProvider>()
         every { provider.isDebugBuild } returns true
-        val manager = AdsCoreManager(context, provider)
+        val manager = AdsCoreManager(context, provider, TestDispatchers())
         val dataStore = mockk<CommonDataStore>()
         val slot = slot<Boolean>()
         every { dataStore.ads(capture(slot)) } returns flowOf(false)
@@ -404,7 +405,7 @@ class TestAdsCoreManager {
         every { context.applicationContext } returns context
         val provider = mockk<BuildInfoProvider>()
         every { provider.isDebugBuild } returns false
-        val manager = AdsCoreManager(context, provider)
+        val manager = AdsCoreManager(context, provider, TestDispatchers())
         val dataStore = mockk<CommonDataStore>()
         val slot = slot<Boolean>()
         every { dataStore.ads(capture(slot)) } returns flowOf(true)


### PR DESCRIPTION
## Summary
- centralize coroutine dispatchers with StandardDispatchers and remove named dispatcher definitions
- inject DispatcherProvider across repositories, view models, and UI components
- update tests for new DispatcherProvider-based constructors

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9eb082864832d9e4828b9bfcb53c1