### PR TITLE
Ensure native ads meet Google policy requirements

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/ui/components/ads/NativeAdBanner.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/ui/components/ads/NativeAdBanner.kt
@@ -1,6 +1,5 @@
 package com.d4rk.android.apps.apptoolkit.core.ui.components.ads
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -11,7 +10,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
 import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -26,13 +24,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.core.graphics.drawable.toBitmap
+import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
 import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdView
@@ -84,50 +80,71 @@ fun NativeAdBanner(
         }
 
         nativeAd?.let { ad ->
-            NativeAdView(ad = ad) { loadedAd, view ->
+            NativeAdView(ad = ad) { loadedAd, assets ->
                 Card(
                     modifier = modifier.fillMaxWidth(),
                     shape = RoundedCornerShape(size = SizeConstants.ExtraLargeSize)
                 ) {
-                    Row(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(SizeConstants.LargeSize),
-                        verticalAlignment = Alignment.CenterVertically
-                    ) {
-                        loadedAd.icon?.drawable?.let { drawable ->
-                            Image(
-                                painter = remember(drawable) {
-                                    BitmapPainter(drawable.toBitmap().asImageBitmap())
-                                },
-                                contentDescription = loadedAd.headline,
-                                modifier = Modifier
-                                    .size(SizeConstants.ExtraLargeIncreasedSize)
-                                    .clip(RoundedCornerShape(size = SizeConstants.SmallSize))
-                            )
-                            LargeHorizontalSpacer()
-                        }
+                    Box {
                         Column(
-                            modifier = Modifier.weight(1f),
-                            verticalArrangement = Arrangement.Center
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(SizeConstants.LargeSize)
                         ) {
                             Text(
-                                text = loadedAd.headline ?: "",
-                                fontWeight = FontWeight.Bold
+                                text = "Ad",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.primary
                             )
-                            loadedAd.body?.let { body ->
-                                Text(
-                                    text = body,
-                                    style = MaterialTheme.typography.bodySmall
-                                )
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                verticalAlignment = Alignment.CenterVertically
+                            ) {
+                                loadedAd.icon?.drawable?.let { drawable ->
+                                    AndroidView(
+                                        factory = { assets.iconView },
+                                        update = { it.setImageDrawable(drawable) },
+                                        modifier = Modifier
+                                            .size(SizeConstants.ExtraLargeIncreasedSize)
+                                            .clip(RoundedCornerShape(size = SizeConstants.SmallSize))
+                                    )
+                                    LargeHorizontalSpacer()
+                                }
+                                Column(
+                                    modifier = Modifier.weight(1f),
+                                    verticalArrangement = Arrangement.Center
+                                ) {
+                                    AndroidView(factory = { assets.headlineView }) { view ->
+                                        view.setContent {
+                                            Text(
+                                                text = loadedAd.headline ?: "",
+                                                fontWeight = FontWeight.Bold
+                                            )
+                                        }
+                                    }
+                                    loadedAd.body?.let { body ->
+                                        AndroidView(factory = { assets.bodyView }) { view ->
+                                            view.setContent {
+                                                Text(
+                                                    text = body,
+                                                    style = MaterialTheme.typography.bodySmall
+                                                )
+                                            }
+                                        }
+                                    }
+                                }
+                                loadedAd.callToAction?.let { cta ->
+                                    LargeHorizontalSpacer()
+                                    AndroidView(factory = { assets.callToActionView }) { button ->
+                                        button.text = cta
+                                    }
+                                }
                             }
                         }
-                        loadedAd.callToAction?.let { cta ->
-                            LargeHorizontalSpacer()
-                            Button(onClick = { view.performClick() }) {
-                                Text(text = cta)
-                            }
-                        }
+                        AndroidView(
+                            factory = { assets.adChoicesView },
+                            modifier = Modifier.align(Alignment.TopEnd)
+                        )
                     }
                 }
             }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/HelpNativeAd.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/HelpNativeAd.kt
@@ -1,5 +1,4 @@
 package com.d4rk.android.libs.apptoolkit.core.ui.components.ads
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -10,9 +9,8 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Card
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -25,13 +23,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.core.graphics.drawable.toBitmap
+import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeHorizontalSpacer
@@ -84,60 +80,72 @@ fun HelpNativeAdBanner(
         }
 
         nativeAd?.let { ad ->
-            NativeAdView(ad = ad) { loadedAd, view ->
+            NativeAdView(ad = ad) { loadedAd, assets ->
                 Card(
                     modifier = modifier.fillMaxWidth(),
                     shape = RoundedCornerShape(size = SizeConstants.MediumSize)
                 ) {
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(SizeConstants.LargeSize)
-                    ) {
-                        Text(
-                            text = "Ad",
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.primary
-                        )
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.Start
+                    Box {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(SizeConstants.LargeSize)
                         ) {
-                            loadedAd.icon?.drawable?.let { drawable ->
-                                Image(
-                                    painter = remember(drawable) {
-                                        BitmapPainter(drawable.toBitmap().asImageBitmap())
-                                    },
-                                    contentDescription = loadedAd.headline,
-                                    modifier = Modifier
-                                        .size(SizeConstants.ExtraLargeIncreasedSize)
-                                        .clip(RoundedCornerShape(size = SizeConstants.SmallSize))
-                                )
-                                LargeHorizontalSpacer()
-                            }
-                            Column(
-                                modifier = Modifier.weight(1f),
-                                verticalArrangement = Arrangement.Center
+                            Text(
+                                text = "Ad",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.primary
+                            )
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.Start
                             ) {
-                                Text(
-                                    text = loadedAd.headline ?: "",
-                                    fontWeight = FontWeight.Bold
-                                )
-                                loadedAd.body?.let { body ->
-                                    Text(
-                                        text = body,
-                                        style = MaterialTheme.typography.bodySmall
+                                loadedAd.icon?.drawable?.let { drawable ->
+                                    AndroidView(
+                                        factory = { assets.iconView },
+                                        update = { it.setImageDrawable(drawable) },
+                                        modifier = Modifier
+                                            .size(SizeConstants.ExtraLargeIncreasedSize)
+                                            .clip(RoundedCornerShape(size = SizeConstants.SmallSize))
                                     )
+                                    LargeHorizontalSpacer()
                                 }
-                            }
-                            loadedAd.callToAction?.let { cta ->
-                                LargeHorizontalSpacer()
-                                Button(onClick = { view.performClick() }) {
-                                    Text(text = cta)
+                                Column(
+                                    modifier = Modifier.weight(1f),
+                                    verticalArrangement = Arrangement.Center
+                                ) {
+                                    AndroidView(factory = { assets.headlineView }) { view ->
+                                        view.setContent {
+                                            Text(
+                                                text = loadedAd.headline ?: "",
+                                                fontWeight = FontWeight.Bold
+                                            )
+                                        }
+                                    }
+                                    loadedAd.body?.let { body ->
+                                        AndroidView(factory = { assets.bodyView }) { view ->
+                                            view.setContent {
+                                                Text(
+                                                    text = body,
+                                                    style = MaterialTheme.typography.bodySmall
+                                                )
+                                            }
+                                        }
+                                    }
+                                }
+                                loadedAd.callToAction?.let { cta ->
+                                    LargeHorizontalSpacer()
+                                    AndroidView(factory = { assets.callToActionView }) { button ->
+                                        button.text = cta
+                                    }
                                 }
                             }
                         }
+                        AndroidView(
+                            factory = { assets.adChoicesView },
+                            modifier = Modifier.align(Alignment.TopEnd)
+                        )
                     }
                 }
             }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/LargeNativeAdBanner.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/LargeNativeAdBanner.kt
@@ -1,6 +1,5 @@
 package com.d4rk.android.libs.apptoolkit.core.ui.components.ads
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -26,13 +25,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.core.graphics.drawable.toBitmap
+import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeHorizontalSpacer
@@ -83,54 +80,71 @@ fun LargeNativeAdBanner(
         }
 
         nativeAd?.let { ad ->
-            NativeAdView(ad = ad) { loadedAd, view ->
+            NativeAdView(ad = ad) { loadedAd, assets ->
                 OutlinedCard(
                     modifier = modifier.fillMaxWidth(),
                     shape = RoundedCornerShape(size = SizeConstants.ExtraLargeSize)
                 ) {
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(SizeConstants.LargeSize)
-                    ) {
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically
+                    Box {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(SizeConstants.LargeSize)
                         ) {
-                            loadedAd.icon?.drawable?.let { drawable ->
-                                Image(
-                                    painter = remember(drawable) {
-                                        BitmapPainter(drawable.toBitmap().asImageBitmap())
-                                    },
-                                    contentDescription = loadedAd.headline,
-                                    modifier = Modifier
-                                        .size(SizeConstants.ExtraExtraLargeSize)
-                                        .clip(RoundedCornerShape(size = SizeConstants.SmallSize))
-                                )
-                                LargeHorizontalSpacer()
-                            }
-                            Column(
-                                modifier = Modifier.weight(1f),
-                                verticalArrangement = Arrangement.Center
+                            Text(
+                                text = "Ad",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.primary
+                            )
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically
                             ) {
-                                Text(
-                                    text = loadedAd.headline ?: "",
-                                    fontWeight = FontWeight.Bold,
-                                    style = MaterialTheme.typography.titleMedium
-                                )
-                                loadedAd.body?.let { body ->
-                                    Text(
-                                        text = body,
-                                        style = MaterialTheme.typography.bodyMedium
+                                loadedAd.icon?.drawable?.let { drawable ->
+                                    AndroidView(
+                                        factory = { assets.iconView },
+                                        update = { it.setImageDrawable(drawable) },
+                                        modifier = Modifier
+                                            .size(SizeConstants.ExtraExtraLargeSize)
+                                            .clip(RoundedCornerShape(size = SizeConstants.SmallSize))
                                     )
+                                    LargeHorizontalSpacer()
                                 }
-                            }
-                            loadedAd.callToAction?.let { cta ->
-                                LargeHorizontalSpacer()
-                                FilledTonalButton(onClick = { view.performClick() }) {
-                                    Text(text = cta)
+                                Column(
+                                    modifier = Modifier.weight(1f),
+                                    verticalArrangement = Arrangement.Center
+                                ) {
+                                    AndroidView(factory = { assets.headlineView }) { view ->
+                                        view.setContent {
+                                            Text(
+                                                text = loadedAd.headline ?: "",
+                                                fontWeight = FontWeight.Bold,
+                                                style = MaterialTheme.typography.titleMedium
+                                            )
+                                        }
+                                    }
+                                    loadedAd.body?.let { body ->
+                                        AndroidView(factory = { assets.bodyView }) { view ->
+                                            view.setContent {
+                                                Text(
+                                                    text = body,
+                                                    style = MaterialTheme.typography.bodyMedium
+                                                )
+                                            }
+                                        }
+                                    }
+                                }
+                                loadedAd.callToAction?.let { cta ->
+                                    LargeHorizontalSpacer()
+                                    AndroidView(factory = { assets.callToActionView }) { button ->
+                                        button.text = cta
+                                    }
                                 }
                             }
                         }
+                        AndroidView(
+                            factory = { assets.adChoicesView },
+                            modifier = Modifier.align(Alignment.TopEnd)
+                        )
                     }
                 }
             }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NativeAdView.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NativeAdView.kt
@@ -1,38 +1,60 @@
 package com.d4rk.android.libs.apptoolkit.core.ui.components.ads
 
-import android.view.View
+import android.widget.Button
+import android.widget.ImageView
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
+import com.google.android.gms.ads.AdChoicesView
+import com.google.android.gms.ads.nativead.MediaView
 import com.google.android.gms.ads.nativead.NativeAd
 import com.google.android.gms.ads.nativead.NativeAdView as GoogleNativeAdView
+
+data class NativeAdViewAssets(
+    val headlineView: ComposeView,
+    val bodyView: ComposeView,
+    val iconView: ImageView,
+    val mediaView: MediaView,
+    val callToActionView: Button,
+    val adChoicesView: AdChoicesView,
+    val contentView: ComposeView,
+)
 
 @Composable
 fun NativeAdView(
     ad: NativeAd,
-    adContent: @Composable (ad: NativeAd, contentView: View) -> Unit,
+    adContent: @Composable (ad: NativeAd, assetViews: NativeAdViewAssets) -> Unit,
 ) {
-    val contentViewId by remember { mutableIntStateOf(View.generateViewId()) }
-    val adViewId by remember { mutableIntStateOf(View.generateViewId()) }
+    val context = LocalContext.current
+    val assets = remember {
+        NativeAdViewAssets(
+            headlineView = ComposeView(context),
+            bodyView = ComposeView(context),
+            iconView = ImageView(context),
+            mediaView = MediaView(context),
+            callToActionView = Button(context),
+            adChoicesView = AdChoicesView(context),
+            contentView = ComposeView(context),
+        )
+    }
 
     AndroidView(
-        factory = { context ->
-            val contentView = ComposeView(context).apply { id = contentViewId }
+        factory = {
             GoogleNativeAdView(context).apply {
-                id = adViewId
-                addView(contentView)
+                addView(assets.contentView)
             }
         },
-        update = { view ->
-            val adView = view.findViewById<GoogleNativeAdView>(adViewId)
-            val contentView = view.findViewById<ComposeView>(contentViewId)
-
+        update = { adView ->
+            adView.headlineView = assets.headlineView
+            adView.bodyView = assets.bodyView
+            adView.iconView = assets.iconView
+            adView.mediaView = assets.mediaView
+            adView.callToActionView = assets.callToActionView
+            adView.adChoicesView = assets.adChoicesView
             adView.setNativeAd(ad)
-            adView.callToActionView = contentView
-            contentView.setContent { adContent(ad, contentView) }
+            assets.contentView.setContent { adContent(ad, assets) }
         }
     )
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NativeAdView.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NativeAdView.kt
@@ -7,7 +7,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
-import com.google.android.gms.ads.AdChoicesView
+import com.google.android.gms.ads.nativead.AdChoicesView
 import com.google.android.gms.ads.nativead.MediaView
 import com.google.android.gms.ads.nativead.NativeAd
 import com.google.android.gms.ads.nativead.NativeAdView as GoogleNativeAdView

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NoDataNativeAd.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NoDataNativeAd.kt
@@ -1,6 +1,5 @@
 package com.d4rk.android.libs.apptoolkit.core.ui.components.ads
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -11,7 +10,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.Button
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
 import androidx.compose.material3.Text
@@ -26,13 +24,11 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.core.graphics.drawable.toBitmap
+import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeHorizontalSpacer
@@ -86,60 +82,72 @@ fun NoDataNativeAdBanner(
         }
 
         nativeAd?.let { ad ->
-            NativeAdView(ad = ad) { loadedAd, view ->
+            NativeAdView(ad = ad) { loadedAd, assets ->
                 OutlinedCard(
                     modifier = modifier.fillMaxWidth(),
                     shape = RoundedCornerShape(size = SizeConstants.ExtraLargeSize)
                 ) {
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(SizeConstants.LargeSize)
-                    ) {
-                        Text(
-                            text = "Ad",
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.primary
-                        )
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.Start
+                    Box {
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(SizeConstants.LargeSize)
                         ) {
-                            loadedAd.icon?.drawable?.let { drawable ->
-                                Image(
-                                    painter = remember(drawable) {
-                                        BitmapPainter(drawable.toBitmap().asImageBitmap())
-                                    },
-                                    contentDescription = loadedAd.headline,
-                                    modifier = Modifier
-                                        .size(SizeConstants.ExtraLargeIncreasedSize)
-                                        .clip(RoundedCornerShape(size = SizeConstants.SmallSize))
-                                )
-                                LargeHorizontalSpacer()
-                            }
-                            Column(
-                                modifier = Modifier.weight(1f),
-                                verticalArrangement = Arrangement.Center
+                            Text(
+                                text = "Ad",
+                                style = MaterialTheme.typography.labelSmall,
+                                color = MaterialTheme.colorScheme.primary
+                            )
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.Start
                             ) {
-                                Text(
-                                    text = loadedAd.headline ?: "",
-                                    fontWeight = FontWeight.Bold
-                                )
-                                loadedAd.body?.let { body ->
-                                    Text(
-                                        text = body,
-                                        style = MaterialTheme.typography.bodySmall
+                                loadedAd.icon?.drawable?.let { drawable ->
+                                    AndroidView(
+                                        factory = { assets.iconView },
+                                        update = { it.setImageDrawable(drawable) },
+                                        modifier = Modifier
+                                            .size(SizeConstants.ExtraLargeIncreasedSize)
+                                            .clip(RoundedCornerShape(size = SizeConstants.SmallSize))
                                     )
+                                    LargeHorizontalSpacer()
                                 }
-                            }
-                            loadedAd.callToAction?.let { cta ->
-                                LargeHorizontalSpacer()
-                                Button(onClick = { view.performClick() }) {
-                                    Text(text = cta)
+                                Column(
+                                    modifier = Modifier.weight(1f),
+                                    verticalArrangement = Arrangement.Center
+                                ) {
+                                    AndroidView(factory = { assets.headlineView }) { view ->
+                                        view.setContent {
+                                            Text(
+                                                text = loadedAd.headline ?: "",
+                                                fontWeight = FontWeight.Bold
+                                            )
+                                        }
+                                    }
+                                    loadedAd.body?.let { body ->
+                                        AndroidView(factory = { assets.bodyView }) { view ->
+                                            view.setContent {
+                                                Text(
+                                                    text = body,
+                                                    style = MaterialTheme.typography.bodySmall
+                                                )
+                                            }
+                                        }
+                                    }
+                                }
+                                loadedAd.callToAction?.let { cta ->
+                                    LargeHorizontalSpacer()
+                                    AndroidView(factory = { assets.callToActionView }) { button ->
+                                        button.text = cta
+                                    }
                                 }
                             }
                         }
+                        AndroidView(
+                            factory = { assets.adChoicesView },
+                            modifier = Modifier.align(Alignment.TopEnd)
+                        )
                     }
                 }
             }


### PR DESCRIPTION
## Summary
- add mandatory "Ad" badges and AdChoices icons to all native ad banners
- register headline, body, icon and CTA views with the `NativeAdView`
- render bottom banner in a card to prevent confusion with app navigation

## Testing
- `./gradlew build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba99b71c88832d91e2cd0a9b8362cd