### PR TITLE
Refactor native ad view components

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/ui/components/ads/NativeAdBanner.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/ui/components/ads/NativeAdBanner.kt
@@ -82,7 +82,7 @@ fun NativeAdBanner(
         }
 
         nativeAd?.let { ad ->
-            NativeAdView(ad = ad) { loadedAd, view ->
+            NativeAdView(ad = ad) { loadedAd, ctaView, _ ->
                 Card(
                     modifier = modifier.fillMaxWidth(),
                     shape = RoundedCornerShape(size = SizeConstants.ExtraLargeSize)
@@ -124,7 +124,7 @@ fun NativeAdBanner(
                             }
                             loadedAd.callToAction?.let { cta ->
                                 LargeHorizontalSpacer()
-                                Button(onClick = { view.performClick() }) {
+                                Button(onClick = { ctaView.performClick() }) {
                                     Text(text = cta)
                                 }
                             }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/BottomAppBarNativeAdBanner.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/BottomAppBarNativeAdBanner.kt
@@ -70,7 +70,7 @@ fun BottomAppBarNativeAdBanner(
         }
 
         nativeAd?.let { ad ->
-            NativeAdView(ad = ad) { loadedAd, view ->
+            NativeAdView(ad = ad) { loadedAd, ctaView, _ ->
                 NavigationBar(modifier = modifier.fillMaxWidth()) {
                     Row(
                         modifier = Modifier
@@ -99,7 +99,7 @@ fun BottomAppBarNativeAdBanner(
                         )
                         loadedAd.callToAction?.let { cta ->
                             LargeHorizontalSpacer()
-                            Button(onClick = { view.performClick() }) {
+                            Button(onClick = { ctaView.performClick() }) {
                                 Text(text = cta)
                             }
                         }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/HelpNativeAd.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/HelpNativeAd.kt
@@ -82,7 +82,7 @@ fun HelpNativeAdBanner(
         }
 
         nativeAd?.let { ad ->
-            NativeAdView(ad = ad) { loadedAd, view ->
+            NativeAdView(ad = ad) { loadedAd, ctaView, _ ->
                 Card(
                     modifier = modifier.fillMaxWidth(),
                     shape = RoundedCornerShape(size = SizeConstants.MediumSize)
@@ -125,7 +125,7 @@ fun HelpNativeAdBanner(
                             }
                             loadedAd.callToAction?.let { cta ->
                                 LargeHorizontalSpacer()
-                                Button(onClick = { view.performClick() }) {
+                                Button(onClick = { ctaView.performClick() }) {
                                     Text(text = cta)
                                 }
                             }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/LargeNativeAdBanner.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/LargeNativeAdBanner.kt
@@ -80,7 +80,7 @@ fun LargeNativeAdBanner(
         }
 
         nativeAd?.let { ad ->
-            NativeAdView(ad = ad) { loadedAd, view ->
+            NativeAdView(ad = ad) { loadedAd, ctaView, _ ->
                 OutlinedCard(
                     modifier = modifier.fillMaxWidth(),
                     shape = RoundedCornerShape(size = SizeConstants.ExtraLargeSize)
@@ -122,7 +122,7 @@ fun LargeNativeAdBanner(
                             }
                             loadedAd.callToAction?.let { cta ->
                                 LargeHorizontalSpacer()
-                                FilledTonalButton(onClick = { view.performClick() }) {
+                                FilledTonalButton(onClick = { ctaView.performClick() }) {
                                     Text(text = cta)
                                 }
                             }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NativeAdView.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NativeAdView.kt
@@ -21,32 +21,64 @@ import com.google.android.gms.ads.nativead.NativeAdView as GoogleNativeAdView
 @Composable
 fun NativeAdView(
     ad: NativeAd,
-    adContent: @Composable (ad: NativeAd, contentView: View) -> Unit,
+    adContent: @Composable (ad: NativeAd, ctaView: View, contentView: View) -> Unit,
 ) {
     val contentViewId by remember { mutableIntStateOf(View.generateViewId()) }
     val adViewId by remember { mutableIntStateOf(View.generateViewId()) }
+    val headlineViewId by remember { mutableIntStateOf(View.generateViewId()) }
+    val iconViewId by remember { mutableIntStateOf(View.generateViewId()) }
+    val bodyViewId by remember { mutableIntStateOf(View.generateViewId()) }
+    val ctaViewId by remember { mutableIntStateOf(View.generateViewId()) }
     val context = LocalContext.current
     val adChoicesView = remember { AdChoicesView(context) }
 
     AndroidView(
         factory = { ctx ->
             val contentView = ComposeView(ctx).apply { id = contentViewId }
+            val headlineView = ComposeView(ctx).apply {
+                id = headlineViewId
+                visibility = View.GONE
+            }
+            val iconView = ComposeView(ctx).apply {
+                id = iconViewId
+                visibility = View.GONE
+            }
+            val bodyView = ComposeView(ctx).apply {
+                id = bodyViewId
+                visibility = View.GONE
+            }
+            val ctaView = ComposeView(ctx).apply {
+                id = ctaViewId
+                visibility = View.GONE
+            }
+
             GoogleNativeAdView(ctx).apply {
                 id = adViewId
                 addView(contentView)
+                addView(headlineView)
+                addView(iconView)
+                addView(bodyView)
+                addView(ctaView)
             }
         },
         update = { view ->
             val adView = view.findViewById<GoogleNativeAdView>(adViewId)
             val contentView = view.findViewById<ComposeView>(contentViewId)
+            val headlineView = view.findViewById<ComposeView>(headlineViewId)
+            val iconView = view.findViewById<ComposeView>(iconViewId)
+            val bodyView = view.findViewById<ComposeView>(bodyViewId)
+            val ctaView = view.findViewById<ComposeView>(ctaViewId)
 
             adView.setNativeAd(ad)
-            adView.callToActionView = contentView
+            adView.headlineView = headlineView
+            adView.iconView = iconView
+            adView.bodyView = bodyView
+            adView.callToActionView = ctaView
             adView.adChoicesView = adChoicesView
 
             contentView.setContent {
                 Box {
-                    adContent(ad, contentView)
+                    adContent(ad, ctaView, contentView)
                     AndroidView(
                         factory = {
                             (adChoicesView.parent as? ViewGroup)?.removeView(adChoicesView)

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NoDataNativeAd.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NoDataNativeAd.kt
@@ -83,7 +83,7 @@ fun NoDataNativeAdBanner(
         }
 
         nativeAd?.let { ad ->
-            NativeAdView(ad = ad) { loadedAd, view ->
+            NativeAdView(ad = ad) { loadedAd, ctaView, _ ->
                 OutlinedCard(
                     modifier = modifier.fillMaxWidth(),
                     shape = RoundedCornerShape(size = SizeConstants.ExtraLargeSize)
@@ -126,7 +126,7 @@ fun NoDataNativeAdBanner(
                             }
                             loadedAd.callToAction?.let { cta ->
                                 LargeHorizontalSpacer()
-                                Button(onClick = { view.performClick() }) {
+                                Button(onClick = { ctaView.performClick() }) {
                                     Text(text = cta)
                                 }
                             }


### PR DESCRIPTION
## Summary
- Split `NativeAdView` into dedicated headline, icon, body and CTA `ComposeView`s with generated IDs
- Register asset views on `GoogleNativeAdView` and expose `ctaView` to ad content
- Update ad banner composables to trigger ad clicks via `ctaView.performClick()`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68baa95510b8832d888a1de9bad27151