### PR TITLE
Use Coil for native ad icons and AdLabel

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/ui/components/ads/NativeAdBanner.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/ui/components/ads/NativeAdBanner.kt
@@ -1,6 +1,5 @@
 package com.d4rk.android.apps.apptoolkit.core.ui.components.ads
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -26,16 +25,15 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.core.graphics.drawable.toBitmap
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil.compose.AsyncImage
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
 import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdView
+import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.AdLabel
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeHorizontalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
@@ -94,20 +92,14 @@ fun NativeAdBanner(
                             .fillMaxWidth()
                             .padding(SizeConstants.LargeSize)
                     ) {
-                        Text(
-                            text = "Ad",
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.primary
-                        )
+                        AdLabel()
                         Row(
                             modifier = Modifier.fillMaxWidth(),
                             verticalAlignment = Alignment.CenterVertically
                         ) {
-                            loadedAd.icon?.drawable?.let { drawable ->
-                                Image(
-                                    painter = remember(drawable) {
-                                        BitmapPainter(drawable.toBitmap().asImageBitmap())
-                                    },
+                            loadedAd.icon?.let { icon ->
+                                AsyncImage(
+                                    model = icon.uri ?: icon.drawable,
                                     contentDescription = loadedAd.headline,
                                     modifier = Modifier
                                         .size(SizeConstants.ExtraLargeIncreasedSize)

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdLabel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/AdLabel.kt
@@ -1,0 +1,21 @@
+package com.d4rk.android.libs.apptoolkit.core.ui.components.ads
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import com.d4rk.android.libs.apptoolkit.R
+
+/**
+ * Reusable label indicating an advertisement.
+ */
+@Composable
+fun AdLabel(modifier: Modifier = Modifier) {
+    Text(
+        text = stringResource(id = R.string.ad),
+        style = MaterialTheme.typography.labelSmall,
+        color = MaterialTheme.colorScheme.primary,
+        modifier = modifier
+    )
+}

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/BottomAppBarNativeAdBanner.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/BottomAppBarNativeAdBanner.kt
@@ -1,6 +1,5 @@
 package com.d4rk.android.libs.apptoolkit.core.ui.components.ads
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -21,15 +20,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextOverflow
-import androidx.core.graphics.drawable.toBitmap
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil.compose.AsyncImage
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
+import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.AdLabel
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeHorizontalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
@@ -81,17 +79,11 @@ fun BottomAppBarNativeAdBanner(
                             .padding(horizontal = SizeConstants.LargeSize),
                         verticalAlignment = Alignment.CenterVertically
                     ) {
-                        Text(
-                            text = "Ad",
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.primary
-                        )
+                        AdLabel()
                         LargeHorizontalSpacer()
-                        loadedAd.icon?.drawable?.let { drawable ->
-                            Image(
-                                painter = remember(drawable) {
-                                    BitmapPainter(drawable.toBitmap().asImageBitmap())
-                                },
+                        loadedAd.icon?.let { icon ->
+                            AsyncImage(
+                                model = icon.uri ?: icon.drawable,
                                 contentDescription = loadedAd.headline,
                                 modifier = Modifier
                                     .size(SizeConstants.ExtraLargeIncreasedSize)

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/HelpNativeAd.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/HelpNativeAd.kt
@@ -1,5 +1,4 @@
 package com.d4rk.android.libs.apptoolkit.core.ui.components.ads
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -25,15 +24,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.core.graphics.drawable.toBitmap
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil.compose.AsyncImage
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
+import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.AdLabel
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeHorizontalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
@@ -94,21 +92,15 @@ fun HelpNativeAdBanner(
                             .fillMaxWidth()
                             .padding(SizeConstants.LargeSize)
                     ) {
-                        Text(
-                            text = "Ad",
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.primary
-                        )
+                        AdLabel()
                         Row(
                             modifier = Modifier.fillMaxWidth(),
                             verticalAlignment = Alignment.CenterVertically,
                             horizontalArrangement = Arrangement.Start
                         ) {
-                            loadedAd.icon?.drawable?.let { drawable ->
-                                Image(
-                                    painter = remember(drawable) {
-                                        BitmapPainter(drawable.toBitmap().asImageBitmap())
-                                    },
+                            loadedAd.icon?.let { icon ->
+                                AsyncImage(
+                                    model = icon.uri ?: icon.drawable,
                                     contentDescription = loadedAd.headline,
                                     modifier = Modifier
                                         .size(SizeConstants.ExtraLargeIncreasedSize)

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/LargeNativeAdBanner.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/LargeNativeAdBanner.kt
@@ -1,6 +1,5 @@
 package com.d4rk.android.libs.apptoolkit.core.ui.components.ads
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -26,15 +25,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.core.graphics.drawable.toBitmap
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil.compose.AsyncImage
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
+import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.AdLabel
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeHorizontalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
@@ -93,19 +91,13 @@ fun LargeNativeAdBanner(
                             .fillMaxWidth()
                             .padding(SizeConstants.LargeSize)
                     ) {
-                        Text(
-                            text = "Ad",
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.primary
-                        )
+                        AdLabel()
                         Row(
                             verticalAlignment = Alignment.CenterVertically
                         ) {
-                            loadedAd.icon?.drawable?.let { drawable ->
-                                Image(
-                                    painter = remember(drawable) {
-                                        BitmapPainter(drawable.toBitmap().asImageBitmap())
-                                    },
+                            loadedAd.icon?.let { icon ->
+                                AsyncImage(
+                                    model = icon.uri ?: icon.drawable,
                                     contentDescription = loadedAd.headline,
                                     modifier = Modifier
                                         .size(SizeConstants.ExtraExtraLargeSize)

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NoDataNativeAd.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NoDataNativeAd.kt
@@ -1,6 +1,5 @@
 package com.d4rk.android.libs.apptoolkit.core.ui.components.ads
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -26,15 +25,14 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.asImageBitmap
-import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
-import androidx.core.graphics.drawable.toBitmap
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import coil.compose.AsyncImage
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
+import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.AdLabel
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeHorizontalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
@@ -96,21 +94,15 @@ fun NoDataNativeAdBanner(
                             .fillMaxWidth()
                             .padding(SizeConstants.LargeSize)
                     ) {
-                        Text(
-                            text = "Ad",
-                            style = MaterialTheme.typography.labelSmall,
-                            color = MaterialTheme.colorScheme.primary
-                        )
+                        AdLabel()
                         Row(
                             modifier = Modifier.fillMaxWidth(),
                             verticalAlignment = Alignment.CenterVertically,
                             horizontalArrangement = Arrangement.Start
                         ) {
-                            loadedAd.icon?.drawable?.let { drawable ->
-                                Image(
-                                    painter = remember(drawable) {
-                                        BitmapPainter(drawable.toBitmap().asImageBitmap())
-                                    },
+                            loadedAd.icon?.let { icon ->
+                                AsyncImage(
+                                    model = icon.uri ?: icon.drawable,
                                     contentDescription = loadedAd.headline,
                                     modifier = Modifier
                                         .size(SizeConstants.ExtraLargeIncreasedSize)

--- a/apptoolkit/src/main/res/values/untranslatable_strings.xml
+++ b/apptoolkit/src/main/res/values/untranslatable_strings.xml
@@ -2,6 +2,7 @@
 <resources>
     <string name="app_name" translatable="false">App Toolkit</string>
     <string name="app_full_name" translatable="false">App Toolkit for Android</string>
+    <string name="ad" translatable="false">Ad</string>
     <string name="bulgarian" translatable="false">Български</string>
     <string name="english" translatable="false">English</string>
     <string name="french" translatable="false">Français</string>


### PR DESCRIPTION
## Summary
- load native ad icons with Coil's `AsyncImage`
- add reusable `AdLabel` composable backed by string resources
- move `Ad` label text to untranslatable resources

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68baa2697800832da7c647990a633cdf