### PR TITLE
Optimize apps grid performance

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/model/AppInfo.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/model/AppInfo.kt
@@ -1,5 +1,8 @@
 package com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model
 
+import androidx.compose.runtime.Immutable
+
+@Immutable
 data class AppInfo(
     val name: String,
     val packageName: String,

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/model/AppListItem.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/model/AppListItem.kt
@@ -1,6 +1,10 @@
 package com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model
 
+import androidx.compose.runtime.Immutable
+
+@Immutable
 sealed interface AppListItem {
-    data class App(val appInfo : AppInfo) : AppListItem
+    @Immutable
+    data class App(val appInfo: AppInfo) : AppListItem
     data object Ad : AppListItem
 }

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/AppsList.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/AppsList.kt
@@ -103,18 +103,30 @@ private fun AppsGrid(
             },
             span = { _, item ->
                 if (item is AppListItem.Ad) GridItemSpan(columnCount) else GridItemSpan(1)
+            },
+            contentType = { _, item ->
+                when (item) {
+                    is AppListItem.App -> "app"
+                    AppListItem.Ad -> "ad"
+                }
             }
         ) { index: Int, item: AppListItem ->
             when (item) {
-                is AppListItem.App -> AppCardItem(
-                    item = item,
-                    isFavorite = favorites.contains(item.appInfo.packageName),
-                    visibilityStates = visibilityStates,
-                    index = index,
-                    onFavoriteToggle = onFavoriteToggle,
-                    onAppClick = onAppClick,
-                    onShareClick = onShareClick
-                )
+                is AppListItem.App -> {
+                    val packageName = item.appInfo.packageName
+                    val isFavorite by remember(favorites, packageName) {
+                        derivedStateOf { favorites.contains(packageName) }
+                    }
+                    AppCardItem(
+                        item = item,
+                        isFavorite = isFavorite,
+                        visibilityStates = visibilityStates,
+                        index = index,
+                        onFavoriteToggle = onFavoriteToggle,
+                        onAppClick = onAppClick,
+                        onShareClick = onShareClick
+                    )
+                }
 
                 AppListItem.Ad -> AdListItem(adsConfig = adsConfig)
             }


### PR DESCRIPTION
## Summary
- Mark app list models as `@Immutable` to help Compose skip unnecessary recompositions
- Provide explicit `contentType` and cached favorite checks in apps grid for better item reuse

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b9ebd2625c832dbca98c3329d63f98