### PR TITLE
Trim redundant transitive dependencies

### DIFF
--- a/apptoolkit/build.gradle.kts
+++ b/apptoolkit/build.gradle.kts
@@ -69,21 +69,13 @@ dependencies {
 
     // Compose
     api(dependencyNotation = platform(libs.androidx.compose.bom))
-    api(dependencyNotation = libs.androidx.ui)
     api(dependencyNotation = libs.androidx.activity.compose)
-    api(dependencyNotation = libs.androidx.ui.graphics)
-    api(dependencyNotation = libs.androidx.compose.runtime)
     api(dependencyNotation = libs.androidx.runtime.livedata)
     api(dependencyNotation = libs.androidx.ui.tooling.preview)
     api(dependencyNotation = libs.androidx.material3)
     api(dependencyNotation = libs.androidx.material.icons.extended)
-    api(dependencyNotation = libs.androidx.foundation)
-    api(dependencyNotation = libs.datastore.preferences.core)
     api(dependencyNotation = libs.androidx.datastore.preferences)
-    api(dependencyNotation = libs.androidx.datastore)
-    api(dependencyNotation = libs.androidx.datastore.core)
     api(dependencyNotation = libs.androidx.navigation.compose)
-    api(dependencyNotation = libs.androidx.graphics.shapes)
 
     // Firebase
     api(dependencyNotation = platform(libs.firebase.bom))


### PR DESCRIPTION
## Summary
- remove Compose UI and foundation libraries already provided by Material3
- drop extra DataStore artifacts, keeping only datastore-preferences

## Testing
- `./gradlew :apptoolkit:build` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bae9e6ddc8832db579e79f9defcc80