### PR TITLE
Delay native ad binding until assets registered and add debug logs

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -20,7 +20,7 @@ android {
         applicationId = "com.d4rk.android.apps.apptoolkit"
         minSdk = 23
         targetSdk = 36
-        versionCode = 63
+        versionCode = 64
         versionName = "1.1.2"
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         @Suppress("UnstableApiUsage")

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/ui/components/ads/NativeAdBanner.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/ui/components/ads/NativeAdBanner.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
@@ -177,7 +177,7 @@ fun NativeAdBanner(
                         }
                     }
                     NativeAdClickOverlay(
-                        modifier = Modifier.fillMaxSize()
+                        modifier = Modifier.matchParentSize()
                     )
                 }
             }

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/ui/components/ads/NativeAdBanner.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/ui/components/ads/NativeAdBanner.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.matchParentSize
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
@@ -33,9 +33,15 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
-import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.TAG
 import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.AdLabel
+import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdBodyView
+import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdButton
+import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdCallToActionView
 import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdChoicesView
+import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdHeadlineView
+import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdIconView
+import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdView
+import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.TAG
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeHorizontalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
@@ -44,12 +50,6 @@ import com.google.android.gms.ads.AdLoader
 import com.google.android.gms.ads.AdRequest
 import com.google.android.gms.ads.LoadAdError
 import com.google.android.gms.ads.nativead.NativeAd
