### PR TITLE
Add native ad banner for no data screen

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NoDataNativeAd.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NoDataNativeAd.kt
@@ -1,0 +1,149 @@
+package com.d4rk.android.libs.apptoolkit.core.ui.components.ads
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedCard
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalInspectionMode
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.core.graphics.drawable.toBitmap
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
+import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeHorizontalSpacer
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
+import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
+import com.google.android.gms.ads.AdLoader
+import com.google.android.gms.ads.AdRequest
+import com.google.android.gms.ads.nativead.NativeAd
+
+/**
+ * Native ad banner tailored for the no data screen.
+ */
+@Composable
+fun NoDataNativeAdBanner(
+    adsConfig: AdsConfig,
+    modifier: Modifier = Modifier,
+) {
+    val context = LocalContext.current
+    val dataStore: CommonDataStore = remember { CommonDataStore.getInstance(context = context) }
+    val showAds: Boolean by dataStore.adsEnabledFlow.collectAsStateWithLifecycle(initialValue = true)
+
+    if (LocalInspectionMode.current) {
+        OutlinedCard(
+            modifier = modifier.fillMaxWidth(),
+            shape = RoundedCornerShape(size = SizeConstants.ExtraLargeSize)
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(80.dp)
+                    .background(Color.LightGray)
+            ) {
+                Text(text = "Native Ad", modifier = Modifier.align(Alignment.Center))
+            }
+        }
+        return
+    }
+
+    if (showAds) {
+        var nativeAd by remember { mutableStateOf<NativeAd?>(null) }
+
+        DisposableEffect(key1 = nativeAd) {
+            onDispose { nativeAd?.destroy() }
+        }
+
+        LaunchedEffect(key1 = adsConfig.bannerAdUnitId) {
+            val loader = AdLoader.Builder(context, adsConfig.bannerAdUnitId)
+                .forNativeAd { ad -> nativeAd = ad }
+                .build()
+            loader.loadAd(AdRequest.Builder().build())
+        }
+
+        nativeAd?.let { ad ->
+            NativeAdView(ad = ad) { loadedAd, view ->
+                OutlinedCard(
+                    modifier = modifier.fillMaxWidth(),
+                    shape = RoundedCornerShape(size = SizeConstants.ExtraLargeSize)
+                ) {
+                    Column(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(SizeConstants.LargeSize)
+                    ) {
+                        Text(
+                            text = "Ad",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically,
+                            horizontalArrangement = Arrangement.Start
+                        ) {
+                            loadedAd.icon?.drawable?.let { drawable ->
+                                Image(
+                                    painter = remember(drawable) {
+                                        BitmapPainter(drawable.toBitmap().asImageBitmap())
+                                    },
+                                    contentDescription = loadedAd.headline,
+                                    modifier = Modifier
+                                        .size(SizeConstants.ExtraLargeIncreasedSize)
+                                        .clip(RoundedCornerShape(size = SizeConstants.SmallSize))
+                                )
+                                LargeHorizontalSpacer()
+                            }
+                            Column(
+                                modifier = Modifier.weight(1f),
+                                verticalArrangement = Arrangement.Center
+                            ) {
+                                Text(
+                                    text = loadedAd.headline ?: "",
+                                    fontWeight = FontWeight.Bold
+                                )
+                                loadedAd.body?.let { body ->
+                                    Text(
+                                        text = body,
+                                        style = MaterialTheme.typography.bodySmall
+                                    )
+                                }
+                            }
+                            loadedAd.callToAction?.let { cta ->
+                                LargeHorizontalSpacer()
+                                Button(onClick = { view.performClick() }) {
+                                    Text(text = cta)
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/layouts/NoDataScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/layouts/NoDataScreen.kt
@@ -23,7 +23,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
-import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.AdBanner
+import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NoDataNativeAdBanner
 import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.IconButtonWithText
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
@@ -51,9 +51,9 @@ fun NoDataScreen(
     onRetry: () -> Unit = {},
     showAd: Boolean = true,
     isError: Boolean = false,
-    adsConfig: AdsConfig = koinInject(qualifier = named(name = "large_banner")),
+    adsConfig: AdsConfig = koinInject(qualifier = named(name = "native_ad")),
 ) {
-    val bannerConfig: AdsConfig = remember { adsConfig }
+    val nativeAdConfig: AdsConfig = remember { adsConfig }
 
     Box(
         modifier = Modifier
@@ -89,11 +89,11 @@ fun NoDataScreen(
             LargeVerticalSpacer()
 
             if (showAd) {
-                AdBanner(
+                NoDataNativeAdBanner(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(bottom = SizeConstants.MediumSize),
-                    adsConfig = bannerConfig
+                    adsConfig = nativeAdConfig
                 )
             }
         }


### PR DESCRIPTION
## Summary
- add `NoDataNativeAdBanner` composable to display a native ad in empty state pages
- hook the new native ad into `NoDataScreen`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba8f27c18c832dac10e3835838535a