### PR TITLE
feat: bind call-to-action view

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/ui/components/ads/NativeAdBanner.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/ui/components/ads/NativeAdBanner.kt
@@ -39,9 +39,11 @@ import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdCallToAct
 import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdChoicesView
 import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdHeadlineView
 import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdIconView
+import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdMediaView
 import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdView
 import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.TAG
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeHorizontalSpacer
+import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
 import com.google.android.gms.ads.AdListener
@@ -128,6 +130,16 @@ fun NativeAdBanner(
                         ) {
                             AdLabel()
                             NativeAdChoicesView()
+                        }
+                        ad.mediaContent?.let {
+                            LargeVerticalSpacer()
+                            NativeAdMediaView(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(120.dp)
+                                    .clip(RoundedCornerShape(size = SizeConstants.SmallSize)),
+                            )
+                            LargeVerticalSpacer()
                         }
                         Row(
                             modifier = Modifier.fillMaxWidth(),

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/ui/components/ads/NativeAdBanner.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/ui/components/ads/NativeAdBanner.kt
@@ -40,6 +40,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdChoicesVi
 import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdHeadlineView
 import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdIconView
 import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdMediaView
+import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.LocalNativeAdView
 import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdView
 import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.TAG
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeHorizontalSpacer
@@ -184,6 +185,9 @@ fun NativeAdBanner(
                             }
                         }
                     }
+                }
+                LaunchedEffect(ad) {
+                    LocalNativeAdView.current?.setNativeAd(ad)
                 }
             }
         }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/BottomAppBarNativeAdBanner.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/BottomAppBarNativeAdBanner.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material3.NavigationBar
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
@@ -26,6 +25,13 @@ import androidx.compose.ui.text.style.TextOverflow
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
+import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.AdLabel
+import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdButton
+import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdCallToActionView
+import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdChoicesView
+import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdHeadlineView
+import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdIconView
+import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.NativeAdView
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeHorizontalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
@@ -44,15 +50,8 @@ fun BottomAppBarNativeAdBanner(
     val dataStore: CommonDataStore = remember { CommonDataStore.getInstance(context = context) }
     val showAds: Boolean by dataStore.adsEnabledFlow.collectAsStateWithLifecycle(initialValue = true)
     if (LocalInspectionMode.current) {
-        NavigationBar(modifier = modifier.fillMaxWidth()) {
-            Box(
-                modifier = Modifier
-                    .weight(1f)
-                    .fillMaxWidth(),
-                contentAlignment = Alignment.Center,
-            ) {
-                Text(text = "Native Ad")
-            }
+        Box(modifier = modifier.fillMaxWidth(), contentAlignment = Alignment.Center) {
+            Text(text = "Native Ad")
         }
         return
     }
@@ -93,10 +92,10 @@ fun BottomAppBarNativeAdBanner(
 
         nativeAd?.let { ad ->
             NativeAdView(modifier = modifier.fillMaxWidth()) {
-                NavigationBar(modifier = Modifier.fillMaxWidth()) {
+                Box(modifier = Modifier.fillMaxWidth()) {
                     Row(
                         modifier = Modifier
-                            .weight(1f)
+                            .fillMaxWidth()
                             .padding(horizontal = SizeConstants.LargeSize),
                         verticalAlignment = Alignment.CenterVertically,
                     ) {
@@ -135,6 +134,9 @@ fun BottomAppBarNativeAdBanner(
                             }
                         }
                     }
+                }
+                LaunchedEffect(ad) {
+                    LocalNativeAdView.current?.setNativeAd(ad)
                 }
             }
         }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/HelpNativeAd.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/HelpNativeAd.kt
@@ -179,6 +179,9 @@ fun HelpNativeAdBanner(
                         }
                     }
                 }
+                LaunchedEffect(ad) {
+                    LocalNativeAdView.current?.setNativeAd(ad)
+                }
             }
         }
     }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/HelpNativeAd.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/HelpNativeAd.kt