-import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdBodyView
-import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdButton
-import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdCallToActionView
-import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdHeadlineView
-import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdIconView
-import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdView
 
 @Composable
 fun NativeAdBanner(
@@ -176,9 +176,9 @@ fun NativeAdBanner(
                         }
                     }
                     NativeAdCallToActionView(
-                        modifier = Modifier.matchParentSize()
+                        modifier = Modifier.fillMaxSize()
                     ) {
-                        Box(modifier = Modifier.matchParentSize())
+                        Box(modifier = Modifier.fillMaxSize())
                     }
                 }
             }

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/ui/components/ads/NativeAdBanner.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/ui/components/ads/NativeAdBanner.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
@@ -112,65 +113,72 @@ fun NativeAdBanner(
 
         nativeAd?.let { ad ->
             NativeAdView(nativeAd = ad) {
-                Card(
-                    modifier = modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(size = SizeConstants.ExtraLargeSize),
-                ) {
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(SizeConstants.LargeSize),
+                Box {
+                    Card(
+                        modifier = modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(size = SizeConstants.ExtraLargeSize),
                     ) {
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically,
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(SizeConstants.LargeSize),
                         ) {
-                            AdLabel()
-                            NativeAdChoicesView()
-                        }
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            ad.icon?.let { icon ->
-                                NativeAdIconView(
-                                    modifier = Modifier
-                                        .size(SizeConstants.ExtraLargeIncreasedSize)
-                                        .clip(RoundedCornerShape(size = SizeConstants.SmallSize)),
-                                ) {
-                                    AsyncImage(
-                                        model = icon.uri ?: icon.drawable,
-                                        contentDescription = ad.headline,
-                                    )
-                                }
-                                LargeHorizontalSpacer()
-                            }
-                            Column(
-                                modifier = Modifier.weight(1f),
-                                verticalArrangement = Arrangement.Center,
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically,
                             ) {
-                                ad.headline?.let {
-                                    NativeAdHeadlineView {
-                                        Text(text = it, fontWeight = FontWeight.Bold)
-                                    }
-                                }
-                                ad.body?.let { body ->
-                                    NativeAdBodyView {
-                                        Text(
-                                            text = body,
-                                            style = MaterialTheme.typography.bodySmall,
+                                AdLabel()
+                                NativeAdChoicesView()
+                            }
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                ad.icon?.let { icon ->
+                                    NativeAdIconView(
+                                        modifier = Modifier
+                                            .size(SizeConstants.ExtraLargeIncreasedSize)
+                                            .clip(RoundedCornerShape(size = SizeConstants.SmallSize)),
+                                    ) {
+                                        AsyncImage(
+                                            model = icon.uri ?: icon.drawable,
+                                            contentDescription = ad.headline,
                                         )
                                     }
+                                    LargeHorizontalSpacer()
                                 }
-                            }
-                            ad.callToAction?.let { cta ->
-                                LargeHorizontalSpacer()
-                                NativeAdCallToActionView {
-                                    NativeAdButton(text = cta)
+                                Column(
+                                    modifier = Modifier.weight(1f),
+                                    verticalArrangement = Arrangement.Center,
+                                ) {
+                                    ad.headline?.let {
+                                        NativeAdHeadlineView {
+                                            Text(text = it, fontWeight = FontWeight.Bold)
+                                        }
+                                    }
+                                    ad.body?.let { body ->
+                                        NativeAdBodyView {
+                                            Text(
+                                                text = body,
+                                                style = MaterialTheme.typography.bodySmall,
+                                            )
+                                        }
+                                    }
+                                }
+                                ad.callToAction?.let { cta ->
+                                    LargeHorizontalSpacer()
+                                    NativeAdCallToActionView(register = false) {
+                                        NativeAdButton(text = cta)
+                                    }
                                 }
                             }
                         }
+                    }
+                    NativeAdCallToActionView(
+                        modifier = Modifier.matchParentSize()
+                    ) {
+                        Box(modifier = Modifier.matchParentSize())
                     }
                 }
             }

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/ui/components/ads/NativeAdBanner.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/ui/components/ads/NativeAdBanner.kt
@@ -38,6 +38,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdBodyView
 import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdButton
 import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdCallToActionView
 import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdChoicesView
+import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdClickOverlay
 import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdHeadlineView
 import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdIconView
 import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdView
@@ -168,18 +169,16 @@ fun NativeAdBanner(
                                 }
                                 ad.callToAction?.let { cta ->
                                     LargeHorizontalSpacer()
-                                    NativeAdCallToActionView(register = false) {
+                                    NativeAdCallToActionView {
                                         NativeAdButton(text = cta)
                                     }
                                 }
                             }
                         }
                     }
-                    NativeAdCallToActionView(
+                    NativeAdClickOverlay(
                         modifier = Modifier.fillMaxSize()
-                    ) {
-                        Box(modifier = Modifier.fillMaxSize())
-                    }
+                    )
                 }
             }
         }

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/ui/components/ads/NativeAdBanner.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/ui/components/ads/NativeAdBanner.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/BottomAppBarNativeAdBanner.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/BottomAppBarNativeAdBanner.kt
@@ -3,7 +3,6 @@ package com.d4rk.android.libs.apptoolkit.core.ui.components.ads
 import android.util.Log
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/BottomAppBarNativeAdBanner.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/BottomAppBarNativeAdBanner.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
@@ -96,47 +97,54 @@ fun BottomAppBarNativeAdBanner(
 
         nativeAd?.let { ad ->
             NativeAdView(nativeAd = ad, modifier = modifier.fillMaxWidth()) {
-                NavigationBar(modifier = Modifier.fillMaxWidth()) {
-                    Row(
-                        modifier = Modifier
-                            .weight(1f)
-                            .padding(horizontal = SizeConstants.LargeSize),
-                        verticalAlignment = Alignment.CenterVertically,
+                Box {
+                    NavigationBar(modifier = Modifier.fillMaxWidth()) {
+                        Row(
+                            modifier = Modifier
+                                .weight(1f)
+                                .padding(horizontal = SizeConstants.LargeSize),
+                            verticalAlignment = Alignment.CenterVertically,
+                        ) {
+                            AdLabel()
+                            LargeHorizontalSpacer()
+                            NativeAdChoicesView()
+                            LargeHorizontalSpacer()
+                            ad.icon?.let { icon ->
+                                NativeAdIconView(
+                                    modifier = Modifier
+                                        .size(SizeConstants.ExtraLargeIncreasedSize)
+                                        .clip(RoundedCornerShape(size = SizeConstants.SmallSize)),
+                                ) {
+                                    AsyncImage(
+                                        model = icon.uri ?: icon.drawable,
+                                        contentDescription = ad.headline,
+                                    )
+                                }
+                                LargeHorizontalSpacer()
+                            }
+                            ad.headline?.let {
+                                NativeAdHeadlineView {
+                                    Text(
+                                        text = it,
+                                        fontWeight = FontWeight.Bold,
+                                        maxLines = 1,
+                                        overflow = TextOverflow.Ellipsis,
+                                        modifier = Modifier.weight(1f),
+                                    )
+                                }
+                            }
+                            ad.callToAction?.let { cta ->
+                                LargeHorizontalSpacer()
+                                NativeAdCallToActionView(register = false) {
+                                    NativeAdButton(text = cta)
+                                }
+                            }
+                        }
+                    }
+                    NativeAdCallToActionView(
+                        modifier = Modifier.matchParentSize()
                     ) {
-                        AdLabel()
-                        LargeHorizontalSpacer()
-                        NativeAdChoicesView()
-                        LargeHorizontalSpacer()
-                        ad.icon?.let { icon ->
-                            NativeAdIconView(
-                                modifier = Modifier
-                                    .size(SizeConstants.ExtraLargeIncreasedSize)
-                                    .clip(RoundedCornerShape(size = SizeConstants.SmallSize)),
-                            ) {
-                                AsyncImage(
-                                    model = icon.uri ?: icon.drawable,
-                                    contentDescription = ad.headline,
-                                )
-                            }
-                            LargeHorizontalSpacer()
-                        }
-                        ad.headline?.let {
-                            NativeAdHeadlineView {
-                                Text(
-                                    text = it,
-                                    fontWeight = FontWeight.Bold,
-                                    maxLines = 1,
-                                    overflow = TextOverflow.Ellipsis,
-                                    modifier = Modifier.weight(1f),
-                                )
-                            }
-                        }
-                        ad.callToAction?.let { cta ->
-                            LargeHorizontalSpacer()
-                            NativeAdCallToActionView {
-                                NativeAdButton(text = cta)
-                            }
-                        }
+                        Box(modifier = Modifier.matchParentSize())
                     }
                 }
             }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/BottomAppBarNativeAdBanner.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/BottomAppBarNativeAdBanner.kt
@@ -132,17 +132,15 @@ fun BottomAppBarNativeAdBanner(
                             }
                             ad.callToAction?.let { cta ->
                                 LargeHorizontalSpacer()
-                                NativeAdCallToActionView(register = false) {
+                                NativeAdCallToActionView {
                                     NativeAdButton(text = cta)
                                 }
                             }
                         }
                     }
-                    NativeAdCallToActionView(
+                    NativeAdClickOverlay(
                         modifier = Modifier.fillMaxSize()
-                    ) {
-                        Box(modifier = Modifier.fillMaxSize())
-                    }
+                    )
                 }
             }
         }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/BottomAppBarNativeAdBanner.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/BottomAppBarNativeAdBanner.kt
