### PR TITLE
Add ad labels and AdChoices overlay

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/ui/components/ads/NativeAdBanner.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/ui/components/ads/NativeAdBanner.kt
@@ -89,43 +89,52 @@ fun NativeAdBanner(
                     modifier = modifier.fillMaxWidth(),
                     shape = RoundedCornerShape(size = SizeConstants.ExtraLargeSize)
                 ) {
-                    Row(
+                    Column(
                         modifier = Modifier
                             .fillMaxWidth()
-                            .padding(SizeConstants.LargeSize),
-                        verticalAlignment = Alignment.CenterVertically
+                            .padding(SizeConstants.LargeSize)
                     ) {
-                        loadedAd.icon?.drawable?.let { drawable ->
-                            Image(
-                                painter = remember(drawable) {
-                                    BitmapPainter(drawable.toBitmap().asImageBitmap())
-                                },
-                                contentDescription = loadedAd.headline,
-                                modifier = Modifier
-                                    .size(SizeConstants.ExtraLargeIncreasedSize)
-                                    .clip(RoundedCornerShape(size = SizeConstants.SmallSize))
-                            )
-                            LargeHorizontalSpacer()
-                        }
-                        Column(
-                            modifier = Modifier.weight(1f),
-                            verticalArrangement = Arrangement.Center
+                        Text(
+                            text = "Ad",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                        Row(
+                            modifier = Modifier.fillMaxWidth(),
+                            verticalAlignment = Alignment.CenterVertically
                         ) {
-                            Text(
-                                text = loadedAd.headline ?: "",
-                                fontWeight = FontWeight.Bold
-                            )
-                            loadedAd.body?.let { body ->
-                                Text(
-                                    text = body,
-                                    style = MaterialTheme.typography.bodySmall
+                            loadedAd.icon?.drawable?.let { drawable ->
+                                Image(
+                                    painter = remember(drawable) {
+                                        BitmapPainter(drawable.toBitmap().asImageBitmap())
+                                    },
+                                    contentDescription = loadedAd.headline,
+                                    modifier = Modifier
+                                        .size(SizeConstants.ExtraLargeIncreasedSize)
+                                        .clip(RoundedCornerShape(size = SizeConstants.SmallSize))
                                 )
+                                LargeHorizontalSpacer()
                             }
-                        }
-                        loadedAd.callToAction?.let { cta ->
-                            LargeHorizontalSpacer()
-                            Button(onClick = { view.performClick() }) {
-                                Text(text = cta)
+                            Column(
+                                modifier = Modifier.weight(1f),
+                                verticalArrangement = Arrangement.Center
+                            ) {
+                                Text(
+                                    text = loadedAd.headline ?: "",
+                                    fontWeight = FontWeight.Bold
+                                )
+                                loadedAd.body?.let { body ->
+                                    Text(
+                                        text = body,
+                                        style = MaterialTheme.typography.bodySmall
+                                    )
+                                }
+                            }
+                            loadedAd.callToAction?.let { cta ->
+                                LargeHorizontalSpacer()
+                                Button(onClick = { view.performClick() }) {
+                                    Text(text = cta)
+                                }
                             }
                         }
                     }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/BottomAppBarNativeAdBanner.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/BottomAppBarNativeAdBanner.kt
@@ -8,6 +8,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -80,6 +81,12 @@ fun BottomAppBarNativeAdBanner(
                             .padding(horizontal = SizeConstants.LargeSize),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
+                        Text(
+                            text = "Ad",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.primary
+                        )
+                        LargeHorizontalSpacer()
                         loadedAd.icon?.drawable?.let { drawable ->
                             Image(
                                 painter = remember(drawable) {

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/LargeNativeAdBanner.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/LargeNativeAdBanner.kt
@@ -93,6 +93,11 @@ fun LargeNativeAdBanner(
                             .fillMaxWidth()
                             .padding(SizeConstants.LargeSize)
                     ) {
+                        Text(
+                            text = "Ad",
+                            style = MaterialTheme.typography.labelSmall,
+                            color = MaterialTheme.colorScheme.primary
+                        )
                         Row(
                             verticalAlignment = Alignment.CenterVertically
                         ) {

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NativeAdView.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NativeAdView.kt
@@ -1,12 +1,20 @@
 package com.d4rk.android.libs.apptoolkit.core.ui.components.ads
 
 import android.view.View
+import android.view.ViewGroup
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.ComposeView
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.viewinterop.AndroidView
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
+import com.google.android.gms.ads.nativead.AdChoicesView
 import com.google.android.gms.ads.nativead.NativeAd
 import com.google.android.gms.ads.nativead.NativeAdView as GoogleNativeAdView
 
@@ -17,11 +25,13 @@ fun NativeAdView(
 ) {
     val contentViewId by remember { mutableIntStateOf(View.generateViewId()) }
     val adViewId by remember { mutableIntStateOf(View.generateViewId()) }
+    val context = LocalContext.current
+    val adChoicesView = remember { AdChoicesView(context) }
 
     AndroidView(
-        factory = { context ->
-            val contentView = ComposeView(context).apply { id = contentViewId }
-            GoogleNativeAdView(context).apply {
+        factory = { ctx ->
+            val contentView = ComposeView(ctx).apply { id = contentViewId }
+            GoogleNativeAdView(ctx).apply {
                 id = adViewId
                 addView(contentView)
             }
@@ -32,7 +42,22 @@ fun NativeAdView(
 
             adView.setNativeAd(ad)
             adView.callToActionView = contentView
-            contentView.setContent { adContent(ad, contentView) }
+            adView.adChoicesView = adChoicesView
+
+            contentView.setContent {
+                Box {
+                    adContent(ad, contentView)
+                    AndroidView(
+                        factory = {
+                            (adChoicesView.parent as? ViewGroup)?.removeView(adChoicesView)
+                            adChoicesView
+                        },
+                        modifier = Modifier
+                            .align(Alignment.TopEnd)
+                            .padding(SizeConstants.SmallSize)
+                    )
+                }
+            }
         }
     )
 }


### PR DESCRIPTION
## Summary
- label native ads with `Ad` text across banner components
- overlay AdChoices icon and expose via `NativeAdView`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba9f0237f4832d964660d7c574d783