### PR TITLE
Use view holder to register native ad asset clicks

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/ui/components/ads/NativeAdBanner.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/ui/components/ads/NativeAdBanner.kt
@@ -2,6 +2,7 @@ package com.d4rk.android.apps.apptoolkit.core.ui.components.ads
 
 import android.view.LayoutInflater
 import android.view.View
+import android.widget.FrameLayout
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.compose.foundation.background
@@ -89,7 +90,11 @@ fun NativeAdBanner(
             AndroidView(
                 modifier = modifier.fillMaxWidth(),
                 factory = { ctx ->
-                    LayoutInflater.from(ctx).inflate(R.layout.native_ad_banner, null)
+                    LayoutInflater.from(ctx).inflate(
+                        R.layout.native_ad_banner,
+                        FrameLayout(ctx),
+                        false
+                    )
                 },
                 update = { view ->
                     val adView = view.findViewById<NativeAdView>(R.id.native_ad_view)
@@ -106,7 +111,7 @@ fun NativeAdBanner(
                         bodyView.text = it
                     } ?: run { bodyView.visibility = View.GONE }
 
-                    val clickableAssets = mutableMapOf(
+                    val clickableAssets = mutableMapOf<String, View>(
                         NativeAdAssetNames.ASSET_HEADLINE to headlineView,
                         NativeAdAssetNames.ASSET_CALL_TO_ACTION to ctaView
                     )

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/ui/components/ads/NativeAdBanner.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/ui/components/ads/NativeAdBanner.kt
@@ -1,16 +1,14 @@
 package com.d4rk.android.apps.apptoolkit.core.ui.components.ads
 
+import android.view.LayoutInflater
 import android.view.View
-import android.view.ViewGroup
+import android.widget.ImageView
+import android.widget.TextView
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
@@ -24,26 +22,26 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
-import coil3.compose.AsyncImage
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
-import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.AdLabel
-import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdView
-import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeHorizontalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
+import com.d4rk.android.apps.apptoolkit.R
 import com.google.android.gms.ads.AdLoader
 import com.google.android.gms.ads.AdRequest
+import com.google.android.gms.ads.nativead.MediaView
 import com.google.android.gms.ads.nativead.NativeAd
+import com.google.android.gms.ads.nativead.NativeAdAssetNames
+import com.google.android.gms.ads.nativead.NativeAdView
+import com.google.android.gms.ads.nativead.NativeAdViewHolder
+import com.google.android.gms.ads.nativead.AdChoicesView
 import com.google.android.material.button.MaterialButton
-import androidx.compose.ui.viewinterop.AndroidView
 
 @Composable
 fun NativeAdBanner(
@@ -88,67 +86,59 @@ fun NativeAdBanner(
         val colorOnPrimary = MaterialTheme.colorScheme.onPrimary.toArgb()
 
         nativeAd?.let { ad ->
-            NativeAdView(ad = ad) { loadedAd, ctaView, _ ->
-                Card(
-                    modifier = modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(size = SizeConstants.ExtraLargeSize)
-                ) {
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(SizeConstants.LargeSize)
-                    ) {
-                        AdLabel()
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            verticalAlignment = Alignment.CenterVertically
-                        ) {
-                            loadedAd.icon?.let { icon ->
-                                AsyncImage(
-                                    model = icon.uri ?: icon.drawable,
-                                    contentDescription = loadedAd.headline,
-                                    modifier = Modifier
-                                        .size(SizeConstants.ExtraLargeIncreasedSize)
-                                        .clip(RoundedCornerShape(size = SizeConstants.SmallSize))
-                                )
-                                LargeHorizontalSpacer()
-                            }
-                            Column(
-                                modifier = Modifier.weight(1f),
-                                verticalArrangement = Arrangement.Center
-                            ) {
-                                Text(
-                                    text = loadedAd.headline ?: "",
-                                    fontWeight = FontWeight.Bold
-                                )
-                                loadedAd.body?.let { body ->
-                                    Text(
-                                        text = body,
-                                        style = MaterialTheme.typography.bodySmall
-                                    )
-                                }
-                            }
-                            loadedAd.callToAction?.let { cta ->
-                                LargeHorizontalSpacer()
-                                AndroidView(
-                                    factory = {
-                                        (ctaView.parent as? ViewGroup)?.removeView(ctaView)
-                                        ctaView
-                                    },
-                                    update = { view ->
-                                        (view as MaterialButton).apply {
-                                            text = cta
-                                            setBackgroundColor(colorPrimary)
-                                            setTextColor(colorOnPrimary)
-                                            visibility = View.VISIBLE
-                                        }
-                                    }
-                                )
-                            }
-                        }
+            AndroidView(
+                modifier = modifier.fillMaxWidth(),
+                factory = { ctx ->
+                    LayoutInflater.from(ctx).inflate(R.layout.native_ad_banner, null)
+                },
+                update = { view ->
+                    val adView = view.findViewById<NativeAdView>(R.id.native_ad_view)
+                    val mediaView = adView.findViewById<MediaView>(R.id.ad_media)
+                    val iconView = adView.findViewById<ImageView>(R.id.ad_icon)
+                    val headlineView = adView.findViewById<TextView>(R.id.ad_headline)
+                    val bodyView = adView.findViewById<TextView>(R.id.ad_body)
+                    val ctaView = adView.findViewById<MaterialButton>(R.id.ad_cta)
+                    val adChoicesView = adView.findViewById<AdChoicesView>(R.id.ad_choices)
+
+                    headlineView.text = ad.headline
+                    ad.body?.let {
+                        bodyView.visibility = View.VISIBLE
+                        bodyView.text = it
+                    } ?: run { bodyView.visibility = View.GONE }
+
+                    val clickableAssets = mutableMapOf(
+                        NativeAdAssetNames.ASSET_HEADLINE to headlineView,
+                        NativeAdAssetNames.ASSET_CALL_TO_ACTION to ctaView
+                    )
+                    val nonClickableAssets = mutableMapOf<String, View>(
+                        NativeAdAssetNames.ASSET_BODY to bodyView
+                    )
+
+                    ad.callToAction?.let {
+                        ctaView.visibility = View.VISIBLE
+                        ctaView.text = it
+                        ctaView.setBackgroundColor(colorPrimary)
+                        ctaView.setTextColor(colorOnPrimary)
+                    } ?: run { ctaView.visibility = View.GONE }
+
+                    if (ad.mediaContent != null && (ad.mediaContent!!.hasVideoContent() || ad.mediaContent!!.mainImage != null)) {
+                        mediaView.visibility = View.VISIBLE
+                        mediaView.mediaContent = ad.mediaContent
+                        iconView.visibility = View.GONE
+                        clickableAssets[NativeAdAssetNames.ASSET_MEDIA_VIDEO] = mediaView
+                    } else {
+                        mediaView.visibility = View.GONE
+                        ad.icon?.let {
+                            iconView.visibility = View.VISIBLE
+                            iconView.setImageDrawable(it.drawable)
+                            clickableAssets[NativeAdAssetNames.ASSET_ICON] = iconView
+                        } ?: run { iconView.visibility = View.GONE }
                     }
+
+                    NativeAdViewHolder(adView, clickableAssets, nonClickableAssets).setNativeAd(ad)
+                    adView.adChoicesView = adChoicesView
                 }
-            }
+            )
         }
     }
 }

--- a/app/src/main/res/layout/native_ad_banner.xml
+++ b/app/src/main/res/layout/native_ad_banner.xml
@@ -1,0 +1,68 @@
+<?xml version="1.0" encoding="utf-8"?>
+<com.google.android.gms.ads.nativead.NativeAdView xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/native_ad_view"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:padding="16dp">
+
+    <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:gravity="center_vertical">
+
+        <com.google.android.gms.ads.nativead.MediaView
+            android:id="@+id/ad_media"
+            android:layout_width="64dp"
+            android:layout_height="64dp"
+            android:layout_marginEnd="8dp"
+            android:visibility="gone" />
+
+        <ImageView
+            android:id="@+id/ad_icon"
+            android:layout_width="64dp"
+            android:layout_height="64dp"
+            android:layout_marginEnd="8dp"
+            android:visibility="gone" />
+
+        <LinearLayout
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_weight="1"
+            android:orientation="vertical">
+
+            <TextView
+                android:id="@+id/ad_headline"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:textStyle="bold" />
+
+            <TextView
+                android:id="@+id/ad_body"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:visibility="gone" />
+        </LinearLayout>
+
+        <com.google.android.material.button.MaterialButton
+            android:id="@+id/ad_cta"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:visibility="gone" />
+    </LinearLayout>
+
+    <TextView
+        android:id="@+id/ad_attribution"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Ad"
+        android:layout_marginTop="8dp"
+        android:layout_gravity="top|start" />
+
+    <com.google.android.gms.ads.nativead.AdChoicesView
+        android:id="@+id/ad_choices"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="top|end" />
+
+</com.google.android.gms.ads.nativead.NativeAdView>


### PR DESCRIPTION
## Summary
- inflate a dedicated native ad layout with real asset views and attribution
- register headline, call-to-action, and media/icon as clickable via `NativeAdViewHolder`
- keep body and labels non-clickable and show AdChoices

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb0dd50c18832d8ba9e4690873eeb6