@@ -3,7 +3,7 @@ package com.d4rk.android.libs.apptoolkit.core.ui.components.ads
 import android.util.Log
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -139,7 +139,7 @@ fun BottomAppBarNativeAdBanner(
                         }
                     }
                     NativeAdClickOverlay(
-                        modifier = Modifier.fillMaxSize()
+                        modifier = Modifier.matchParentSize()
                     )
                 }
             }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/BottomAppBarNativeAdBanner.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/BottomAppBarNativeAdBanner.kt
@@ -3,12 +3,11 @@ package com.d4rk.android.libs.apptoolkit.core.ui.components.ads
 import android.util.Log
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -28,8 +27,6 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
-import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.TAG
-import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdChoicesView
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeHorizontalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
@@ -142,9 +139,9 @@ fun BottomAppBarNativeAdBanner(
                         }
                     }
                     NativeAdCallToActionView(
-                        modifier = Modifier.matchParentSize()
+                        modifier = Modifier.fillMaxSize()
                     ) {
-                        Box(modifier = Modifier.matchParentSize())
+                        Box(modifier = Modifier.fillMaxSize())
                     }
                 }
             }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/HelpNativeAd.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/HelpNativeAd.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
@@ -171,7 +171,7 @@ fun HelpNativeAdBanner(
                         }
                     }
                     NativeAdClickOverlay(
-                        modifier = Modifier.fillMaxSize()
+                        modifier = Modifier.matchParentSize()
                     )
                 }
             }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/HelpNativeAd.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/HelpNativeAd.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.matchParentSize
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
@@ -33,8 +33,6 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
-import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.TAG
-import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdChoicesView
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeHorizontalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
@@ -173,9 +171,9 @@ fun HelpNativeAdBanner(
                         }
                     }
                     NativeAdCallToActionView(
-                        modifier = Modifier.matchParentSize()
+                        modifier = Modifier.fillMaxSize()
                     ) {
-                        Box(modifier = Modifier.matchParentSize())
+                        Box(modifier = Modifier.fillMaxSize())
                     }
                 }
             }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/HelpNativeAd.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/HelpNativeAd.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme
