### PR TITLE
Optimize native ad config usage

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/AppsList.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/AppsList.kt
@@ -52,6 +52,7 @@ fun AppsList(
     val items by remember(apps, adsEnabled) {
         derivedStateOf { buildAppListItems(apps, adsEnabled, adFrequency) }
     }
+    val adsConfig: AdsConfig = koinInject(qualifier = named("native_ad"))
 
     AppsGrid(
         items = items,
@@ -61,7 +62,8 @@ fun AppsList(
         listState = listState,
         onFavoriteToggle = onFavoriteToggle,
         onAppClick = onAppClick,
-        onShareClick = onShareClick
+        onShareClick = onShareClick,
+        adsConfig = adsConfig
     )
 }
 
@@ -75,7 +77,8 @@ private fun AppsGrid(
     listState: LazyGridState,
     onFavoriteToggle: (String) -> Unit,
     onAppClick: (AppInfo) -> Unit,
-    onShareClick: (AppInfo) -> Unit
+    onShareClick: (AppInfo) -> Unit,
+    adsConfig: AdsConfig,
 ) {
     LazyVerticalGrid(
         columns = GridCells.Fixed(count = columnCount),
@@ -127,6 +130,7 @@ private fun AppsGrid(
                     modifier = Modifier
                         .animateItem()
                         .animateVisibility(index = index),
+                    adsConfig = adsConfig
                 )
             }
         }
@@ -156,9 +160,8 @@ private fun AppCardItem(
 @Composable
 private fun AdListItem(
     modifier: Modifier = Modifier,
+    adsConfig: AdsConfig,
 ) {
-    val adsConfig: AdsConfig = koinInject(qualifier = named("native_ad"))
-
     NativeAdBanner(
         modifier = modifier.fillMaxWidth(),
         adsConfig = adsConfig

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpScreen.kt
@@ -44,6 +44,9 @@ import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.ExtraLargeVer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.IntentsHelper
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.ReviewHelper
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
+import org.koin.compose.koinInject
+import org.koin.core.qualifier.named
 import kotlinx.coroutines.CoroutineScope
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -104,6 +107,7 @@ fun HelpScreen(activity: ComponentActivity, config: HelpScreenConfig, scope: Cor
 
 @Composable
 fun HelpScreenContent(questions : List<UiHelpQuestion> , paddingValues : PaddingValues , activity : ComponentActivity) {
+    val adsConfig: AdsConfig = koinInject(qualifier = named("native_ad"))
     LazyColumn(
         modifier = Modifier.fillMaxSize() , contentPadding = PaddingValues(
             top = paddingValues.calculateTopPadding() , bottom = paddingValues.calculateBottomPadding() , start = SizeConstants.LargeSize , end = SizeConstants.LargeSize
@@ -118,7 +122,8 @@ fun HelpScreenContent(questions : List<UiHelpQuestion> , paddingValues : Padding
         }
         item {
             HelpNativeAdBanner(
-                modifier = Modifier.padding(vertical = SizeConstants.MediumSize).animateItem()
+                modifier = Modifier.padding(vertical = SizeConstants.MediumSize).animateItem(),
+                adsConfig = adsConfig
             )
         }
         item {

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/main/ui/components/navigation/BottomNavigationBar.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/main/ui/components/navigation/BottomNavigationBar.kt
@@ -27,6 +27,9 @@ import com.d4rk.android.libs.apptoolkit.app.main.domain.model.BottomBarItem
 import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.BottomAppBarNativeAdBanner
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
 import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
+import org.koin.compose.koinInject
+import org.koin.core.qualifier.named
 
 @Composable
 fun BottomNavigationBar(
@@ -38,6 +41,7 @@ fun BottomNavigationBar(
     val view: View = LocalView.current
     val context = LocalContext.current
     val dataStore: CommonDataStore = CommonDataStore.getInstance(context = context)
+    val adsConfig: AdsConfig = koinInject(qualifier = named("native_ad"))
     val backStackEntry by navController.currentBackStackEntryAsState()
     val currentRoute = backStackEntry?.destination?.route ?: navController.currentDestination?.route
     val showLabels: Boolean =
@@ -45,7 +49,10 @@ fun BottomNavigationBar(
 
     Column(modifier = modifier) {
         key("bottom_ad") {
-            BottomAppBarNativeAdBanner(modifier = Modifier.fillMaxWidth())
+            BottomAppBarNativeAdBanner(
+                modifier = Modifier.fillMaxWidth(),
+                adsConfig = adsConfig
+            )
         }
 
         NavigationBar {

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/BottomAppBarNativeAdBanner.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/BottomAppBarNativeAdBanner.kt
@@ -35,15 +35,14 @@ import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
 import com.google.android.gms.ads.AdLoader
 import com.google.android.gms.ads.AdRequest
 import com.google.android.gms.ads.nativead.NativeAd
-import org.koin.compose.koinInject
-import org.koin.core.qualifier.named
-
 @Composable
-fun BottomAppBarNativeAdBanner(modifier: Modifier = Modifier) {
+fun BottomAppBarNativeAdBanner(
+    modifier: Modifier = Modifier,
+    adsConfig: AdsConfig,
+) {
     val context = LocalContext.current
     val dataStore: CommonDataStore = remember { CommonDataStore.getInstance(context = context) }
     val showAds: Boolean by dataStore.adsEnabledFlow.collectAsStateWithLifecycle(initialValue = true)
-    val adsConfig: AdsConfig = koinInject(qualifier = named("native_ad"))
     if (LocalInspectionMode.current) {
         NavigationBar(modifier = modifier.fillMaxWidth()) {
             Box(

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/HelpNativeAd.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/HelpNativeAd.kt
@@ -40,17 +40,14 @@ import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
 import com.google.android.gms.ads.AdLoader
 import com.google.android.gms.ads.AdRequest
 import com.google.android.gms.ads.nativead.NativeAd
-import org.koin.compose.koinInject
-import org.koin.core.qualifier.named
-
 /**
  * Help screen specific native ad banner composable.
  */
 @Composable
 fun HelpNativeAdBanner(
     modifier: Modifier = Modifier,
+    adsConfig: AdsConfig,
 ) {
-    val adsConfig: AdsConfig = koinInject(qualifier = named("native_ad"))
     val context = LocalContext.current
     val dataStore: CommonDataStore = remember { CommonDataStore.getInstance(context = context) }
     val showAds: Boolean by dataStore.adsEnabledFlow.collectAsStateWithLifecycle(initialValue = true)

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/layouts/NoDataScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/layouts/NoDataScreen.kt
@@ -15,7 +15,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -53,7 +52,6 @@ fun NoDataScreen(
     isError: Boolean = false,
     adsConfig: AdsConfig = koinInject(qualifier = named(name = "native_ad")),
 ) {
-    val nativeAdConfig: AdsConfig = remember { adsConfig }
 
     Box(
         modifier = Modifier
@@ -93,7 +91,7 @@ fun NoDataScreen(
                     modifier = Modifier
                         .fillMaxWidth()
                         .padding(all = SizeConstants.MediumSize),
-                    adsConfig = nativeAdConfig
+                    adsConfig = adsConfig
                 )
             }
         }


### PR DESCRIPTION
## Summary
- Pass AdsConfig from callers into native ad banners instead of injecting inside
- Remove redundant remember calls for ad configuration

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba965e3d88832dab26c8f7674a3a12