### PR TITLE
docs: add AGENTS instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,31 @@
+# App Toolkit for Android
+
+You are an experienced Android app developer contributing to **App Toolkit for Android**.
+
+## Important locations
+- Main entry activity: `app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainActivity.kt`.
+- Navigation host: `app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/components/navigation/AppNavigationHost.kt`.
+
+## Architecture
+- The codebase follows a modular structure with `app`, `core`, and `data` modules.
+- Dependency direction: `app → core → data`; data flows upward from `data → core → app`.
+- Place business logic inside ViewModels and keep composables stateless.
+- Use unidirectional data flow with Kotlin Coroutines and Flow.
+- Rely on Koin for dependency injection and ViewModel provisioning.
+
+## UI
+- Build all UI with Jetpack Compose and Material 3 components.
+- Do not use XML layouts for new UI.
+
+## Coding style
+
+@./docs/style-guidance.md
+
+## Jetpack Compose architecture
+@./docs/jetpack-compose-layering.md
+
+## Android architecture recommendations
+@./docs/android-architecture-recommendations.md
+
+## Testing
+- Run `./gradlew test` and ensure it passes before submitting changes.

--- a/docs/android-architecture-recommendations.md
+++ b/docs/android-architecture-recommendations.md
@@ -1,0 +1,166 @@
+# Recommendations for Android architecture
+
+bookmark_border
+This page presents several Architecture best practices and recommendations. Adopt them to improve your app’s quality, robustness, and scalability. They also make it easier to maintain and test your app.
+
+> Note: You should treat the recommendations in the document as recommendations and not strict requirements. Adapt them to your app as needed.
+
+The best practices below are grouped by topic. Each has a priority that reflects how strongly the team recommends it. The list of priorities is as follows:
+
+- **Strongly recommended**: You should implement this practice unless it clashes fundamentally with your approach.
+- **Recommended**: This practice is likely to improve your app.
+- **Optional**: This practice can improve your app in certain circumstances.
+
+> Note: In order to understand these recommendations, you should be familiar with the Architecture guidance.
+
+## Layered architecture
+Our recommended layered architecture favors separation of concerns. It drives UI from data models, complies with the single source of truth principle, and follows unidirectional data flow principles. Here are some best practices for layered architecture:
+
+| Recommendation | Description |
+| --- | --- |
+| Use a clearly defined data layer. | **Strongly recommended**<br>The data layer exposes application data to the rest of the app and contains the vast majority of business logic of your app.<br>You should create repositories even if they just contain a single data source.<br>In small apps, you can choose to place data layer types in a data package or module. |
+| Use a clearly defined UI layer. | **Strongly recommended**<br>The UI layer displays the application data on the screen and serves as the primary point of user interaction.<br>In small apps, you can choose to place data layer types in a ui package or module.<br>More UI layer best practices here. |
+| The data layer should expose application data using a repository. | **Strongly recommended**<br>Components in the UI layer such as composables, activities, or ViewModels shouldn't interact directly with a data source. Examples of data sources are:<br><br>- Databases, DataStore, SharedPreferences, Firebase APIs.<br>- GPS location providers.<br>- Bluetooth data providers.<br>- Network connectivity status provider. |
+| Use coroutines and flows. | **Strongly recommended**<br>Use coroutines and flows to communicate between layers.<br>More coroutines best practices here. |
+| Use a domain layer. | **Recommended in big apps**<br>Use a domain layer, use cases, if you need to reuse business logic that interacts with the data layer across multiple ViewModels, or you want to simplify the business logic complexity of a particular ViewModel |
+
+## UI layer
+The role of the UI layer is to display the application data on the screen and serve as the primary point of user interaction. Here are some best practices for the UI layer:
+
+| Recommendation | Description |
+| --- | --- |
+| Follow Unidirectional Data Flow (UDF). | **Strongly recommended**<br>Follow Unidirectional Data Flow (UDF) principles, where ViewModels expose UI state using the observer pattern and receive actions from the UI through method calls. |
+| Use AAC ViewModels if their benefits apply to your app. | **Strongly recommended**<br>Use AAC ViewModels to handle business logic, and fetch application data to expose UI state to the UI (Compose or Android Views).<br>See more ViewModel best practices here.<br><br>See the benefits of ViewModels here. |
+| Use lifecycle-aware UI state collection. | **Strongly recommended**<br>Collect UI state from the UI using the appropriate lifecycle-aware coroutine builder: `repeatOnLifecycle` in the View system and `collectAsStateWithLifecycle` in Jetpack Compose.<br>Read more about `repeatOnLifecycle`.<br><br>Read more about `collectAsStateWithLifecycle`. |
+| Do not send events from the ViewModel to the UI. | **Strongly recommended**<br>Process the event immediately in the ViewModel and cause a state update with the result of handling the event. More about UI events here. |
+| Use a single-activity application. | **Recommended**<br>Use Navigation Fragments or Navigation Compose to navigate between screens and deep link to your app if your app has more than one screen. |
+| Use Jetpack Compose. | **Recommended**<br>Use Jetpack Compose to build new apps for phones, tablets and foldables and Wear OS. |
+
+The following snippet outlines how to collect the UI state in a lifecycle-aware manner:
+
+### Views
+```kotlin
+class MyFragment : Fragment() {
+
+    private val viewModel: MyViewModel by viewModel()
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        viewLifecycleOwner.lifecycleScope.launch {
+            viewLifecycleOwner.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.uiState.collect {
+                    // Process item
+                }
+            }
+        }
+    }
+}
+```
+
+### Compose
+```kotlin
+// Compose snippet omitted for brevity
+```
+
+## ViewModel
+ViewModels are responsible for providing the UI state and access to the data layer. Here are some best practices for ViewModels:
+
+| Recommendation | Description |
+| --- | --- |
+| ViewModels should be agnostic of the Android lifecycle. | **Strongly recommended**<br>ViewModels shouldn't hold a reference to any Lifecycle-related type. Don't pass Activity, Fragment, Context or Resources as a dependency. If something needs a Context in the ViewModel, you should strongly evaluate if that is in the right layer. |
+| Use coroutines and flows. | **Strongly recommended**<br>The ViewModel interacts with the data or domain layers using:<br><br>- Kotlin flows for receiving application data,<br>- `suspend` functions to perform actions using `viewModelScope`. |
+| Use ViewModels at screen level. | **Strongly recommended**<br>Do not use ViewModels in reusable pieces of UI. You should use ViewModels in:<br><br>- Screen-level composables,<br>- Activities/Fragments in Views,<br>- Destinations or graphs when using Jetpack Navigation. |
+| Use plain state holder classes in reusable UI components. | **Strongly recommended**<br>Use plain state holder classes for handling complexity in reusable UI components. By doing this, the state can be hoisted and controlled externally. |
+| Do not use AndroidViewModel. | **Recommended**<br>Use the ViewModel class, not AndroidViewModel. The Application class shouldn't be used in the ViewModel. Instead, move the dependency to the UI or the data layer. |
+| Expose a UI state. | **Recommended**<br>ViewModels should expose data to the UI through a single property called `uiState`. If the UI shows multiple, unrelated pieces of data, the VM can expose multiple UI state properties.<br>You should make `uiState` a `StateFlow`.<br>You should create the `uiState` using the `stateIn` operator with the `WhileSubscribed(5000)` policy if the data comes as a stream of data from other layers of the hierarchy.<br>For simpler cases with no streams of data coming from the data layer, it's acceptable to use a `MutableStateFlow` exposed as an immutable `StateFlow`.<br>You can choose to have the `${Screen}UiState` as a data class that can contain data, errors and loading signals. This class could also be a sealed class if the different states are exclusive. |
+
+The following snippet outlines how to expose UI state from a ViewModel:
+
+```kotlin
+@HiltViewModel
+class BookmarksViewModel @Inject constructor(
+    newsRepository: NewsRepository
+) : ViewModel() {
+
+    val feedState: StateFlow<NewsFeedUiState> =
+        newsRepository
+            .getNewsResourcesStream()
+            .mapToFeedState(savedNewsResourcesState)
+            .stateIn(
+                scope = viewModelScope,
+                started = SharingStarted.WhileSubscribed(5_000),
+                initialValue = NewsFeedUiState.Loading
+            )
+
+    // ...
+}
+```
+
+## Lifecycle
+The following are some best practices for working with the Android lifecycle:
+
+| Recommendation | Description |
+| --- | --- |
+| Do not override lifecycle methods in Activities or Fragments. | **Strongly recommended**<br>Do not override lifecycle methods such as `onResume` in Activities or Fragments. Use `LifecycleObserver` instead. If the app needs to perform work when the lifecycle reaches a certain `Lifecycle.State`, use the `repeatOnLifecycle` API. |
+
+The following snippet outlines how to perform operations given a certain Lifecycle state:
+
+### Views
+```kotlin
+class MyFragment: Fragment() {
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        viewLifecycleOwner.lifecycle.addObserver(object : DefaultLifecycleObserver {
+            override fun onResume(owner: LifecycleOwner) {
+                // ...
+            }
+            override fun onPause(owner: LifecycleOwner) {
+                // ...
+            }
+        })
+    }
+}
+```
+
+### Compose
+```kotlin
+// Compose snippet omitted for brevity
+```
+
+## Handle dependencies
+There are several best practices you should observe when managing dependencies between components:
+
+| Recommendation | Description |
+| --- | --- |
+| Use dependency injection. | **Strongly recommended**<br>Use dependency injection best practices, mainly constructor injection when possible. |
+| Scope to a component when necessary. | **Strongly recommended**<br>Scope to a dependency container when the type contains mutable data that needs to be shared or the type is expensive to initialize and is widely used in the app. |
+| Use Hilt. | **Recommended**<br>Use Hilt or manual dependency injection in simple apps. Use Hilt if your project is complex enough. For example, if you have:<br><br>- Multiple screens with ViewModels—integration<br>- WorkManager usage—integration<br>- Advance usage of Navigation, such as ViewModels scoped to the nav graph—integration. |
+
+## Testing
+The following are some best practices for testing:
+
+| Recommendation | Description |
+| --- | --- |
+| Know what to test. | **Strongly recommended**<br>Unless the project is roughly as simple as a hello world app, you should test it, at minimum with:<br><br>- Unit test ViewModels, including Flows.<br>- Unit test data layer entities. That is, repositories and data sources.<br>- UI navigation tests that are useful as regression tests in CI. |
+| Prefer fakes to mocks. | **Strongly recommended**<br>Read more in the Use test doubles in Android documentation. |
+| Test StateFlows. | **Strongly recommended**<br>When testing StateFlow:<br>- Assert on the `value` property whenever possible<br>- You should create a `collectJob` if using `WhileSubscribed`<br>For more information, check the *What to test in Android* DAC guide. |
+
+## Models
+You should observe these best practices when developing models in your apps:
+
+| Recommendation | Description |
+| --- | --- |
+| Create a model per layer in complex apps. | **Recommended**<br>In complex apps, create new models in different layers or components when it makes sense. Consider the following examples:<br><br>- A remote data source can map the model that it receives through the network to a simpler class with just the data the app needs<br>- Repositories can map DAO models to simpler data classes with just the information the UI layer needs.<br>- ViewModel can include data layer models in `UiState` classes. |
+
+## Naming conventions
+When naming your codebase, you should be aware of the following best practices:
+
+| Recommendation | Description |
+| --- | --- |
+| Naming methods. | **Optional**<br>Methods should be a verb phrase. For example, `makePayment()`. |
+| Naming properties. | **Optional**<br>Properties should be a noun phrase. For example, `inProgressTopicSelection`. |
+| Naming streams of data. | **Optional**<br>When a class exposes a Flow stream, LiveData, or any other stream, the naming convention is `get{model}Stream()`. For example, `getAuthorStream(): Flow<Author>` If the function returns a list of models the model name should be in the plural: `getAuthorsStream(): Flow<List<Author>>`. |
+| Naming interfaces implementations. | **Optional**<br>Names for the implementations of interfaces should be meaningful. Have `Default` as the prefix if a better name cannot be found. For example, for a `NewsRepository` interface, you could have an `OfflineFirstNewsRepository`, or `InMemoryNewsRepository`. If you can find no good name, then use `DefaultNewsRepository`. Fake implementations should be prefixed with `Fake`, as in `FakeAuthorsRepository`. |
+