@@ -108,66 +109,73 @@ fun HelpNativeAdBanner(
 
         nativeAd?.let { ad ->
             NativeAdView(nativeAd = ad) {
-                Card(
-                    modifier = modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(size = SizeConstants.MediumSize),
-                ) {
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(SizeConstants.LargeSize),
+                Box {
+                    Card(
+                        modifier = modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(size = SizeConstants.MediumSize),
                     ) {
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically,
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(SizeConstants.LargeSize),
                         ) {
-                            AdLabel()
-                            NativeAdChoicesView()
-                        }
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.Start,
-                        ) {
-                            ad.icon?.let { icon ->
-                                NativeAdIconView(
-                                    modifier = Modifier
-                                        .size(SizeConstants.ExtraLargeIncreasedSize)
-                                        .clip(RoundedCornerShape(size = SizeConstants.SmallSize)),
-                                ) {
-                                    AsyncImage(
-                                        model = icon.uri ?: icon.drawable,
-                                        contentDescription = ad.headline,
-                                    )
-                                }
-                                LargeHorizontalSpacer()
-                            }
-                            Column(
-                                modifier = Modifier.weight(1f),
-                                verticalArrangement = Arrangement.Center,
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically,
                             ) {
-                                ad.headline?.let {
-                                    NativeAdHeadlineView {
-                                        Text(text = it, fontWeight = FontWeight.Bold)
-                                    }
-                                }
-                                ad.body?.let { body ->
-                                    NativeAdBodyView {
-                                        Text(
-                                            text = body,
-                                            style = MaterialTheme.typography.bodySmall,
+                                AdLabel()
+                                NativeAdChoicesView()
+                            }
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.Start,
+                            ) {
+                                ad.icon?.let { icon ->
+                                    NativeAdIconView(
+                                        modifier = Modifier
+                                            .size(SizeConstants.ExtraLargeIncreasedSize)
+                                            .clip(RoundedCornerShape(size = SizeConstants.SmallSize)),
+                                    ) {
+                                        AsyncImage(
+                                            model = icon.uri ?: icon.drawable,
+                                            contentDescription = ad.headline,
                                         )
                                     }
+                                    LargeHorizontalSpacer()
                                 }
-                            }
-                            ad.callToAction?.let { cta ->
-                                LargeHorizontalSpacer()
-                                NativeAdCallToActionView {
-                                    NativeAdButton(text = cta)
+                                Column(
+                                    modifier = Modifier.weight(1f),
+                                    verticalArrangement = Arrangement.Center,
+                                ) {
+                                    ad.headline?.let {
+                                        NativeAdHeadlineView {
+                                            Text(text = it, fontWeight = FontWeight.Bold)
+                                        }
+                                    }
+                                    ad.body?.let { body ->
+                                        NativeAdBodyView {
+                                            Text(
+                                                text = body,
+                                                style = MaterialTheme.typography.bodySmall,
+                                            )
+                                        }
+                                    }
+                                }
+                                ad.callToAction?.let { cta ->
+                                    LargeHorizontalSpacer()
+                                    NativeAdCallToActionView(register = false) {
+                                        NativeAdButton(text = cta)
+                                    }
                                 }
                             }
                         }
+                    }
+                    NativeAdCallToActionView(
+                        modifier = Modifier.matchParentSize()
+                    ) {
+                        Box(modifier = Modifier.matchParentSize())
                     }
                 }
             }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/HelpNativeAd.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/HelpNativeAd.kt
@@ -163,18 +163,16 @@ fun HelpNativeAdBanner(
                                 }
                                 ad.callToAction?.let { cta ->
                                     LargeHorizontalSpacer()
-                                    NativeAdCallToActionView(register = false) {
+                                    NativeAdCallToActionView {
                                         NativeAdButton(text = cta)
                                     }
                                 }
                             }
                         }
                     }
-                    NativeAdCallToActionView(
+                    NativeAdClickOverlay(
                         modifier = Modifier.fillMaxSize()
-                    ) {
-                        Box(modifier = Modifier.fillMaxSize())
-                    }
+                    )
                 }
             }
         }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/HelpNativeAd.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/HelpNativeAd.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.MaterialTheme

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/LargeNativeAdBanner.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/LargeNativeAdBanner.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
@@ -170,7 +170,7 @@ fun LargeNativeAdBanner(
                         }
                     }
                     NativeAdClickOverlay(
-                        modifier = Modifier.fillMaxSize()
+                        modifier = Modifier.matchParentSize()
                     )
                 }
             }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/LargeNativeAdBanner.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/LargeNativeAdBanner.kt
@@ -162,18 +162,16 @@ fun LargeNativeAdBanner(
                                 }
                                 ad.callToAction?.let { cta ->
                                     LargeHorizontalSpacer()
-                                    NativeAdCallToActionView(register = false) {
+                                    NativeAdCallToActionView {
                                         NativeAdButton(text = cta)
                                     }
                                 }
                             }
                         }
                     }
-                    NativeAdCallToActionView(
+                    NativeAdClickOverlay(
                         modifier = Modifier.fillMaxSize()
-                    ) {
-                        Box(modifier = Modifier.fillMaxSize())
-                    }
+                    )
                 }
             }
         }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/LargeNativeAdBanner.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/LargeNativeAdBanner.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/LargeNativeAdBanner.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/LargeNativeAdBanner.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
