### PR TITLE
feat: add native bottom nav ad banner

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/main/ui/components/navigation/BottomNavigationBar.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/main/ui/components/navigation/BottomNavigationBar.kt
@@ -25,7 +25,7 @@ import androidx.navigation.NavController
 import androidx.navigation.compose.currentBackStackEntryAsState
 import com.d4rk.android.libs.apptoolkit.app.main.domain.model.BottomBarItem
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
-import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.AdBanner
+import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.BottomAppBarNativeAdBanner
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
 import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
 import org.koin.compose.koinInject
@@ -50,7 +50,7 @@ fun BottomNavigationBar(
 
     Column(modifier = modifier) {
         key("bottom_ad") {
-            AdBanner(modifier = Modifier.fillMaxWidth(), adsConfig = adsConfig)
+            BottomAppBarNativeAdBanner(modifier = Modifier.fillMaxWidth(), adsConfig = adsConfig)
         }
 
         NavigationBar {

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NativeAdView.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NativeAdView.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -17,6 +18,7 @@ import androidx.compose.material3.Card
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.NavigationBar
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
@@ -35,6 +37,7 @@ import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.graphics.drawable.toBitmap
@@ -227,6 +230,85 @@ fun LargeNativeAdBanner(
                                 Button(onClick = { view.performClick() }) {
                                     Text(text = cta)
                                 }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun BottomAppBarNativeAdBanner(
+    modifier: Modifier = Modifier,
+    adsConfig: AdsConfig,
+) {
+    val context = LocalContext.current
+    val dataStore: CommonDataStore = remember { CommonDataStore.getInstance(context = context) }
+    val showAds: Boolean by dataStore.adsEnabledFlow.collectAsStateWithLifecycle(initialValue = true)
+
+    if (LocalInspectionMode.current) {
+        NavigationBar(modifier = modifier.fillMaxWidth()) {
+            Box(
+                modifier = Modifier
+                    .weight(1f)
+                    .fillMaxWidth(),
+                contentAlignment = Alignment.Center
+            ) {
+                Text(text = "Native Ad")
+            }
+        }
+        return
+    }
+
+    if (showAds) {
+        var nativeAd by remember { mutableStateOf<NativeAd?>(null) }
+
+        DisposableEffect(key1 = nativeAd) {
+            onDispose { nativeAd?.destroy() }
+        }
+
+        LaunchedEffect(key1 = adsConfig.bannerAdUnitId) {
+            val loader = AdLoader.Builder(context, adsConfig.bannerAdUnitId)
+                .forNativeAd { ad -> nativeAd = ad }
+                .build()
+            loader.loadAd(AdRequest.Builder().build())
+        }
+
+        nativeAd?.let { ad ->
+            NativeAdView(ad = ad) { loadedAd, view ->
+                NavigationBar(modifier = modifier.fillMaxWidth()) {
+                    Row(
+                        modifier = Modifier
+                            .weight(1f)
+                            .fillMaxHeight()
+                            .padding(horizontal = SizeConstants.LargeSize),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        loadedAd.icon?.drawable?.let { drawable ->
+                            Image(
+                                painter = remember(drawable) {
+                                    BitmapPainter(drawable.toBitmap().asImageBitmap())
+                                },
+                                contentDescription = loadedAd.headline,
+                                modifier = Modifier
+                                    .size(SizeConstants.ExtraLargeIncreasedSize)
+                                    .clip(RoundedCornerShape(size = SizeConstants.SmallSize))
+                            )
+                            LargeHorizontalSpacer()
+                        }
+                        Text(
+                            text = loadedAd.headline ?: "",
+                            fontWeight = FontWeight.Bold,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis,
+                            modifier = Modifier.weight(1f)
+                        )
+                        loadedAd.callToAction?.let { cta ->
+                            LargeHorizontalSpacer()
+                            Button(onClick = { view.performClick() }) {
+                                Text(text = cta)
                             }
                         }
                     }


### PR DESCRIPTION
## Summary
- add BottomAppBarNativeAdBanner native ad styled like bottom navigation
- replace full banner ad in bottom navigation with new native banner

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba897c879c832db32b5d33c9d8b6ab