--- a/docs/jetpack-compose-layering.md
+++ b/docs/jetpack-compose-layering.md
@@ -1,0 +1,152 @@
+# Jetpack Compose architectural layering
+
+bookmark_border
+This page provides a high-level overview of the architectural layers that make up Jetpack Compose, and the core principles that inform this design.
+
+Jetpack Compose is not a single monolithic project; it is created from a number of modules which are assembled together to form a complete stack. Understanding the different modules that make up Jetpack Compose enables you to:
+
+Use the appropriate level of abstraction to build your app or library
+Understand when you can ‘drop down’ to a lower level for more control or customization
+Minimize your dependencies
+
+## Layers
+The major layers of Jetpack Compose are:
+
+
+
+Figure 1. The major layers of Jetpack Compose.
+
+Each layer is built upon the lower levels, combining functionality to create higher level components. Each layer builds on public APIs of the lower layers to verify the module boundaries and enable you to replace any layer should you need to. Let's examine these layers from the bottom up.
+
+### Runtime
+This module provides the fundamentals of the Compose runtime such as remember, mutableStateOf, the @Composable annotation and SideEffect. You might consider building directly upon this layer if you only need Compose’s tree management abilities, not its UI.
+
+### UI
+The UI layer is made up of multiple modules ( ui-text, ui-graphics, ui-tooling, etc.). These modules implement the fundamentals of the UI toolkit, such as LayoutNode, Modifier, input handlers, custom layouts, and drawing. You might consider building upon this layer if you only need fundamental concepts of a UI toolkit.
+
+### Foundation
+This module provides design system agnostic building blocks for Compose UI, like Row and Column, LazyColumn, recognition of particular gestures, etc. You might consider building upon the foundation layer to create your own design system.
+
+### Material
+This module provides an implementation of the Material Design system for Compose UI, providing a theming system, styled components, ripple indications, icons. Build upon this layer when using Material Design in your app.
+
+## Design principles
+A guiding principle for Jetpack Compose is to provide small, focused pieces of functionality that can be assembled (or composed) together, rather than a few monolithic components. This approach has a number of advantages.
+
+### Control
+Higher level components tend to do more for you, but limit the amount of direct control that you have. If you need more control, you can "drop down" to use a lower level component.
+
+For example, if you want to animate the color of a component you might use the animateColorAsState API:
+
+```kotlin
+val color = animateColorAsState(if (condition) Color.Green else Color.Red)
+```
+
+However, if you needed the component to always start out grey, you cannot do it with this API. Instead, you can drop down to use the lower level Animatable API:
+
+```kotlin
+val color = remember { Animatable(Color.Gray) }
+LaunchedEffect(condition) {
+    color.animateTo(if (condition) Color.Green else Color.Red)
+}
+```
+
+The higher level animateColorAsState API is itself built upon the lower level Animatable API. Using the lower level API is more complex but offers more control. Choose the level of abstraction that best suits your needs.
+
+### Customization
+Assembling higher level components from smaller building blocks makes it far easier to customize components should you need to. For example, consider the implementation of Button provided by the Material layer:
+
+```kotlin
+@Composable
+fun Button(
+    // …
+    content: @Composable RowScope.() -> Unit
+) {
+    Surface(/* … */) {
+        CompositionLocalProvider(/* … */) { // set LocalContentAlpha
+            ProvideTextStyle(MaterialTheme.typography.button) {
+                Row(
+                    // …
+                    content = content
+                )
+            }
+        }
+    }
+}
+```
+
+A Button is assembled from 4 components:
+
+1. A material Surface providing the background, shape, click handling, etc.
+2. A CompositionLocalProvider which changes the content’s alpha when the button is enabled or disabled
+3. A ProvideTextStyle sets the default text style to use
+4. A Row provides the default layout policy for the button's content
+
+We have omitted some parameters and comments to make the structure clearer, but the entire component is only around 40 lines of code because it simply assembles these 4 components to implement the button. Components like Button are opinionated about which parameters they expose, balancing enabling common customizations against an explosion of parameters that can make a component harder to use. Material components, for example, offer customizations specified in the Material Design system, making it easy to follow material design principles.
+
+If, however, you wish to make a customization beyond a component's parameters, then you can "drop down" a level and fork a component. For example, Material Design specifies that buttons should have a solid colored background. If you need a gradient background, this option is not supported by the Button parameters. In this case you can use the Material Button implementation as a reference and build your own component:
+
+```kotlin
+@Composable
+fun GradientButton(
+    // …
+    background: List<Color>,
+    modifier: Modifier = Modifier,
+    content: @Composable RowScope.() -> Unit
+) {
+    Row(
+        // …
+        modifier = modifier
+            .clickable(onClick = {})
+            .background(
+                Brush.horizontalGradient(background)
+            )
+    ) {
+        CompositionLocalProvider(/* … */) { // set material LocalContentAlpha
+            ProvideTextStyle(MaterialTheme.typography.button) {
+                content()
+            }
+        }
+    }
+}
+```
+
+The above implementation continues to use components from the Material layer, such as Material’s concepts of current content alpha and the current text style. However, it replaces the material Surface with a Row and styles it to achieve the desired appearance.
+
+Caution: When dropping down to a lower layer to customize a component, ensure that you do not degrade any functionality by, for example, neglecting accessibility support. Use the component you are forking as a guide.
+If you do not want to use Material concepts at all, for example if building your own bespoke design system, then you can drop down to purely using foundation layer components:
+
+```kotlin
+@Composable
+fun BespokeButton(
+    // …
+    backgroundColor: Color,
+    modifier: Modifier = Modifier,
+    content: @Composable RowScope.() -> Unit
+) {
+    Row(
+        // …
+        modifier = modifier
+            .clickable(onClick = {})
+            .background(backgroundColor)
+    ) {
+        // No Material components used
+        content()
+    }
+}
+```
+
+Jetpack Compose reserves the simplest names for the highest level components. For example, androidx.compose.material.Text is built upon androidx.compose.foundation.text.BasicText. This makes it possible to provide your own implementation with the most discoverable name if you wish to replace higher levels.
+
+Caution: Forking a component means that you will not benefit from any future additions or bug fixes from the upstream component.
+
+### Picking the right abstraction
+Compose’s philosophy of building layered, reusable components means that you should not always reach for the lower level building blocks. Many higher level components not only offer more functionality but often implement best practices such as supporting accessibility.
+
+For example, if you wanted to add gesture support to your custom component, you could build this from scratch using Modifier.pointerInput but there are other, higher level components built on top of this which may offer a better starting point, for example Modifier.draggable, Modifier.scrollable or Modifier.swipeable.
+
+As a rule, prefer building on the highest-level component which offers the functionality you need in order to benefit from the best practices they include.
+
+## Learn more
+See the Jetsnack sample for an example of building a custom design system.
+

--- a/docs/style-guidance.md
+++ b/docs/style-guidance.md
@@ -1,0 +1,9 @@
+# Style Guidance
+
+- Follow official Kotlin coding conventions.
+- Prefer immutable `val` properties and keep functions small and focused.
+- Name classes and files using `PascalCase`; use `camelCase` for functions and variables.
+- Each file should end with a trailing newline.
+- Compose UI uses Material 3 theming; reference `MaterialTheme` for colors, typography, and spacing.
+- Use Kotlin Coroutines and Flow for asynchronous work and state streams.
+- Inject dependencies with Koin; obtain ViewModels via Koin helpers.


### PR DESCRIPTION
## Summary
- add project-level AGENTS.md outlining architecture, UI, and testing guidelines
- include reusable docs/style-guidance.md and import it from AGENTS.md
- document Jetpack Compose layering and Android architecture recommendations and reference them from AGENTS.md

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c105bc0b2c832d83061ca73e79e9df