### PR TITLE
Add help screen native ad banner

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AdsModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AdsModule.kt
@@ -32,6 +32,10 @@ val adsModule : Module = module {
         AdsConfig(bannerAdUnitId = AdsConstants.NATIVE_AD_UNIT_ID)
     }
 
+    single<AdsConfig>(named(name = "help_native_ad")) {
+        AdsConfig(bannerAdUnitId = AdsConstants.HELP_NATIVE_AD_UNIT_ID)
+    }
+
     single<AdsConfig> {
         AdsConfig(bannerAdUnitId = AdsConstants.BANNER_AD_UNIT_ID , adSize = AdSize.BANNER)
     }

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/utils/constants/ads/AdsConstants.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/utils/constants/ads/AdsConstants.kt
@@ -27,4 +27,11 @@ object AdsConstants {
         } else {
             "ca-app-pub-5294151573817700/5578142927"
         }
+
+    val HELP_NATIVE_AD_UNIT_ID: String
+        get() = if (BuildConfig.DEBUG) {
+            DebugAdsConstants.NATIVE_AD_UNIT_ID
+        } else {
+            "ca-app-pub-5294151573817700/5578142927"
+        }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpScreen.kt
@@ -42,6 +42,10 @@ import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.MediumVertica
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.IntentsHelper
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.ReviewHelper
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
+import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.HelpNativeAdBanner
+import org.koin.compose.koinInject
+import org.koin.core.qualifier.named
 import kotlinx.coroutines.CoroutineScope
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -102,6 +106,8 @@ fun HelpScreen(activity: ComponentActivity, config: HelpScreenConfig, scope: Cor
 
 @Composable
 fun HelpScreenContent(questions : List<UiHelpQuestion> , paddingValues : PaddingValues , activity : ComponentActivity) {
+    val nativeAdsConfig: AdsConfig = koinInject(qualifier = named("help_native_ad"))
+
     LazyColumn(
         modifier = Modifier.fillMaxSize() , contentPadding = PaddingValues(
             top = paddingValues.calculateTopPadding() , bottom = paddingValues.calculateBottomPadding() , start = SizeConstants.LargeSize , end = SizeConstants.LargeSize
@@ -114,6 +120,12 @@ fun HelpScreenContent(questions : List<UiHelpQuestion> , paddingValues : Padding
         item {
             HelpQuestionsList(questions = questions)
             MediumVerticalSpacer()
+        }
+        item {
+            HelpNativeAdBanner(
+                adsConfig = nativeAdsConfig,
+                modifier = Modifier.padding(vertical = SizeConstants.MediumSize)
+            )
         }
         item {
             ContactUsCard(onClick = {

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/HelpNativeAd.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/HelpNativeAd.kt
@@ -1,0 +1,148 @@
+package com.d4rk.android.libs.apptoolkit.core.ui.components.ads
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.core.graphics.drawable.toBitmap
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
+import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeHorizontalSpacer
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
+import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
+import com.google.android.gms.ads.AdLoader
+import com.google.android.gms.ads.AdRequest
+import com.google.android.gms.ads.nativead.NativeAd
+
+/**
+ * Help screen specific native ad banner composable.
+ */
+@Composable
+fun HelpNativeAdBanner(
+    adsConfig: AdsConfig,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val dataStore: CommonDataStore = remember { CommonDataStore.getInstance(context = context) }
+    val showAds: Boolean by dataStore.adsEnabledFlow.collectAsStateWithLifecycle(initialValue = true)
+
+    if (LocalInspectionMode.current) {
+        OutlinedCard(
+            modifier = modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(size = SizeConstants.MediumSize)
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(80.dp)
+                    .background(Color.LightGray)
+            ) {
+                Text(text = "Native Ad", modifier = Modifier.align(Alignment.Center))
+            }
+        }
+        return
+    }
+
+    if (showAds) {
+        var nativeAd by remember { mutableStateOf<NativeAd?>(null) }
+
+        DisposableEffect(key1 = nativeAd) {
+            onDispose { nativeAd?.destroy() }
+        }
+
+        LaunchedEffect(key1 = adsConfig.bannerAdUnitId) {
+            val loader = AdLoader.Builder(context, adsConfig.bannerAdUnitId)
+                .forNativeAd { ad -> nativeAd = ad }
+                .build()
+            loader.loadAd(AdRequest.Builder().build())
+        }
+
+        nativeAd?.let { ad ->
+            NativeAdView(ad = ad) { loadedAd, view ->
+                OutlinedCard(
+                    modifier = modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(size = SizeConstants.MediumSize)
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(SizeConstants.LargeSize)
+                    ) {
+                        Text(
+                            text = "Ad",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.Start
+                        ) {
+                            loadedAd.icon?.drawable?.let { drawable ->
+                                Image(
+                                    painter = remember(drawable) {
+                                        BitmapPainter(drawable.toBitmap().asImageBitmap())
+                                    },
+                                    contentDescription = loadedAd.headline,
+                                    modifier = Modifier
+                                        .size(SizeConstants.ExtraLargeIncreasedSize)
+                                        .clip(RoundedCornerShape(size = SizeConstants.SmallSize))
+                                )
+                                LargeHorizontalSpacer()
+                            }
+                            Column(
+                                modifier = Modifier.weight(1f),
+                                verticalArrangement = Arrangement.Center
+                            ) {
+                                Text(
+                                    text = loadedAd.headline ?: "",
+                                    fontWeight = FontWeight.Bold
+                                )
+                                loadedAd.body?.let { body ->
+                                    Text(
+                                        text = body,
+                                        style = MaterialTheme.typography.bodySmall
+                                    )
+                                }
+                            }
+                            loadedAd.callToAction?.let { cta ->
+                                LargeHorizontalSpacer()
+                                Button(onClick = { view.performClick() }) {
+                                    Text(text = cta)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+


### PR DESCRIPTION
## Summary
- add HelpNativeAdBanner composable for displaying native ads on the Help screen with proper styling and disclosure
- inject Help screen native ad configuration and show the banner in Help content
- register help native ad config and constant in DI and constants

## Testing
- `./gradlew test` *(fails: SDK location not found)*
- `apt-get install -y android-sdk` *(fails: Unable to locate package android-sdk)*

------
https://chatgpt.com/codex/tasks/task_e_68ba89300120832d9726b78679bc6d0a