@@ -105,68 +106,75 @@ fun LargeNativeAdBanner(
 
         nativeAd?.let { ad ->
             NativeAdView(nativeAd = ad) {
-                OutlinedCard(
-                    modifier = modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(size = SizeConstants.ExtraLargeSize),
-                ) {
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(SizeConstants.LargeSize),
+                Box {
+                    OutlinedCard(
+                        modifier = modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(size = SizeConstants.ExtraLargeSize),
                     ) {
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically,
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(SizeConstants.LargeSize),
                         ) {
-                            AdLabel()
-                            NativeAdChoicesView()
-                        }
-                        Row(
-                            verticalAlignment = Alignment.CenterVertically,
-                        ) {
-                            ad.icon?.let { icon ->
-                                NativeAdIconView(
-                                    modifier = Modifier
-                                        .size(SizeConstants.ExtraExtraLargeSize)
-                                        .clip(RoundedCornerShape(size = SizeConstants.SmallSize)),
-                                ) {
-                                    AsyncImage(
-                                        model = icon.uri ?: icon.drawable,
-                                        contentDescription = ad.headline,
-                                    )
-                                }
-                                LargeHorizontalSpacer()
-                            }
-                            Column(
-                                modifier = Modifier.weight(1f),
-                                verticalArrangement = Arrangement.Center,
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically,
                             ) {
-                                ad.headline?.let {
-                                    NativeAdHeadlineView {
-                                        Text(
-                                            text = it,
-                                            fontWeight = FontWeight.Bold,
-                                            style = MaterialTheme.typography.titleMedium,
-                                        )
-                                    }
-                                }
-                                ad.body?.let { body ->
-                                    NativeAdBodyView {
-                                        Text(
-                                            text = body,
-                                            style = MaterialTheme.typography.bodyMedium,
-                                        )
-                                    }
-                                }
+                                AdLabel()
+                                NativeAdChoicesView()
                             }
-                            ad.callToAction?.let { cta ->
-                                LargeHorizontalSpacer()
-                                NativeAdCallToActionView {
-                                    NativeAdButton(text = cta)
+                            Row(
+                                verticalAlignment = Alignment.CenterVertically,
+                            ) {
+                                ad.icon?.let { icon ->
+                                    NativeAdIconView(
+                                        modifier = Modifier
+                                            .size(SizeConstants.ExtraExtraLargeSize)
+                                            .clip(RoundedCornerShape(size = SizeConstants.SmallSize)),
+                                    ) {
+                                        AsyncImage(
+                                            model = icon.uri ?: icon.drawable,
+                                            contentDescription = ad.headline,
+                                        )
+                                    }
+                                    LargeHorizontalSpacer()
+                                }
+                                Column(
+                                    modifier = Modifier.weight(1f),
+                                    verticalArrangement = Arrangement.Center,
+                                ) {
+                                    ad.headline?.let {
+                                        NativeAdHeadlineView {
+                                            Text(
+                                                text = it,
+                                                fontWeight = FontWeight.Bold,
+                                                style = MaterialTheme.typography.titleMedium,
+                                            )
+                                        }
+                                    }
+                                    ad.body?.let { body ->
+                                        NativeAdBodyView {
+                                            Text(
+                                                text = body,
+                                                style = MaterialTheme.typography.bodyMedium,
+                                            )
+                                        }
+                                    }
+                                }
+                                ad.callToAction?.let { cta ->
+                                    LargeHorizontalSpacer()
+                                    NativeAdCallToActionView(register = false) {
+                                        NativeAdButton(text = cta)
+                                    }
                                 }
                             }
                         }
+                    }
+                    NativeAdCallToActionView(
+                        modifier = Modifier.matchParentSize()
+                    ) {
+                        Box(modifier = Modifier.matchParentSize())
                     }
                 }
             }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/LargeNativeAdBanner.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/LargeNativeAdBanner.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.matchParentSize
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
@@ -33,8 +33,6 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
-import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.TAG
-import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdChoicesView
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeHorizontalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
@@ -172,9 +170,9 @@ fun LargeNativeAdBanner(
                         }
                     }
                     NativeAdCallToActionView(
-                        modifier = Modifier.matchParentSize()
+                        modifier = Modifier.fillMaxSize()
                     ) {
-                        Box(modifier = Modifier.matchParentSize())
+                        Box(modifier = Modifier.fillMaxSize())
                     }
                 }
             }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NativeAdCompose.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NativeAdCompose.kt
@@ -3,6 +3,7 @@ package com.d4rk.android.libs.apptoolkit.core.ui.components.ads
 import android.view.View
 import android.view.ViewGroup
 import android.util.Log
+import androidx.core.view.doOnNextLayout
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
@@ -71,7 +72,7 @@ fun NativeAdView(
     )
 
     LaunchedEffect(nativeAd) {
-        nativeAdView.post {
+        nativeAdView.doOnNextLayout {
             Log.d(TAG, "setNativeAd invoked")
             nativeAdView.setNativeAd(nativeAd)
         }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NativeAdCompose.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NativeAdCompose.kt
@@ -12,8 +12,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -79,9 +81,9 @@ fun NativeAdView(
 
     DisposableEffect(nativeAd) {
         onDispose {
-            Log.d(TAG, "disposing, ad.isDestroyed=${'$'}{nativeAd.isDestroyed}")
+            Log.d(TAG, "disposing, ad.isDestroyed=${nativeAd.isDestroyed}")
             nativeAd.destroy()
-            Log.d(TAG, "destroyed, ad.isDestroyed=${'$'}{nativeAd.isDestroyed}")
+            Log.d(TAG, "destroyed, ad.isDestroyed=${nativeAd.isDestroyed}")
         }
     }
 }
@@ -165,10 +167,10 @@ fun NativeAdClickOverlay(modifier: Modifier = Modifier) {
                 Log.d(TAG, "callToActionView registered")
                 view.doOnAttach {
                     view.doOnNextLayout {
-                        Log.d(TAG, "cta bounds ${'$'}{view.width}x${'$'}{view.height}")
-                        Log.d(TAG, "before bind ad.isDestroyed=${'$'}{nativeAd.isDestroyed}")
+                        Log.d(TAG, "cta bounds ${view.width}x${view.height}")
+                        Log.d(TAG, "before bind ad.isDestroyed=${nativeAd.isDestroyed}")
                         adView.setNativeAd(nativeAd)
-                        Log.d(TAG, "setNativeAd invoked hasClick=${'$'}{adView.hasOnClickListeners()}")
+                        Log.d(TAG, "setNativeAd invoked hasClick=${adView.hasOnClickListeners()}")
                     }
                 }
                 bound = true

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NativeAdCompose.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NativeAdCompose.kt
@@ -3,7 +3,6 @@ package com.d4rk.android.libs.apptoolkit.core.ui.components.ads
 import android.view.View
 import android.view.ViewGroup
 import android.util.Log
-import androidx.core.view.doOnNextLayout
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
@@ -11,7 +10,7 @@ import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
-import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.staticCompositionLocalOf
 import androidx.compose.ui.Modifier
@@ -71,11 +70,13 @@ fun NativeAdView(
         modifier = modifier,
     )
 
-    LaunchedEffect(nativeAd) {
-        nativeAdView.doOnNextLayout {
+    DisposableEffect(nativeAd) {
+        val bindAd = Runnable {
             Log.d(TAG, "setNativeAd invoked")
             nativeAdView.setNativeAd(nativeAd)
         }
+        nativeAdView.post(bindAd)
+        onDispose { nativeAdView.removeCallbacks(bindAd) }
     }
 }
 

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NativeAdCompose.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NativeAdCompose.kt
@@ -1,8 +1,8 @@
 package com.d4rk.android.libs.apptoolkit.core.ui.components.ads
 
+import android.util.Log
 import android.view.View
 import android.view.ViewGroup
-import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
@@ -29,7 +29,6 @@ import com.google.android.gms.ads.nativead.NativeAdView as GoogleNativeAdView
  * [NativeAdHeadlineView].
  */
 internal val LocalNativeAdView = staticCompositionLocalOf<GoogleNativeAdView?> { null }
-private const val TAG = "NativeAdCompose"
 
 /**
  * Compose wrapper for a [GoogleNativeAdView]. It binds the provided [nativeAd] and allows [content]

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NativeAdCompose.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NativeAdCompose.kt
@@ -2,6 +2,7 @@ package com.d4rk.android.libs.apptoolkit.core.ui.components.ads
 
 import android.view.View
 import android.view.ViewGroup
+import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.padding
@@ -27,6 +28,7 @@ import com.google.android.gms.ads.nativead.NativeAdView as GoogleNativeAdView
  * [NativeAdHeadlineView].
  */
 internal val LocalNativeAdView = staticCompositionLocalOf<GoogleNativeAdView?> { null }
+private const val TAG = "NativeAdCompose"
 
 /**
  * Compose wrapper for a [GoogleNativeAdView]. It binds the provided [nativeAd] and allows [content]
@@ -68,7 +70,12 @@ fun NativeAdView(
         modifier = modifier,
     )
 
-    LaunchedEffect(nativeAd) { nativeAdView.setNativeAd(nativeAd) }
+    LaunchedEffect(nativeAd) {
+        nativeAdView.post {
+            Log.d(TAG, "setNativeAd invoked")
+            nativeAdView.setNativeAd(nativeAd)
+        }
+    }
 }
 
 /**
@@ -84,6 +91,7 @@ fun NativeAdAdvertiserView(modifier: Modifier = Modifier, content: @Composable (
                 isClickable = true
                 setContent(content)
                 adView.advertiserView = this
+                Log.d(TAG, "advertiserView registered")
             }
         },
         modifier = modifier,
@@ -100,6 +108,7 @@ fun NativeAdBodyView(modifier: Modifier = Modifier, content: @Composable () -> U
     AndroidView(
         factory = {
             adView.bodyView = composeView
+            Log.d(TAG, "bodyView registered")
             composeView.apply { setContent(content) }
         },
         modifier = modifier,
@@ -115,6 +124,7 @@ fun NativeAdCallToActionView(modifier: Modifier = Modifier, content: @Composable
     AndroidView(
         factory = {
             adView.callToActionView = composeView
+            Log.d(TAG, "callToActionView registered")
             composeView.apply { setContent(content) }
         },
         modifier = modifier,
@@ -133,7 +143,10 @@ fun NativeAdChoicesView(modifier: Modifier = Modifier) {
                 minimumHeight = 15
             }
         },
-        update = { adView.adChoicesView = it },
+        update = {
+            adView.adChoicesView = it
+            Log.d(TAG, "adChoicesView registered")
+        },
         modifier = modifier,
     )
 }
@@ -147,6 +160,7 @@ fun NativeAdHeadlineView(modifier: Modifier = Modifier, content: @Composable () 
     AndroidView(
         factory = {
             adView.headlineView = composeView
+            Log.d(TAG, "headlineView registered")
             composeView.apply { setContent(content) }
         },
         modifier = modifier,
@@ -162,6 +176,7 @@ fun NativeAdIconView(modifier: Modifier = Modifier, content: @Composable () -> U
     AndroidView(
         factory = {
             adView.iconView = composeView
+            Log.d(TAG, "iconView registered")
             composeView.apply { setContent(content) }
         },
         modifier = modifier,
@@ -178,6 +193,7 @@ fun NativeAdMediaView(modifier: Modifier = Modifier) {
         update = {
             it.isClickable = true
             adView.mediaView = it
+            Log.d(TAG, "mediaView registered")
         },
         modifier = modifier,
     )
@@ -192,6 +208,7 @@ fun NativeAdPriceView(modifier: Modifier = Modifier, content: @Composable () -> 
     AndroidView(
         factory = {
             adView.priceView = composeView
+            Log.d(TAG, "priceView registered")
             composeView.apply { setContent(content) }
         },
         modifier = modifier,
@@ -207,6 +224,7 @@ fun NativeAdStarRatingView(modifier: Modifier = Modifier, content: @Composable (
     AndroidView(
         factory = {
             adView.starRatingView = composeView
+            Log.d(TAG, "starRatingView registered")
             composeView.apply { setContent(content) }
         },
         modifier = modifier,
@@ -222,6 +240,7 @@ fun NativeAdStoreView(modifier: Modifier = Modifier, content: @Composable () -> 
     AndroidView(
         factory = {
             adView.storeView = composeView
+            Log.d(TAG, "storeView registered")
             composeView.apply { setContent(content) }
         },
         modifier = modifier,

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NativeAdCompose.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NativeAdCompose.kt
@@ -89,7 +89,7 @@ fun NativeAdView(
                     val cta = nativeAdView.callToActionView
                     if (cta != null && cta.width > 0 && cta.height > 0) {
                         Log.d(TAG, "cta bounds ${cta.width}x${cta.height}")
-                        Log.d(TAG, "before bind ad.isDestroyed=${nativeAd.isDestroyed}")
+                        //Log.d(TAG, "before bind ad.isDestroyed=${nativeAd.isDestroyed}")
                         nativeAdView.setNativeAd(nativeAd)
                         Log.d(TAG, "setNativeAd invoked hasClick=${nativeAdView.hasOnClickListeners()}")
                     } else {
@@ -103,9 +103,9 @@ fun NativeAdView(
         nativeAdView.post(bindAd)
         onDispose {
             nativeAdView.removeCallbacks(bindAd)
-            Log.d(TAG, "disposing, ad.isDestroyed=${nativeAd.isDestroyed}")
+            //Log.d(TAG, "disposing, ad.isDestroyed=${nativeAd.isDestroyed}")
             nativeAd.destroy()
-            Log.d(TAG, "destroyed, ad.isDestroyed=${nativeAd.isDestroyed}")
+            //Log.d(TAG, "destroyed, ad.isDestroyed=${nativeAd.isDestroyed}")
         }
     }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NoDataNativeAd.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NoDataNativeAd.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
@@ -171,7 +171,7 @@ fun NoDataNativeAdBanner(
                         }
                     }
                     NativeAdClickOverlay(
-                        modifier = Modifier.fillMaxSize()
+                        modifier = Modifier.matchParentSize()
                     )
                 }
             }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NoDataNativeAd.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NoDataNativeAd.kt
@@ -10,7 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.matchParentSize
+import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
@@ -33,8 +33,6 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
-import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.TAG
-import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdChoicesView
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeHorizontalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
@@ -173,9 +171,9 @@ fun NoDataNativeAdBanner(
                         }
                     }
                     NativeAdCallToActionView(
-                        modifier = Modifier.matchParentSize()
+                        modifier = Modifier.fillMaxSize()
                     ) {
-                        Box(modifier = Modifier.matchParentSize())
+                        Box(modifier = Modifier.fillMaxSize())
                     }
                 }
             }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NoDataNativeAd.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NoDataNativeAd.kt
@@ -10,7 +10,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NoDataNativeAd.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NoDataNativeAd.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.matchParentSize
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedCard
@@ -108,66 +109,73 @@ fun NoDataNativeAdBanner(
 
         nativeAd?.let { ad ->
             NativeAdView(nativeAd = ad) {
-                OutlinedCard(
-                    modifier = modifier.fillMaxWidth(),
-                    shape = RoundedCornerShape(size = SizeConstants.ExtraLargeSize),
-                ) {
-                    Column(
-                        modifier = Modifier
-                            .fillMaxWidth()
-                            .padding(SizeConstants.LargeSize),
+                Box {
+                    OutlinedCard(
+                        modifier = modifier.fillMaxWidth(),
+                        shape = RoundedCornerShape(size = SizeConstants.ExtraLargeSize),
                     ) {
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            horizontalArrangement = Arrangement.SpaceBetween,
-                            verticalAlignment = Alignment.CenterVertically,
+                        Column(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .padding(SizeConstants.LargeSize),
                         ) {
-                            AdLabel()
-                            NativeAdChoicesView()
-                        }
-                        Row(
-                            modifier = Modifier.fillMaxWidth(),
-                            verticalAlignment = Alignment.CenterVertically,
-                            horizontalArrangement = Arrangement.Start,
-                        ) {
-                            ad.icon?.let { icon ->
-                                NativeAdIconView(
-                                    modifier = Modifier
-                                        .size(SizeConstants.ExtraLargeIncreasedSize)
-                                        .clip(RoundedCornerShape(size = SizeConstants.SmallSize)),
-                                ) {
-                                    AsyncImage(
-                                        model = icon.uri ?: icon.drawable,
-                                        contentDescription = ad.headline,
-                                    )
-                                }
-                                LargeHorizontalSpacer()
-                            }
-                            Column(
-                                modifier = Modifier.weight(1f),
-                                verticalArrangement = Arrangement.Center,
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                horizontalArrangement = Arrangement.SpaceBetween,
+                                verticalAlignment = Alignment.CenterVertically,
                             ) {
-                                ad.headline?.let {
-                                    NativeAdHeadlineView {
-                                        Text(text = it, fontWeight = FontWeight.Bold)
-                                    }
-                                }
-                                ad.body?.let { body ->
-                                    NativeAdBodyView {
-                                        Text(
-                                            text = body,
-                                            style = MaterialTheme.typography.bodySmall,
+                                AdLabel()
+                                NativeAdChoicesView()
+                            }
+                            Row(
+                                modifier = Modifier.fillMaxWidth(),
+                                verticalAlignment = Alignment.CenterVertically,
+                                horizontalArrangement = Arrangement.Start,
+                            ) {
+                                ad.icon?.let { icon ->
+                                    NativeAdIconView(
+                                        modifier = Modifier
+                                            .size(SizeConstants.ExtraLargeIncreasedSize)
+                                            .clip(RoundedCornerShape(size = SizeConstants.SmallSize)),
+                                    ) {
+                                        AsyncImage(
+                                            model = icon.uri ?: icon.drawable,
+                                            contentDescription = ad.headline,
                                         )
                                     }
+                                    LargeHorizontalSpacer()
                                 }
-                            }
-                            ad.callToAction?.let { cta ->
-                                LargeHorizontalSpacer()
-                                NativeAdCallToActionView {
-                                    NativeAdButton(text = cta)
+                                Column(
+                                    modifier = Modifier.weight(1f),
+                                    verticalArrangement = Arrangement.Center,
+                                ) {
+                                    ad.headline?.let {
+                                        NativeAdHeadlineView {
+                                            Text(text = it, fontWeight = FontWeight.Bold)
+                                        }
+                                    }
+                                    ad.body?.let { body ->
+                                        NativeAdBodyView {
+                                            Text(
+                                                text = body,
+                                                style = MaterialTheme.typography.bodySmall,
+                                            )
+                                        }
+                                    }
+                                }
+                                ad.callToAction?.let { cta ->
+                                    LargeHorizontalSpacer()
+                                    NativeAdCallToActionView(register = false) {
+                                        NativeAdButton(text = cta)
+                                    }
                                 }
                             }
                         }
+                    }
+                    NativeAdCallToActionView(
+                        modifier = Modifier.matchParentSize()
+                    ) {
+                        Box(modifier = Modifier.matchParentSize())
                     }
                 }
             }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NoDataNativeAd.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NoDataNativeAd.kt
@@ -163,18 +163,16 @@ fun NoDataNativeAdBanner(
                                 }
                                 ad.callToAction?.let { cta ->
                                     LargeHorizontalSpacer()
-                                    NativeAdCallToActionView(register = false) {
+                                    NativeAdCallToActionView {
                                         NativeAdButton(text = cta)
                                     }
                                 }
                             }
                         }
                     }
-                    NativeAdCallToActionView(
+                    NativeAdClickOverlay(
                         modifier = Modifier.fillMaxSize()
-                    ) {
-                        Box(modifier = Modifier.fillMaxSize())
-                    }
+                    )
                 }
             }
         }


### PR DESCRIPTION
## Summary
- post setNativeAd to run after asset views attach
- add debug logging when assets like headline or CTA are registered

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbf7ac139c832d930eda3b66961f43