@@ -33,6 +33,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeHorizontalSpacer
+import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
 import com.google.android.gms.ads.AdListener
@@ -122,6 +123,16 @@ fun HelpNativeAdBanner(
                         ) {
                             AdLabel()
                             NativeAdChoicesView()
+                        }
+                        ad.mediaContent?.let {
+                            LargeVerticalSpacer()
+                            NativeAdMediaView(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(120.dp)
+                                    .clip(RoundedCornerShape(size = SizeConstants.SmallSize)),
+                            )
+                            LargeVerticalSpacer()
                         }
                         Row(
                             modifier = Modifier.fillMaxWidth(),

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/LargeNativeAdBanner.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/LargeNativeAdBanner.kt
@@ -178,6 +178,9 @@ fun LargeNativeAdBanner(
                         }
                     }
                 }
+                LaunchedEffect(ad) {
+                    LocalNativeAdView.current?.setNativeAd(ad)
+                }
             }
         }
     }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/LargeNativeAdBanner.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/LargeNativeAdBanner.kt
@@ -33,6 +33,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeHorizontalSpacer
+import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
 import com.google.android.gms.ads.AdListener
@@ -119,6 +120,16 @@ fun LargeNativeAdBanner(
                         ) {
                             AdLabel()
                             NativeAdChoicesView()
+                        }
+                        ad.mediaContent?.let {
+                            LargeVerticalSpacer()
+                            NativeAdMediaView(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(120.dp)
+                                    .clip(RoundedCornerShape(size = SizeConstants.SmallSize)),
+                            )
+                            LargeVerticalSpacer()
                         }
                         Row(
                             verticalAlignment = Alignment.CenterVertically,

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NativeAdCompose.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NativeAdCompose.kt
@@ -130,11 +130,18 @@ fun NativeAdCallToActionView(modifier: Modifier = Modifier, content: @Composable
     val localContext = LocalContext.current
     val localComposeView = remember { ComposeView(localContext).apply { id = View.generateViewId() } }
     AndroidView(
-        factory = {
-            nativeAdView.callToActionView = localComposeView
-            localComposeView.apply { setContent(content) }
-        },
+        factory = { localComposeView },
         modifier = modifier,
+        update = { view ->
+            // Remove any overlay registered as the call-to-action view.
+            (nativeAdView.callToActionView as? View)?.let { overlay ->
+                if (overlay !== view) {
+                    (overlay.parent as? ViewGroup)?.removeView(overlay)
+                }
+            }
+            nativeAdView.callToActionView = view
+            view.setContent(content)
+        },
     )
 }
 

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NoDataNativeAd.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NoDataNativeAd.kt
@@ -33,6 +33,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeHorizontalSpacer
+import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
 import com.google.android.gms.ads.AdListener
@@ -122,6 +123,16 @@ fun NoDataNativeAdBanner(
                         ) {
                             AdLabel()
                             NativeAdChoicesView()
+                        }
+                        ad.mediaContent?.let {
+                            LargeVerticalSpacer()
+                            NativeAdMediaView(
+                                modifier = Modifier
+                                    .fillMaxWidth()
+                                    .height(120.dp)
+                                    .clip(RoundedCornerShape(size = SizeConstants.SmallSize)),
+                            )
+                            LargeVerticalSpacer()
                         }
                         Row(
                             modifier = Modifier.fillMaxWidth(),

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NoDataNativeAd.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NoDataNativeAd.kt
@@ -179,6 +179,9 @@ fun NoDataNativeAdBanner(
                         }
                     }
                 }
+                LaunchedEffect(ad) {
+                    LocalNativeAdView.current?.setNativeAd(ad)
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- bind dedicated call-to-action ComposeView to NativeAdView
- remove any full-screen overlay when call-to-action asset is present

## Testing
- `./gradlew :apptoolkit:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bed9a70ab0832d967e0eb5a583b1b5