### PR TITLE
docs: add agent, coroutine, flow, and compose guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,8 +24,32 @@ You are an experienced Android app developer contributing to **App Toolkit for A
 ## Jetpack Compose architecture
 @./docs/jetpack-compose-layering.md
 
+## Jetpack Compose best practices
+@./docs/compose-best-practices.md
+
+## State and Jetpack Compose
+@./docs/compose-state.md
+
+## Thinking in Compose
+@./docs/thinking-in-compose.md
+
 ## Android architecture recommendations
 @./docs/android-architecture-recommendations.md
+
+## AGENTS usage
+@./docs/gemini-agents.md
+
+## Coroutines best practices
+@./docs/coroutines-best-practices.md
+
+## Kotlin coroutines on Android
+@./docs/kotlin-coroutines-android.md
+
+## Kotlin flows on Android
+@./docs/kotlin-flows-android.md
+
+## Testing Kotlin flows on Android
+@./docs/testing-kotlin-flows-android.md
 
 ## Testing
 - Run `./gradlew test` and ensure it passes before submitting changes.

--- a/docs/compose-best-practices.md
+++ b/docs/compose-best-practices.md
@@ -1,0 +1,266 @@
+# Follow best practices
+
+You might encounter common Compose pitfalls. These mistakes might give you code that seems to run well enough, but can hurt your UI performance. Follow best practices to optimize your app on Compose.
+
+## Use `remember` to minimize expensive calculations
+Composable functions can run very frequently, as often as for every frame of an animation. For this reason, you should do as little calculation in the body of your composable as you can.
+
+An important technique is to store the results of calculations with `remember`. That way, the calculation runs once, and you can fetch the results whenever they're needed.
+
+For example, here's some code that displays a sorted list of names, but does the sorting in a very expensive way:
+
+```kotlin
+@Composable
+fun ContactList(
+    contacts: List<Contact>,
+    comparator: Comparator<Contact>,
+    modifier: Modifier = Modifier
+) {
+    LazyColumn(modifier) {
+        // DON’T DO THIS
+        items(contacts.sortedWith(comparator)) { contact ->
+            // ...
+        }
+    }
+}
+```
+
+Every time `ContactsList` is recomposed, the entire contact list is sorted all over again, even though the list hasn't changed. If the user scrolls the list, the composable gets recomposed whenever a new row appears.
+
+To solve this problem, sort the list outside the `LazyColumn`, and store the sorted list with `remember`:
+
+```kotlin
+@Composable
+fun ContactList(
+    contacts: List<Contact>,
+    comparator: Comparator<Contact>,
+    modifier: Modifier = Modifier
+) {
+    val sortedContacts = remember(contacts, comparator) {
+        contacts.sortedWith(comparator)
+    }
+
+    LazyColumn(modifier) {
+        items(sortedContacts) {
+            // ...
+        }
+    }
+}
+```
+
+Now, the list is sorted once, when `ContactList` is first composed. If the `contacts` or `comparator` change, the sorted list is regenerated. Otherwise, the composable can keep using the cached sorted list.
+
+> **Note:** If possible, it's best to move calculations outside of the composable altogether. In this case, you might want to sort the list elsewhere, like in your ViewModel, and provide the sorted list as an input to the composable.
+
+## Use lazy layout keys
+Lazy layouts efficiently reuse items, only regenerating or recomposing them when they have to. However, you can help optimize lazy layouts for recomposition.
+
+Suppose a user operation causes an item to move in the list. For example, suppose you show a list of notes sorted by modification time with the most recently modified note on top.
+
+```kotlin
+@Composable
+fun NotesList(notes: List<Note>) {
+    LazyColumn {
+        items(
+            items = notes
+        ) { note ->
+            NoteRow(note)
+        }
+    }
+}
+```
+
+There's a problem with this code though. Suppose the bottom note is changed. It's now the most recently modified note, so it goes to the top of the list, and every other note moves down one spot.
+
+Without your help, Compose doesn't realize that unchanged items are just being moved in the list. Instead, Compose thinks the old "item 2" was deleted and a new one was created for item 3, item 4, and all the way down. The result is that Compose recomposes every item on the list, even though only one of them actually changed.
+
+The solution here is to provide item keys. Providing a stable key for each item lets Compose avoid unnecessary recompositions. In this case, Compose can determine the item now at spot 3 is the same item that used to be at spot 2. Since none of the data for that item has changed, Compose doesn't have to recompose it.
+
+```kotlin
+@Composable
+fun NotesList(notes: List<Note>) {
+    LazyColumn {
+        items(
+            items = notes,
+            key = { note ->
+                // Return a stable, unique key for the note
+                note.id
+            }
+        ) { note ->
+            NoteRow(note)
+        }
+    }
+}
+```
+
+## Use `derivedStateOf` to limit recompositions
+One risk of using state in your compositions is that, if the state changes rapidly, your UI might get recomposed more than you need it to. For example, suppose you're displaying a scrollable list. You examine the list's state to see which item is the first visible item on the list:
+
+```kotlin
+val listState = rememberLazyListState()
+
+LazyColumn(state = listState) {
+    // ...
+}
+
+val showButton = listState.firstVisibleItemIndex > 0
+
+AnimatedVisibility(visible = showButton) {
+    ScrollToTopButton()
+}
+```
+
+The problem here is, if the user scrolls the list, `listState` is constantly changing as the user drags their finger. That means the list is constantly being recomposed. However, you don't actually need to recompose it that often—you don't need to recompose until a new item becomes visible at the bottom. So, that's a lot of extra computation, which makes your UI perform badly.
+
+The solution is to use derived state. `derivedStateOf` lets you tell Compose which changes of state actually should trigger recomposition. In this case, specify that you care about when the first visible item changes. When that state value changes, the UI needs to recompose, but if the user hasn't yet scrolled enough to bring a new item to the top, it doesn't have to recompose.
+
+```kotlin
+val listState = rememberLazyListState()
+
+LazyColumn(state = listState) {
+    // ...
+}
+
+val showButton by remember {
+    derivedStateOf {
+        listState.firstVisibleItemIndex > 0
+    }
+}
+
+AnimatedVisibility(visible = showButton) {
+    ScrollToTopButton()
+}
+```
+
+## Defer reads as long as possible
+When a performance issue has been identified, deferring state reads can help. Deferring state reads will ensure that Compose re-runs the minimum possible code on recomposition. For example, if your UI has state that is hoisted high up in the composable tree and you read the state in a child composable, you can wrap the state read in a lambda function. Doing this makes the read occur only when it is actually needed. For reference, see the implementation in the Jetsnack sample app. Jetsnack implements a collapsing-toolbar-like effect on its detail screen. To understand why this technique works, see the blog post [Jetpack Compose: Debugging Recomposition](https://medium.com/androiddevelopers/jetpack-compose-debugging-recomposition-33badf84eb5d).
+
+To achieve this effect, the `Title` composable needs the scroll offset in order to offset itself using a `Modifier`. Here's a simplified version of the Jetsnack code before the optimization is made:
+
+```kotlin
+@Composable
+fun SnackDetail() {
+    // ...
+
+    Box(Modifier.fillMaxSize()) { // Recomposition Scope Start
+        val scroll = rememberScrollState(0)
+        // ...
+        Title(snack, scroll.value)
+        // ...
+    } // Recomposition Scope End
+}
+
+@Composable
+private fun Title(snack: Snack, scroll: Int) {
+    // ...
+    val offset = with(LocalDensity.current) { scroll.toDp() }
+
+    Column(
+        modifier = Modifier
+            .offset(y = offset)
+    ) {
+        // ...
+    }
+}
+```
+
+When the scroll state changes, Compose invalidates the nearest parent recomposition scope. In this case, the nearest scope is the `SnackDetail` composable. Note that `Box` is an inline function, and so is not a recomposition scope. So Compose recomposes `SnackDetail` and any composables inside `SnackDetail`. If you change your code to only read the state where you actually use it, then you could reduce the number of elements that need to be recomposed.
+
+```kotlin
+@Composable
+fun SnackDetail() {
+    // ...
+
+    Box(Modifier.fillMaxSize()) { // Recomposition Scope Start
+        val scroll = rememberScrollState(0)
+        // ...
+        Title(snack) { scroll.value }
+        // ...
+    } // Recomposition Scope End
+}
+
+@Composable
+private fun Title(snack: Snack, scrollProvider: () -> Int) {
+    // ...
+    val offset = with(LocalDensity.current) { scrollProvider().toDp() }
+    Column(
+        modifier = Modifier
+            .offset(y = offset)
+    ) {
+        // ...
+    }
+}
+```
+
+The `scroll` parameter is now a lambda. That means `Title` can still reference the hoisted state, but the value is only read inside `Title`, where it's actually needed. As a result, when the scroll value changes, the nearest recomposition scope is now the `Title` composable–Compose no longer needs to recompose the whole `Box`.
+
+This is a good improvement, but you can do better! You should be suspicious if you are causing recomposition just to re-layout or redraw a composable. In this case, all you are doing is changing the offset of the `Title` composable, which could be done in the layout phase.
+
+```kotlin
+@Composable
+private fun Title(snack: Snack, scrollProvider: () -> Int) {
+    // ...
+    Column(
+        modifier = Modifier
+            .offset { IntOffset(x = 0, y = scrollProvider()) }
+    ) {
+        // ...
+    }
+}
+```
+
+Previously, the code used `Modifier.offset(x: Dp, y: Dp)`, which takes the offset as a parameter. By switching to the lambda version of the modifier, you can make sure the function reads the scroll state in the layout phase. As a result, when the scroll state changes, Compose can skip the composition phase entirely, and go straight to the layout phase. When you are passing frequently changing `State` variables into modifiers, you should use the lambda versions of the modifiers whenever possible.
+
+Here is another example of this approach. This code hasn't been optimized yet:
+
+```kotlin
+// Here, assume animateColorBetween() is a function that swaps between
+// two colors
+val color by animateColorBetween(Color.Cyan, Color.Magenta)
+
+Box(
+    Modifier
+        .fillMaxSize()
+        .background(color)
+)
+```
+
+Here, the box's background color is switching rapidly between two colors. This state is thus changing very frequently. The composable then reads this state in the `background` modifier. As a result, the box has to recompose on every frame, since the color is changing on every frame.
+
+To improve this, use a lambda-based modifier—in this case, `drawBehind`. That means the color state is only read during the draw phase. As a result, Compose can skip the composition and layout phases entirely—when the color changes, Compose goes straight to the draw phase.
+
+```kotlin
+val color by animateColorBetween(Color.Cyan, Color.Magenta)
+Box(
+    Modifier
+        .fillMaxSize()
+        .drawBehind {
+            drawRect(color)
+        }
+)
+```
+
+## Avoid backwards writes
+Compose has a core assumption that you will never write to state that has already been read. When you do this, it is called a backwards write and it can cause recomposition to occur on every frame, endlessly.
+
+The following composable shows an example of this kind of mistake.
+
+```kotlin
+@Composable
+fun BadComposable() {
+    var count by remember { mutableIntStateOf(0) }
+
+    // Causes recomposition on click
+    Button(onClick = { count++ }, Modifier.wrapContentSize()) {
+        Text("Recompose")
+    }
+
+    Text("$count")
+    count++ // Backwards write, writing to state after it has been read
+}
+```
+
+This code updates the count at the end of the composable after reading it on the preceding line. If you run this code, you'll see that after you click the button, which causes a recomposition, the counter rapidly increases in an infinite loop as Compose recomposes this composable, sees a state read that is out of date, and so schedules another recomposition.
+
+You can avoid backwards writes altogether by never writing to state in composition. If at all possible, always write to state in response to an event and in a lambda like in the preceding `onClick` example.
+

--- a/docs/compose-state.md
+++ b/docs/compose-state.md
@@ -1,0 +1,439 @@
+# State and Jetpack Compose
+
+State in an app is any value that can change over time. This is a very broad definition and encompasses everything from a Room database to a variable in a class.
+
+All Android apps display state to the user. A few examples of state in Android apps:
+
+- A Snackbar that shows when a network connection can't be established.
+- A blog post and associated comments.
+- Ripple animations on buttons that play when a user clicks them.
+- Stickers that a user can draw on top of an image.
+
+Jetpack Compose helps you be explicit about where and how you store and use state in an Android app. This guide focuses on the connection between state and composables, and on the APIs that Jetpack Compose offers to work with state more easily.
+
+## State and composition
+
+Compose is declarative and as such the only way to update it is by calling the same composable with new arguments. These arguments are representations of the UI state. Any time a state is updated a recomposition takes place. As a result, things like `TextField` don’t automatically update like they do in imperative XML based views. A composable has to explicitly be told the new state in order for it to update accordingly.
+
+```kotlin
+@Composable
+private fun HelloContent() {
+    Column(modifier = Modifier.padding(16.dp)) {
+        Text(
+            text = "Hello!",
+            modifier = Modifier.padding(bottom = 8.dp),
+            style = MaterialTheme.typography.bodyMedium
+        )
+        OutlinedTextField(
+            value = "",
+            onValueChange = { },
+            label = { Text("Name") }
+        )
+    }
+}
+```
+
+If you run this and try to enter text, you'll see that nothing happens. That's because the `TextField` doesn't update itself—it updates when its `value` parameter changes. This is due to how composition and recomposition work in Compose.
+
+**Key Term:**
+
+- **Composition:** a description of the UI built by Jetpack Compose when it executes composables.
+- **Initial composition:** creation of a Composition by running composables the first time.
+- **Recomposition:** re-running composables to update the Composition when data changes.
+
+To learn more about initial composition and recomposition, see [Thinking in Compose](https://developer.android.com/jetpack/compose/mental-model).
+
+## State in composables
+
+Composable functions can use the `remember` API to store an object in memory. A value computed by `remember` is stored in the Composition during initial composition, and the stored value is returned during recomposition. `remember` can be used to store both mutable and immutable objects.
+
+> Note: `remember` stores objects in the Composition, and forgets the object when the composable that called `remember` is removed from the Composition.
+
+`mutableStateOf` creates an observable `MutableState<T>`, which is an observable type integrated with the compose runtime.
+
+```kotlin
+interface MutableState<T> : State<T> {
+    override var value: T
+}
+```
+
+Any changes to `value` schedules recomposition of any composable functions that read `value`.
+
+There are three ways to declare a `MutableState` object in a composable:
+
+```kotlin
+val mutableState = remember { mutableStateOf(default) }
+var value by remember { mutableStateOf(default) }
+val (value, setValue) = remember { mutableStateOf(default) }
+```
+
+These declarations are equivalent, and are provided as syntax sugar for different uses of state. You should pick the one that produces the easiest-to-read code in the composable you're writing.
+
+The `by` delegate syntax requires the following imports:
+
+```kotlin
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.setValue
+```
+
+You can use the remembered value as a parameter for other composables or even as logic in statements to change which composables are displayed. For example, if you don't want to display the greeting if the name is empty, use the state in an `if` statement:
+
+```kotlin
+@Composable
+fun HelloContent() {
+    Column(modifier = Modifier.padding(16.dp)) {
+        var name by remember { mutableStateOf("") }
+        if (name.isNotEmpty()) {
+            Text(
+                text = "Hello, $name!",
+                modifier = Modifier.padding(bottom = 8.dp),
+                style = MaterialTheme.typography.bodyMedium
+            )
+        }
+        OutlinedTextField(
+            value = name,
+            onValueChange = { name = it },
+            label = { Text("Name") }
+        )
+    }
+}
+```
+
+While `remember` helps you retain state across recompositions, the state is not retained across configuration changes. For this, you must use `rememberSaveable`. `rememberSaveable` automatically saves any value that can be saved in a `Bundle`. For other values, you can pass in a custom saver object.
+
+> Caution: Using mutable objects such as `ArrayList<T>` or `mutableListOf()` as state in Compose causes your users to see incorrect or stale data in your app. Mutable objects that are not observable, such as `ArrayList` or a mutable data class, are not observable by Compose and don't trigger a recomposition when they change. Instead of using non-observable mutable objects, the recommendation is to use an observable data holder such as `State<List<T>>` and the immutable `listOf()`.
+
+## Other supported types of state
+
+Compose doesn't require that you use `MutableState<T>` to hold state; it supports other observable types. Before reading another observable type in Compose, you must convert it to a `State<T>` so that composables can automatically recompose when the state changes.
+
+Compose ships with functions to create `State<T>` from common observable types used in Android apps. Before using these integrations, add the appropriate artifact(s) as outlined below:
+
+### Flow: `collectAsStateWithLifecycle()`
+
+`collectAsStateWithLifecycle()` collects values from a `Flow` in a lifecycle-aware manner, allowing your app to conserve app resources. It represents the latest emitted value from the Compose `State`. Use this API as the recommended way to collect flows on Android apps.
+
+> Note: To learn more about collecting flows safely in Android with `collectAsStateWithLifecycle()` API, you can read [this blog post](https://android-developers.googleblog.com/2023/03/collect-flows-safely-in-android.html).
+
+Add the following dependency to the `build.gradle` file (2.6.0-beta01 or newer):
+
+```kotlin
+dependencies {
+      ...
+      implementation("androidx.lifecycle:lifecycle-runtime-compose:2.8.7")
+}
+```
+
+### Flow: `collectAsState()`
+
+`collectAsState` is similar to `collectAsStateWithLifecycle`, because it also collects values from a `Flow` and transforms it into Compose `State`.
+
+Use `collectAsState` for platform-agnostic code instead of `collectAsStateWithLifecycle`, which is Android-only.
+
+Additional dependencies are not required for `collectAsState`, because it is available in `compose-runtime`.
+
+### LiveData: `observeAsState()`
+
+`observeAsState()` starts observing this `LiveData` and represents its values via `State`.
+
+Add the following dependency to the `build.gradle` file:
+
+```kotlin
+dependencies {
+      ...
+      implementation("androidx.compose.runtime:runtime-livedata:1.9.0")
+}
+```
+
+### RxJava2: `subscribeAsState()`
+
+`subscribeAsState()` are extension functions that transform RxJava2’s reactive streams (e.g. `Single`, `Observable`, `Completable`) into Compose `State`.
+
+Add the following dependency to the `build.gradle` file:
+
+```kotlin
+dependencies {
+      ...
+      implementation("androidx.compose.runtime:runtime-rxjava2:1.9.0")
+}
+```
+
+### RxJava3: `subscribeAsState()`
+
+`subscribeAsState()` are extension functions that transform RxJava3’s reactive streams (e.g. `Single`, `Observable`, `Completable`) into Compose `State`.
+
+Add the following dependency to the `build.gradle` file:
+
+```kotlin
+dependencies {
+      ...
+      implementation("androidx.compose.runtime:runtime-rxjava3:1.9.0")
+}
+```
+
+**Key Point:** Compose automatically recomposes from reading `State` objects. If you use another observable type such as `LiveData` in Compose, you should convert it to `State` before reading it. Make sure that type conversion happens in a composable, using a composable extension function like `LiveData<T>.observeAsState()`.
+
+> Note: You are not limited to these integrations. You can build an extension function for Jetpack Compose that reads other observable types. If your app uses a custom observable class, convert it to produce `State<T>` using the `produceState` API.
+>
+> See the implementation of the builtins for examples of how to do this: `collectAsStateWithLifecycle`. Any object that allows Jetpack Compose to subscribe to every change can be converted to `State<T>` and read in a composable.
+
+## Stateful versus stateless
+
+A composable that uses `remember` to store an object creates internal state, making the composable stateful. `HelloContent` is an example of a stateful composable because it holds and modifies its `name` state internally. This can be useful in situations where a caller doesn't need to control the state and can use it without having to manage the state themselves. However, composables with internal state tend to be less reusable and harder to test.
+
+A stateless composable is a composable that doesn't hold any state. An easy way to achieve stateless is by using state hoisting.
+
+As you develop reusable composables, you often want to expose both a stateful and a stateless version of the same composable. The stateful version is convenient for callers that don't care about the state, and the stateless version is necessary for callers that need to control or hoist the state.
+
+## State hoisting
+
+State hoisting in Compose is a pattern of moving state to a composable's caller to make a composable stateless. The general pattern for state hoisting in Jetpack Compose is to replace the state variable with two parameters:
+
+- `value: T`: the current value to display
+- `onValueChange: (T) -> Unit`: an event that requests the value to change, where `T` is the proposed new value
+
+However, you are not limited to `onValueChange`. If more specific events are appropriate for the composable, you should define them using lambdas.
+
+State that is hoisted this way has some important properties:
+
+- **Single source of truth:** By moving state instead of duplicating it, we're ensuring there's only one source of truth. This helps avoid bugs.
+- **Encapsulated:** Only stateful composables can modify their state. It's completely internal.
+- **Shareable:** Hoisted state can be shared with multiple composables. If you wanted to read `name` in a different composable, hoisting would allow you to do that.
+- **Interceptable:** callers to the stateless composables can decide to ignore or modify events before changing the state.
+- **Decoupled:** the state for the stateless composables may be stored anywhere. For example, it's now possible to move `name` into a `ViewModel`.
+
+In the example case, you extract the `name` and the `onValueChange` out of `HelloContent` and move them up the tree to a `HelloScreen` composable that calls `HelloContent`.
+
+```kotlin
+@Composable
+fun HelloScreen() {
+    var name by rememberSaveable { mutableStateOf("") }
+
+    HelloContent(name = name, onNameChange = { name = it })
+}
+
+@Composable
+fun HelloContent(name: String, onNameChange: (String) -> Unit) {
+    Column(modifier = Modifier.padding(16.dp)) {
+        Text(
+            text = "Hello, $name",
+            modifier = Modifier.padding(bottom = 8.dp),
+            style = MaterialTheme.typography.bodyMedium
+        )
+        OutlinedTextField(value = name, onValueChange = onNameChange, label = { Text("Name") })
+    }
+}
+```
+
+By hoisting the state out of `HelloContent`, it's easier to reason about the composable, reuse it in different situations, and test. `HelloContent` is decoupled from how its state is stored. Decoupling means that if you modify or replace `HelloScreen`, you don't have to change how `HelloContent` is implemented.
+
+The pattern where the state goes down, and events go up is called a **unidirectional data flow**. In this case, the state goes down from `HelloScreen` to `HelloContent` and events go up from `HelloContent` to `HelloScreen`. By following unidirectional data flow, you can decouple composables that display state in the UI from the parts of your app that store and change state.
+
+**Key Point:** When hoisting state, there are three rules to help you figure out where state should go:
+
+1. State should be hoisted to at least the lowest common parent of all composables that use the state (read).
+2. State should be hoisted to at least the highest level it may be changed (write).
+3. If two states change in response to the same events they should be hoisted together.
+
+You can hoist state higher than these rules require, but underhoisting state makes it difficult or impossible to follow unidirectional data flow.
+
+See the [Where to hoist state](https://developer.android.com/jetpack/compose/state#where-to-hoist) page to learn more.
+
+## Restoring state in Compose
+
+The `rememberSaveable` API behaves similarly to `remember` because it retains state across recompositions, and also across activity or process recreation using the saved instance state mechanism. For example, this happens when the screen is rotated.
+
+> Note: `rememberSaveable` will not retain state if the activity is completely dismissed by the user. For example, it does not retain state if the user swipes the current activity up from the recents screen.
+
+### Ways to store state
+
+All data types that are added to the `Bundle` are saved automatically. If you want to save something that cannot be added to the `Bundle`, there are several options.
+
+#### `Parcelize`
+
+The simplest solution is to add the `@Parcelize` annotation to the object. The object becomes parcelable, and can be bundled. For example, this code makes a parcelable `City` data type and saves it to the state.
+
+```kotlin
+@Parcelize
+data class City(val name: String, val country: String) : Parcelable
+
+@Composable
+fun CityScreen() {
+    var selectedCity = rememberSaveable {
+        mutableStateOf(City("Madrid", "Spain"))
+    }
+}
+```
+
+#### `MapSaver`
+
+If for some reason `@Parcelize` is not suitable, you can use `mapSaver` to define your own rule for converting an object into a set of values that the system can save to the `Bundle`.
+
+```kotlin
+data class City(val name: String, val country: String)
+
+val CitySaver = run {
+    val nameKey = "Name"
+    val countryKey = "Country"
+    mapSaver(
+        save = { mapOf(nameKey to it.name, countryKey to it.country) },
+        restore = { City(it[nameKey] as String, it[countryKey] as String) }
+    )
+}
+
+@Composable
+fun CityScreen() {
+    var selectedCity = rememberSaveable(stateSaver = CitySaver) {
+        mutableStateOf(City("Madrid", "Spain"))
+    }
+}
+```
+
+#### `ListSaver`
+
+To avoid needing to define the keys for the map, you can also use `listSaver` and use its indices as keys:
+
+```kotlin
+data class City(val name: String, val country: String)
+
+val CitySaver = listSaver<City, Any>(
+    save = { listOf(it.name, it.country) },
+    restore = { City(it[0] as String, it[1] as String) }
+)
+
+@Composable
+fun CityScreen() {
+    var selectedCity = rememberSaveable(stateSaver = CitySaver) {
+        mutableStateOf(City("Madrid", "Spain"))
+    }
+}
+```
+
+## State holders in Compose
+
+Simple state hoisting can be managed in the composable functions itself. However, if the amount of state to keep track of increases, or the logic to perform in composable functions arises, it's a good practice to delegate the logic and state responsibilities to other classes: state holders.
+
+**Key Term:** State holders manage logic and state of composables.
+
+Note that in other materials, state holders are also called hoisted state objects.
+
+See the [state hoisting in Compose](https://developer.android.com/jetpack/compose/state#state-hoisting) documentation or, more generally, the [State holders and UI State](https://developer.android.com/topic/architecture/ui-layer/stateholders) page in the architecture guide to learn more.
+
+## Retrigger `remember` calculations when keys change
+
+The `remember` API is frequently used together with `MutableState`:
+
+```kotlin
+var name by remember { mutableStateOf("") }
+```
+
+Here, using the `remember` function makes the `MutableState` value survive recompositions.
+
+In general, `remember` takes a calculation lambda parameter. When `remember` is first run, it invokes the calculation lambda and stores its result. During recomposition, `remember` returns the value that was last stored.
+
+Apart from caching state, you can also use `remember` to store any object or result of an operation in the Composition that is expensive to initialize or calculate. You might not want to repeat this calculation in every recomposition. An example is creating this `ShaderBrush` object, which is an expensive operation:
+
+```kotlin
+val brush = remember {
+    ShaderBrush(
+        BitmapShader(
+            ImageBitmap.imageResource(res, avatarRes).asAndroidBitmap(),
+            Shader.TileMode.REPEAT,
+            Shader.TileMode.REPEAT
+        )
+    )
+}
+```
+
+`remember` stores the value until it leaves the Composition. However, there is a way to invalidate the cached value. The `remember` API also takes a `key` or `keys` parameter. If any of these keys change, the next time the function recomposes, `remember` invalidates the cache and executes the calculation lambda block again. This mechanism gives you control over the lifetime of an object in the Composition. The calculation remains valid until the inputs change, instead of until the remembered value leaves the Composition.
+
+The following examples show how this mechanism works.
+
+In this snippet, a `ShaderBrush` is created and used as the background paint of a `Box` composable. `remember` stores the `ShaderBrush` instance because it is expensive to recreate, as explained earlier. `remember` takes `avatarRes` as the `key1` parameter, which is the selected background image. If `avatarRes` changes, the brush recomposes with the new image, and reapplies to the `Box`. This can occur when the user selects another image to be the background from a picker.
+
+```kotlin
+@Composable
+private fun BackgroundBanner(
+    @DrawableRes avatarRes: Int,
+    modifier: Modifier = Modifier,
+    res: Resources = LocalContext.current.resources
+) {
+    val brush = remember(key1 = avatarRes) {
+        ShaderBrush(
+            BitmapShader(
+                ImageBitmap.imageResource(res, avatarRes).asAndroidBitmap(),
+                Shader.TileMode.REPEAT,
+                Shader.TileMode.REPEAT
+            )
+        )
+    }
+
+    Box(
+        modifier = modifier.background(brush)
+    ) {
+        /* ... */
+    }
+}
+```
+
+In the next snippet, state is hoisted to a plain state holder class `MyAppState`. It exposes a `rememberMyAppState` function to initialize an instance of the class using `remember`. Exposing such functions to create an instance that survives recompositions is a common pattern in Compose. The `rememberMyAppState` function receives `windowSizeClass`, which serves as the `key` parameter for `remember`. If this parameter changes, the app needs to recreate the plain state holder class with the latest value. This may occur if, for example, the user rotates the device.
+
+```kotlin
+@Composable
+private fun rememberMyAppState(
+    windowSizeClass: WindowSizeClass
+): MyAppState {
+    return remember(windowSizeClass) {
+        MyAppState(windowSizeClass)
+    }
+}
+
+@Stable
+class MyAppState(
+    private val windowSizeClass: WindowSizeClass
+) { /* ... */ }
+```
+
+> Note: For more information about plain state holder classes, see the [Plain state holder class as state owner](https://developer.android.com/topic/architecture/ui-layer/stateholders#plain-state-holder) documentation, or the [State holders and UI State](https://developer.android.com/topic/architecture/ui-layer/stateholders) documentation in the Architecture guide.
+
+Compose uses the class's `equals` implementation to decide if a key has changed and invalidate the stored value.
+
+> Note: At first glance, using `remember` with keys might seem similar to using other Compose APIs, like `derivedStateOf`. See the [Jetpack Compose — When should I use derivedStateOf?](https://medium.com/androiddevelopers/jetpack-compose-when-should-i-use-derivedstateof-6c5ab6c90541) blog post to learn about the difference.
+
+## Store state with keys beyond recomposition
+
+The `rememberSaveable` API is a wrapper around `remember` that can store data in a `Bundle`. This API allows state to survive not only recomposition, but also activity recreation and system-initiated process death. `rememberSaveable` receives input parameters for the same purpose that `remember` receives keys. The cache is invalidated when any of the inputs change. The next time the function recomposes, `rememberSaveable` re-executes the calculation lambda block.
+
+> Note: There is a difference in API naming that you should note. In the `remember` API, you use the parameter name `keys`, and in `rememberSaveable` you use `inputs` for the same purpose. If any of these parameters changes, the cached value is invalidated.
+
+In the following example, `rememberSaveable` stores `userTypedQuery` until `typedQuery` changes:
+
+```kotlin
+var userTypedQuery by rememberSaveable(typedQuery, stateSaver = TextFieldValue.Saver) {
+    mutableStateOf(
+        TextFieldValue(text = typedQuery, selection = TextRange(typedQuery.length))
+    )
+}
+```
+
+## Learn more
+
+To learn more about state and Jetpack Compose, consult the following additional resources.
+
+### Samples
+
+- [Jetchat sample](https://github.com/android/compose-samples/tree/main/Jetchat)
+- [Jetnews sample](https://github.com/android/compose-samples/tree/main/JetNews)
+- [Now in Android app](https://github.com/android/nowinandroid)
+
+### Codelabs
+
+- [Using State in Jetpack Compose](https://developer.android.com/codelabs/basic-android-kotlin-compose-state#0)
+
+### Videos
+
+- [A Compose state of mind](https://www.youtube.com/watch?v=8AqLBOTjSgw)
+
+### Blogs
+
+- [Jetpack Compose: Debugging Recomposition](https://medium.com/androiddevelopers/jetpack-compose-debugging-recomposition-81c014c030c6)

--- a/docs/coroutines-best-practices.md
+++ b/docs/coroutines-best-practices.md
@@ -1,0 +1,282 @@
+Best practices for coroutines in Android
+
+bookmark_border
+This page presents several best practices that have a positive impact by making your app more scalable and testable when using coroutines.
+
+Note: These tips can be applied to a broad spectrum of apps. However, you should treat them as guidelines and adapt them to your requirements as needed.
+Inject Dispatchers
+Don't hardcode Dispatchers when creating new coroutines or calling withContext.
+
+
+// DO inject Dispatchers
+class NewsRepository(
+    private val defaultDispatcher: CoroutineDispatcher = Dispatchers.Default
+) {
+    suspend fun loadNews() = withContext(defaultDispatcher) { /* ... */ }
+}
+
+// DO NOT hardcode Dispatchers
+class NewsRepository {
+    // DO NOT use Dispatchers.Default directly, inject it instead
+    suspend fun loadNews() = withContext(Dispatchers.Default) { /* ... */ }
+}
+This dependency injection pattern makes testing easier as you can replace those dispatchers in unit and instrumentation tests with a test dispatcher to make your tests more deterministic.
+
+Note: The viewModelScope property of ViewModel classes is hardcoded to Dispatchers.Main. Replace it in tests by calling Dispatchers.setMain and passing in a test dispatcher.
+Note: While you might have seen hardcoded dispatchers in code snippets across this site and our codelabs, this is only to keep the sample code concise and simple. In your application, you should inject dispatchers.
+Suspend functions should be safe to call from the main thread
+Suspend functions should be main-safe, meaning they're safe to call from the main thread. If a class is doing long-running blocking operations in a coroutine, it's in charge of moving the execution off the main thread using withContext. This applies to all classes in your app, regardless of the part of the architecture the class is in.
+
+
+class NewsRepository(private val ioDispatcher: CoroutineDispatcher) {
+
+    // As this operation is manually retrieving the news from the server
+    // using a blocking HttpURLConnection, it needs to move the execution
+    // to an IO dispatcher to make it main-safe
+    suspend fun fetchLatestNews(): List<Article> {
+        withContext(ioDispatcher) { /* ... implementation ... */ }
+    }
+}
+
+// This use case fetches the latest news and the associated author.
+class GetLatestNewsWithAuthorsUseCase(
+    private val newsRepository: NewsRepository,
+    private val authorsRepository: AuthorsRepository
+) {
+    // This method doesn't need to worry about moving the execution of the
+    // coroutine to a different thread as newsRepository is main-safe.
+    // The work done in the coroutine is lightweight as it only creates
+    // a list and add elements to it
+    suspend operator fun invoke(): List<ArticleWithAuthor> {
+        val news = newsRepository.fetchLatestNews()
+
+        val response: List<ArticleWithAuthor> = mutableEmptyList()
+        for (article in news) {
+            val author = authorsRepository.getAuthor(article.author)
+            response.add(ArticleWithAuthor(article, author))
+        }
+        return Result.Success(response)
+    }
+}
+This pattern makes your app more scalable, as classes calling suspend functions don't have to worry about what Dispatcher to use for what type of work. This responsibility lies in the class that does the work.
+
+The ViewModel should create coroutines
+ViewModel classes should prefer creating coroutines instead of exposing suspend functions to perform business logic. Suspend functions in the ViewModel can be useful if instead of exposing state using a stream of data, only a single value needs to be emitted.
+
+
+// DO create coroutines in the ViewModel
+class LatestNewsViewModel(
+    private val getLatestNewsWithAuthors: GetLatestNewsWithAuthorsUseCase
+) : ViewModel() {
+
+    private val _uiState = MutableStateFlow<LatestNewsUiState>(LatestNewsUiState.Loading)
+    val uiState: StateFlow<LatestNewsUiState> = _uiState
+
+    fun loadNews() {
+        viewModelScope.launch {
+            val latestNewsWithAuthors = getLatestNewsWithAuthors()
+            _uiState.value = LatestNewsUiState.Success(latestNewsWithAuthors)
+        }
+    }
+}
+
+// Prefer observable state rather than suspend functions from the ViewModel
+class LatestNewsViewModel(
+    private val getLatestNewsWithAuthors: GetLatestNewsWithAuthorsUseCase
+) : ViewModel() {
+    // DO NOT do this. News would probably need to be refreshed as well.
+    // Instead of exposing a single value with a suspend function, news should
+    // be exposed using a stream of data as in the code snippet above.
+    suspend fun loadNews() = getLatestNewsWithAuthors()
+}
+Views shouldn't directly trigger any coroutines to perform business logic. Instead, defer that responsibility to the ViewModel. This makes your business logic easier to test as ViewModel objects can be unit tested, instead of using instrumentation tests that are required to test views.
+
+In addition to that, your coroutines will survive configuration changes automatically if the work is started in the viewModelScope. If you create coroutines using lifecycleScope instead, you'd have to handle that manually. If the coroutine needs to outlive the ViewModel's scope, check out the Creating coroutines in the business and data layer section.
+
+Note: Views should trigger coroutines for UI-related logic. For example, fetching an image from the Internet or formatting a String.
+Don't expose mutable types
+Prefer exposing immutable types to other classes. In this way, all changes to the mutable type is centralized in one class making it easier to debug when something goes wrong.
+
+
+// DO expose immutable types
+class LatestNewsViewModel : ViewModel() {
+
+    private val _uiState = MutableStateFlow(LatestNewsUiState.Loading)
+    val uiState: StateFlow<LatestNewsUiState> = _uiState
+
+    /* ... */
+}
+
+class LatestNewsViewModel : ViewModel() {
+
+    // DO NOT expose mutable types
+    val uiState = MutableStateFlow(LatestNewsUiState.Loading)
+
+    /* ... */
+}
+The data and business layer should expose suspend functions and Flows
+Classes in the data and business layers generally expose functions to perform one-shot calls or to be notified of data changes over time. Classes in those layers should expose suspend functions for one-shot calls and Flow to notify about data changes.
+
+
+// Classes in the data and business layer expose
+// either suspend functions or Flows
+class ExampleRepository {
+    suspend fun makeNetworkRequest() { /* ... */ }
+
+    fun getExamples(): Flow<Example> { /* ... */ }
+}
+This best practice makes the caller, generally the presentation layer, able to control the execution and lifecycle of the work happening in those layers, and cancel when needed.
+
+Creating coroutines in the business and data layer
+For classes in the data or business layer that need to create coroutines for different reasons, there are different options.
+
+If the work to be done in those coroutines is relevant only when the user is present on the current screen, it should follow the caller's lifecycle. In most cases, the caller will be the ViewModel, and the call will be cancelled when the user navigates away from the screen and the ViewModel is cleared. In this case, coroutineScope or supervisorScope should be used.
+
+
+class GetAllBooksAndAuthorsUseCase(
+    private val booksRepository: BooksRepository,
+    private val authorsRepository: AuthorsRepository,
+) {
+    suspend fun getBookAndAuthors(): BookAndAuthors {
+        // In parallel, fetch books and authors and return when both requests
+        // complete and the data is ready
+        return coroutineScope {
+            val books = async { booksRepository.getAllBooks() }
+            val authors = async { authorsRepository.getAllAuthors() }
+            BookAndAuthors(books.await(), authors.await())
+        }
+    }
+}
+If the work to be done is relevant as long as the app is opened, and the work is not bound to a particular screen, then the work should outlive the caller's lifecycle. For this scenario, an external CoroutineScope should be used as explained in the Coroutines & Patterns for work that shouldn’t be cancelled blog post.
+
+
+class ArticlesRepository(
+    private val articlesDataSource: ArticlesDataSource,
+    private val externalScope: CoroutineScope,
+) {
+    // As we want to complete bookmarking the article even if the user moves
+    // away from the screen, the work is done creating a new coroutine
+    // from an external scope
+    suspend fun bookmarkArticle(article: Article) {
+        externalScope.launch { articlesDataSource.bookmarkArticle(article) }
+            .join() // Wait for the coroutine to complete
+    }
+}
+externalScope should be created and managed by a class that lives longer than the current screen, it could be managed by the Application class or a ViewModel scoped to a navigation graph.
+
+Inject TestDispatchers in tests
+An instance of TestDispatcher should be injected into your classes in tests. There are two available implementations in the kotlinx-coroutines-test library:
+
+StandardTestDispatcher: Queues up coroutines started on it with a scheduler, and executes them when the test thread is not busy. You can suspend the test thread to let other queued coroutines run using methods such as advanceUntilIdle.
+
+UnconfinedTestDispatcher: Runs new coroutines eagerly, in a blocking way. This generally makes writing tests easier, but gives you less control over how coroutines are executed during the test.
+
+See the documentation of each dispatcher implementation for additional details.
+
+To test coroutines, use the runTest coroutine builder. runTest uses a TestCoroutineScheduler to skip delays in tests and to allow you to control virtual time. You can also use this scheduler to create additional test dispatchers as needed.
+
+
+class ArticlesRepositoryTest {
+
+    @Test
+    fun testBookmarkArticle() = runTest {
+        // Pass the testScheduler provided by runTest's coroutine scope to
+        // the test dispatcher
+        val testDispatcher = UnconfinedTestDispatcher(testScheduler)
+
+        val articlesDataSource = FakeArticlesDataSource()
+        val repository = ArticlesRepository(
+            articlesDataSource,
+            testDispatcher
+        )
+        val article = Article()
+        repository.bookmarkArticle(article)
+        assertThat(articlesDataSource.isBookmarked(article)).isTrue()
+    }
+}
+All TestDispatchers should share the same scheduler. This allows you to run all your coroutine code on the single test thread to make your tests deterministic. runTest will wait for all coroutines that are on the same scheduler or are children of the test coroutine to complete before returning.
+
+Note: The above works best if no other Dispatchers are used in the code under test. This is why it's not recommended to hardcode Dispatchers in your classes.
+Note: The coroutine testing APIs changed significantly in kotlinx.coroutines 1.6.0. See the migration guide if you need to migrate from the previous testing APIs.
+Avoid GlobalScope
+This is similar to the Inject Dispatchers best practice. By using GlobalScope, you're hardcoding the CoroutineScope that a class uses bringing some downsides with it:
+
+Promotes hard-coding values. If you hardcode GlobalScope, you might be hard-coding Dispatchers as well.
+
+Makes testing very hard as your code is executed in an uncontrolled scope, you won't be able to control its execution.
+
+You can't have a common CoroutineContext to execute for all coroutines built into the scope itself.
+
+Instead, consider injecting a CoroutineScope for work that needs to outlive the current scope. Check out the Creating coroutines in the business and data layer section to learn more about this topic.
+
+
+// DO inject an external scope instead of using GlobalScope.
+// GlobalScope can be used indirectly. Here as a default parameter makes sense.
+class ArticlesRepository(
+    private val articlesDataSource: ArticlesDataSource,
+    private val externalScope: CoroutineScope = GlobalScope,
+    private val defaultDispatcher: CoroutineDispatcher = Dispatchers.Default
+) {
+    // As we want to complete bookmarking the article even if the user moves
+    // away from the screen, the work is done creating a new coroutine
+    // from an external scope
+    suspend fun bookmarkArticle(article: Article) {
+        externalScope.launch(defaultDispatcher) {
+            articlesDataSource.bookmarkArticle(article)
+        }
+            .join() // Wait for the coroutine to complete
+    }
+}
+
+// DO NOT use GlobalScope directly
+class ArticlesRepository(
+    private val articlesDataSource: ArticlesDataSource,
+) {
+    // As we want to complete bookmarking the article even if the user moves away
+    // from the screen, the work is done creating a new coroutine with GlobalScope
+    suspend fun bookmarkArticle(article: Article) {
+        GlobalScope.launch {
+            articlesDataSource.bookmarkArticle(article)
+        }
+            .join() // Wait for the coroutine to complete
+    }
+}
+Learn more about GlobalScope and its alternatives in the Coroutines & Patterns for work that shouldn’t be cancelled blog post.
+
+Make your coroutine cancellable
+Cancellation in coroutines is cooperative, which means that when a coroutine's Job is cancelled, the coroutine isn't cancelled until it suspends or checks for cancellation. If you do blocking operations in a coroutine, make sure that the coroutine is cancellable.
+
+For example, if you're reading multiple files from disk, before you start reading each file, check whether the coroutine was cancelled. One way to check for cancellation is by calling the ensureActive function.
+
+
+someScope.launch {
+    for(file in files) {
+        ensureActive() // Check for cancellation
+        readFile(file)
+    }
+}
+All suspend functions from kotlinx.coroutines such as withContext and delay are cancellable. If your coroutine calls them, you shouldn't need to do any additional work.
+
+For more information about cancellation in coroutines, check out the Cancellation in coroutines blog post.
+
+Watch out for exceptions
+Unhandled exceptions thrown in coroutines can make your app crash. If exceptions are likely to happen, catch them in the body of any coroutines created with viewModelScope or lifecycleScope.
+
+
+class LoginViewModel(
+    private val loginRepository: LoginRepository
+) : ViewModel() {
+
+    fun login(username: String, token: String) {
+        viewModelScope.launch {
+            try {
+                loginRepository.login(username, token)
+                // Notify view user logged in successfully
+            } catch (exception: IOException) {
+                // Notify view login attempt failed
+            }
+        }
+    }
+}
+Caution: To enable coroutine cancellation, don't consume exceptions of type CancellationException (don't catch them, or always rethrow them if caught). Prefer catching specific exception types like IOException over generic types like Exception or Throwable.
+For more information, check out the blog post Exceptions in coroutines, or Coroutine exceptions handling in the Kotlin documentation.

--- a/docs/gemini-agents.md
+++ b/docs/gemini-agents.md
@@ -1,0 +1,62 @@
+Customize Gemini using AGENTS.md files
+
+bookmark_border
+Note: Agent files titled AGENTS.md are compatible with Android Studio Narwhal 4 Feature Drop Canary 4 and higher. To use agent files with Android Studio Narwhal 3 Feature Drop, use the name AGENT.md instead of AGENTS.md.
+Give Gemini in Android Studio customized instructions to follow using one or more AGENTS.md files. AGENTS.md files are placed alongside the other files in your codebase, so it's straightforward to check them in to your version control system (VCS) and share project-specific instructions, coding style rules, and other guidance with your entire team.
+
+To get started, follow these steps:
+
+Create an AGENTS.md file anywhere in your project's file system. Gemini scans the current directory and all parent directories for AGENTS.md files when you submit a query. For more details, see How AGENTS.md files work.
+
+Tip: Use multiple instruction files across different directories for more granular control over different parts of your codebase. For example, you can have a global AGENTS.md file at the project root and more specific AGENTS.md files in subdirectories for different modules.
+Add your instructions. Write your instructions using Markdown. For readability, consider using headings and bullet points for different rules. See example instructions.
+
+Save and commit the file to your VCS to share it with your team.
+
+Manage AGENTS.md files as context
+You can apply or remove AGENTS.md files as context for a particular query using the Context drawer in the chat panel. The AGENTS.md Files options includes all AGENTS.md files in the current directory and its parent directories.
+
+Example instructions
+You can use the AGENTS.md file to give instructions to the agent. The following are some examples, but the instructions that you provide should be specific to your project.
+
+"The main activity is /path/to/MainActivity.kt."
+"The code to support navigating between screens is path/to/navigation/UiNavigation.kt"
+"The code handling HTTP requests is at <path>."
+Project architecture
+"Place all business logic in ViewModels."
+"Always follow official architecture recommendations, including use of a layered architecture. Use a unidirectional data flow (UDF), ViewModels, lifecycle-aware UI state collection, and other recommendations."
+Preferred libraries: "Use the <library name> library for navigation."
+Defining placeholder names for common API services or internal terminology: "The primary backend service is referred to as 'PhotoSift-API'."
+Company style guides: "All new UI components must be built with Jetpack Compose. Don't suggest XML-based layouts."
+Modularize your AGENTS.md files
+You can break down large AGENTS.md files into smaller files that can be reused in different contexts:
+
+Separate out a set of instructions and save them in another Markdown file, such as style-guidance.md.
+
+Reference the smaller Markdown files in an AGENTS.md file by using the @ symbol followed by the path to the file you want to import. The following path formats are supported:
+
+Relative paths:
+@./file.md - Import from the same directory
+@../file.md - Import from the parent directory
+@./subdirectory/file.md - Import from a subdirectory
+Absolute paths: @/absolute/path/to/file.md
+For example, the following AGENTS.md file references two other instruction files:
+
+
+# My AGENTS.md
+
+You are an experienced Android app developer.
+
+@./get-started.md
+
+## Coding style
+
+@./shared/style-guidance.md
+How AGENTS.md files work
+Gemini automatically scans the current directory and parent directories for AGENTS.md files and adds their content to the beginning of every prompt as a preamble. If you don't have a file open when you submit a query, then the AGENTS.md file at the project root (if there is one) is included by default.
+
+Note: If you have a GEMINI.md file and AGENTS.md file in the same directory, the GEMINI.md file takes precedence.
+What's the difference between AGENTS.md files and Rules?
+Rules also let you define instructions and preferences that apply to all prompts. However, rules are defined in the IntelliJ file /.idea/project.prompts.xml, whereas AGENTS.md files are saved next to your source code and are IDE-neutral. We recommend using AGENTS.md files if one of the primary purposes is to share the instructions with your team.
+
+Note: Gemini combines rules and instructions in AGENTS.md files when processing your query.

--- a/docs/kotlin-coroutines-android.md
+++ b/docs/kotlin-coroutines-android.md
@@ -1,0 +1,194 @@
+Kotlin coroutines on Android
+
+bookmark_border
+A coroutine is a concurrency design pattern that you can use on Android to simplify code that executes asynchronously. Coroutines were added to Kotlin in version 1.3 and are based on established concepts from other languages.
+
+On Android, coroutines help to manage long-running tasks that might otherwise block the main thread and cause your app to become unresponsive. Over 50% of professional developers who use coroutines have reported seeing increased productivity. This topic describes how you can use Kotlin coroutines to address these problems, enabling you to write cleaner and more concise app code.
+
+Features
+Coroutines is our recommended solution for asynchronous programming on Android. Noteworthy features include the following:
+
+Lightweight: You can run many coroutines on a single thread due to support for suspension, which doesn't block the thread where the coroutine is running. Suspending saves memory over blocking while supporting many concurrent operations.
+Fewer memory leaks: Use structured concurrency to run operations within a scope.
+Built-in cancellation support: Cancellation is propagated automatically through the running coroutine hierarchy.
+Jetpack integration: Many Jetpack libraries include extensions that provide full coroutines support. Some libraries also provide their own coroutine scope that you can use for structured concurrency.
+Examples overview
+Based on the Guide to app architecture, the examples in this topic make a network request and return the result to the main thread, where the app can then display the result to the user.
+
+Specifically, the ViewModel Architecture component calls the repository layer on the main thread to trigger the network request. This guide iterates through various solutions that use coroutines to keep the main thread unblocked.
+
+ViewModel includes a set of KTX extensions that work directly with coroutines. These extension are lifecycle-viewmodel-ktx library and are used in this guide.
+
+Dependency info
+To use coroutines in your Android project, add the following dependency to your app's build.gradle file:
+
+Groovy
+Kotlin
+
+dependencies {
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.3.9'
+}
+Executing in a background thread
+Making a network request on the main thread causes it to wait, or block, until it receives a response. Since the thread is blocked, the OS isn't able to call onDraw(), which causes your app to freeze and potentially leads to an Application Not Responding (ANR) dialog. For a better user experience, let's run this operation on a background thread.
+
+First, let's take a look at our Repository class and see how it's making the network request:
+
+
+sealed class Result<out R> {
+    data class Success<out T>(val data: T) : Result<T>()
+    data class Error(val exception: Exception) : Result<Nothing>()
+}
+
+class LoginRepository(private val responseParser: LoginResponseParser) {
+    private const val loginUrl = "https://example.com/login"
+
+    // Function that makes the network request, blocking the current thread
+    fun makeLoginRequest(
+        jsonBody: String
+    ): Result<LoginResponse> {
+        val url = URL(loginUrl)
+        (url.openConnection() as? HttpURLConnection)?.run {
+            requestMethod = "POST"
+            setRequestProperty("Content-Type", "application/json; utf-8")
+            setRequestProperty("Accept", "application/json")
+            doOutput = true
+            outputStream.write(jsonBody.toByteArray())
+            return Result.Success(responseParser.parse(inputStream))
+        }
+        return Result.Error(Exception("Cannot open HttpURLConnection"))
+    }
+}
+makeLoginRequest is synchronous and blocks the calling thread. To model the response of the network request, we have our own Result class.
+
+The ViewModel triggers the network request when the user clicks, for example, on a button:
+
+
+class LoginViewModel(
+    private val loginRepository: LoginRepository
+): ViewModel() {
+
+    fun login(username: String, token: String) {
+        val jsonBody = "{ username: \"$username\", token: \"$token\"}"
+        loginRepository.makeLoginRequest(jsonBody)
+    }
+}
+With the previous code, LoginViewModel is blocking the UI thread when making the network request. The simplest solution to move the execution off the main thread is to create a new coroutine and execute the network request on an I/O thread:
+
+
+class LoginViewModel(
+    private val loginRepository: LoginRepository
+): ViewModel() {
+
+    fun login(username: String, token: String) {
+        // Create a new coroutine to move the execution off the UI thread
+        viewModelScope.launch(Dispatchers.IO) {
+            val jsonBody = "{ username: \"$username\", token: \"$token\"}"
+            loginRepository.makeLoginRequest(jsonBody)
+        }
+    }
+}
+Let's dissect the coroutines code in the login function:
+
+viewModelScope is a predefined CoroutineScope that is included with the ViewModel KTX extensions. Note that all coroutines must run in a scope. A CoroutineScope manages one or more related coroutines.
+launch is a function that creates a coroutine and dispatches the execution of its function body to the corresponding dispatcher.
+Dispatchers.IO indicates that this coroutine should be executed on a thread reserved for I/O operations.
+The login function is executed as follows:
+
+The app calls the login function from the View layer on the main thread.
+launch creates a new coroutine, and the network request is made independently on a thread reserved for I/O operations.
+While the coroutine is running, the login function continues execution and returns, possibly before the network request is finished. Note that for simplicity, the network response is ignored for now.
+Since this coroutine is started with viewModelScope, it is executed in the scope of the ViewModel. If the ViewModel is destroyed because the user is navigating away from the screen, viewModelScope is automatically cancelled, and all running coroutines are canceled as well.
+
+One issue with the previous example is that anything calling makeLoginRequest needs to remember to explicitly move the execution off the main thread. Let's see how we can modify the Repository to solve this problem for us.
+
+Use coroutines for main-safety
+We consider a function main-safe when it doesn't block UI updates on the main thread. The makeLoginRequest function is not main-safe, as calling makeLoginRequest from the main thread does block the UI. Use the withContext() function from the coroutines library to move the execution of a coroutine to a different thread:
+
+
+class LoginRepository(...) {
+    ...
+    suspend fun makeLoginRequest(
+        jsonBody: String
+    ): Result<LoginResponse> {
+
+        // Move the execution of the coroutine to the I/O dispatcher
+        return withContext(Dispatchers.IO) {
+            // Blocking network request code
+        }
+    }
+}
+withContext(Dispatchers.IO) moves the execution of the coroutine to an I/O thread, making our calling function main-safe and enabling the UI to update as needed.
+
+makeLoginRequest is also marked with the suspend keyword. This keyword is Kotlin's way to enforce a function to be called from within a coroutine.
+
+Note: For easier testing, we recommend injecting Dispatchers into a Repository layer. To learn more, see Testing coroutines on Android.
+In the following example, the coroutine is created in the LoginViewModel. As makeLoginRequest moves the execution off the main thread, the coroutine in the login function can be now executed in the main thread:
+
+
+class LoginViewModel(
+    private val loginRepository: LoginRepository
+): ViewModel() {
+
+    fun login(username: String, token: String) {
+
+        // Create a new coroutine on the UI thread
+        viewModelScope.launch {
+            val jsonBody = "{ username: \"$username\", token: \"$token\"}"
+
+            // Make the network call and suspend execution until it finishes
+            val result = loginRepository.makeLoginRequest(jsonBody)
+
+            // Display result of the network request to the user
+            when (result) {
+                is Result.Success<LoginResponse> -> // Happy path
+                else -> // Show error in UI
+            }
+        }
+    }
+}
+Note that the coroutine is still needed here, since makeLoginRequest is a suspend function, and all suspend functions must be executed in a coroutine.
+
+This code differs from the previous login example in a couple of ways:
+
+launch doesn't take a Dispatchers.IO parameter. When you don't pass a Dispatcher to launch, any coroutines launched from viewModelScope run in the main thread.
+The result of the network request is now handled to display the success or failure UI.
+The login function now executes as follows:
+
+The app calls the login() function from the View layer on the main thread.
+launch creates a new coroutine on the main thread, and the coroutine begins execution.
+Within the coroutine, the call to loginRepository.makeLoginRequest() now suspends further execution of the coroutine until the withContext block in makeLoginRequest() finishes running.
+Once the withContext block finishes, the coroutine in login() resumes execution on the main thread with the result of the network request.
+Note: To communicate with the View from the ViewModel layer, use LiveData as recommended in the Guide to app architecture. When following this pattern, the code in the ViewModel is executed on the main thread, so you can call MutableLiveData's setValue() function directly.
+Handling exceptions
+To handle exceptions that the Repository layer can throw, use Kotlin's built-in support for exceptions. In the following example, we use a try-catch block:
+
+
+class LoginViewModel(
+    private val loginRepository: LoginRepository
+): ViewModel() {
+
+    fun login(username: String, token: String) {
+        viewModelScope.launch {
+            val jsonBody = "{ username: \"$username\", token: \"$token\"}"
+            val result = try {
+                loginRepository.makeLoginRequest(jsonBody)
+            } catch(e: Exception) {
+                Result.Error(Exception("Network request failed"))
+            }
+            when (result) {
+                is Result.Success<LoginResponse> -> // Happy path
+                else -> // Show error in UI
+            }
+        }
+    }
+}
+In this example, any unexpected exception thrown by the makeLoginRequest() call is handled as an error in the UI.
+
+Additional coroutines resources
+For a more detailed look at coroutines on Android, see Improve app performance with Kotlin coroutines.
+
+For more coroutines resources, see the following links:
+
+Coroutines overview (JetBrains)
+Coroutines guide (JetBrains)
+Additional resources for Kotlin coroutines and flow

--- a/docs/kotlin-flows-android.md
+++ b/docs/kotlin-flows-android.md
@@ -1,0 +1,236 @@
+Kotlin flows on Android
+
+bookmark_border
+
+In coroutines, a flow is a type that can emit multiple values sequentially, as opposed to suspend functions that return only a single value. For example, you can use a flow to receive live updates from a database.
+
+Flows are built on top of coroutines and can provide multiple values. A flow is conceptually a stream of data that can be computed asynchronously. The emitted values must be of the same type. For example, a Flow<Int> is a flow that emits integer values.
+
+A flow is very similar to an Iterator that produces a sequence of values, but it uses suspend functions to produce and consume values asynchronously. This means, for example, that the flow can safely make a network request to produce the next value without blocking the main thread.
+
+There are three entities involved in streams of data:
+
+A producer produces data that is added to the stream. Thanks to coroutines, flows can also produce data asynchronously.
+(Optional) Intermediaries can modify each value emitted into the stream or the stream itself.
+A consumer consumes the values from the stream.
+entities involved in streams of data; consumer, optional
+              intermediaries, and producer
+Figure 1. Entities involved in streams of data: consumer, optional intermediaries, and producer.
+In Android, a repository is typically a producer of UI data that has the user interface (UI) as the consumer that ultimately displays the data. Other times, the UI layer is a producer of user input events and other layers of the hierarchy consume them. Layers in between the producer and consumer usually act as intermediaries that modify the stream of data to adjust it to the requirements of the following layer.
+
+Creating a flow
+To create flows, use the flow builder APIs. The flow builder function creates a new flow where you can manually emit new values into the stream of data using the emit function.
+
+In the following example, a data source fetches the latest news automatically at a fixed interval. As a suspend function cannot return multiple consecutive values, the data source creates and returns a flow to fulfill this requirement. In this case, the data source acts as the producer.
+
+
+class NewsRemoteDataSource(
+    private val newsApi: NewsApi,
+    private val refreshIntervalMs: Long = 5000
+) {
+    val latestNews: Flow<List<ArticleHeadline>> = flow {
+        while(true) {
+            val latestNews = newsApi.fetchLatestNews()
+            emit(latestNews) // Emits the result of the request to the flow
+            delay(refreshIntervalMs) // Suspends the coroutine for some time
+        }
+    }
+}
+
+// Interface that provides a way to make network requests with suspend functions
+interface NewsApi {
+    suspend fun fetchLatestNews(): List<ArticleHeadline>
+}
+The flow builder is executed within a coroutine. Thus, it benefits from the same asynchronous APIs, but some restrictions apply:
+
+Flows are sequential. As the producer is in a coroutine, when calling a suspend function, the producer suspends until the suspend function returns. In the example, the producer suspends until the fetchLatestNews network request completes. Only then is the result emitted to the stream.
+With the flow builder, the producer cannot emit values from a different CoroutineContext. Therefore, don't call emit in a different CoroutineContext by creating new coroutines or by using withContext blocks of code. You can use other flow builders such as callbackFlow in these cases.
+Modifying the stream
+Intermediaries can use intermediate operators to modify the stream of data without consuming the values. These operators are functions that, when applied to a stream of data, set up a chain of operations that aren't executed until the values are consumed in the future. Learn more about intermediate operators in the Flow reference documentation.
+
+In the example below, the repository layer uses the intermediate operator map to transform the data to be displayed on the View:
+
+
+class NewsRepository(
+    private val newsRemoteDataSource: NewsRemoteDataSource,
+    private val userData: UserData
+) {
+    /**
+     * Returns the favorite latest news applying transformations on the flow.
+     * These operations are lazy and don't trigger the flow. They just transform
+     * the current value emitted by the flow at that point in time.
+     */
+    val favoriteLatestNews: Flow<List<ArticleHeadline>> =
+        newsRemoteDataSource.latestNews
+            // Intermediate operation to filter the list of favorite topics
+            .map { news -> news.filter { userData.isFavoriteTopic(it) } }
+            // Intermediate operation to save the latest news in the cache
+            .onEach { news -> saveInCache(news) }
+}
+Intermediate operators can be applied one after the other, forming a chain of operations that are executed lazily when an item is emitted into the flow. Note that simply applying an intermediate operator to a stream does not start the flow collection.
+
+Collecting from a flow
+Use a terminal operator to trigger the flow to start listening for values. To get all the values in the stream as they're emitted, use collect. You can learn more about terminal operators in the official flow documentation.
+
+As collect is a suspend function, it needs to be executed within a coroutine. It takes a lambda as a parameter that is called on every new value. Since it's a suspend function, the coroutine that calls collect may suspend until the flow is closed.
+
+Continuing the previous example, here's a simple implementation of a ViewModel consuming the data from the repository layer:
+
+
+class LatestNewsViewModel(
+    private val newsRepository: NewsRepository
+) : ViewModel() {
+
+    init {
+        viewModelScope.launch {
+            // Trigger the flow and consume its elements using collect
+            newsRepository.favoriteLatestNews.collect { favoriteNews ->
+                // Update View with the latest favorite news
+            }
+        }
+    }
+}
+Collecting the flow triggers the producer that refreshes the latest news and emits the result of the network request on a fixed interval. As the producer remains always active with the while(true) loop, the stream of data will be closed when the ViewModel is cleared and viewModelScope is cancelled.
+
+Flow collection can stop for the following reasons:
+
+The coroutine that collects is cancelled, as shown in the previous example. This also stops the underlying producer.
+The producer finishes emitting items. In this case, the stream of data is closed and the coroutine that called collect resumes execution.
+Flows are cold and lazy unless specified with other intermediate operators. This means that the producer code is executed each time a terminal operator is called on the flow. In the previous example, having multiple flow collectors causes the data source to fetch the latest news multiple times on different fixed intervals. To optimize and share a flow when multiple consumers collect at the same time, use the shareIn operator.
+
+Catching unexpected exceptions
+The implementation of the producer can come from a third party library. This means that it can throw unexpected exceptions. To handle these exceptions, use the catch intermediate operator.
+
+
+class LatestNewsViewModel(
+    private val newsRepository: NewsRepository
+) : ViewModel() {
+
+    init {
+        viewModelScope.launch {
+            newsRepository.favoriteLatestNews
+                // Intermediate catch operator. If an exception is thrown,
+                // catch and update the UI
+                .catch { exception -> notifyError(exception) }
+                .collect { favoriteNews ->
+                    // Update View with the latest favorite news
+                }
+        }
+    }
+}
+In the previous example, when an exception occurs, the collect lambda isn't called, as a new item hasn't been received.
+
+catch can also emit items to the flow. The example repository layer could emit the cached values instead:
+
+
+class NewsRepository(...) {
+    val favoriteLatestNews: Flow<List<ArticleHeadline>> =
+        newsRemoteDataSource.latestNews
+            .map { news -> news.filter { userData.isFavoriteTopic(it) } }
+            .onEach { news -> saveInCache(news) }
+            // If an error happens, emit the last cached values
+            .catch { exception -> emit(lastCachedNews()) }
+}
+In this example, when an exception occurs, the collect lambda is called, as a new item has been emitted to the stream because of the exception.
+
+Executing in a different CoroutineContext
+By default, the producer of a flow builder executes in the CoroutineContext of the coroutine that collects from it, and as previously mentioned, it cannot emit values from a different CoroutineContext. This behavior might be undesirable in some cases. For instance, in the examples used throughout this topic, the repository layer shouldn't be performing operations on Dispatchers.Main that is used by viewModelScope.
+
+To change the CoroutineContext of a flow, use the intermediate operator flowOn. flowOn changes the CoroutineContext of the upstream flow, meaning the producer and any intermediate operators applied before (or above) flowOn. The downstream flow (the intermediate operators after flowOn along with the consumer) is not affected and executes on the CoroutineContext used to collect from the flow. If there are multiple flowOn operators, each one changes the upstream from its current location.
+
+
+class NewsRepository(
+    private val newsRemoteDataSource: NewsRemoteDataSource,
+    private val userData: UserData,
+    private val defaultDispatcher: CoroutineDispatcher
+) {
+    val favoriteLatestNews: Flow<List<ArticleHeadline>> =
+        newsRemoteDataSource.latestNews
+            .map { news -> // Executes on the default dispatcher
+                news.filter { userData.isFavoriteTopic(it) }
+            }
+            .onEach { news -> // Executes on the default dispatcher
+                saveInCache(news)
+            }
+            // flowOn affects the upstream flow ↑
+            .flowOn(defaultDispatcher)
+            // the downstream flow ↓ is not affected
+            .catch { exception -> // Executes in the consumer's context
+                emit(lastCachedNews())
+            }
+}
+With this code, the onEach and map operators use the defaultDispatcher, whereas the catch operator and the consumer are executed on Dispatchers.Main used by viewModelScope.
+
+As the data source layer is doing I/O work, you should use a dispatcher that is optimized for I/O operations:
+
+
+class NewsRemoteDataSource(
+    ...,
+    private val ioDispatcher: CoroutineDispatcher
+) {
+    val latestNews: Flow<List<ArticleHeadline>> = flow {
+        // Executes on the IO dispatcher
+        ...
+    }
+        .flowOn(ioDispatcher)
+}
+Flows in Jetpack libraries
+Flow is integrated into many Jetpack libraries, and it's popular among Android third party libraries. Flow is a great fit for live data updates and endless streams of data.
+
+You can use Flow with Room to be notified of changes in a database. When using data access objects (DAO), return a Flow type to get live updates.
+
+
+@Dao
+abstract class ExampleDao {
+    @Query("SELECT * FROM Example")
+    abstract fun getExamples(): Flow<List<Example>>
+}
+Every time there's a change in the Example table, a new list is emitted with the new items in the database.
+
+Convert callback-based APIs to flows
+callbackFlow is a flow builder that lets you convert callback-based APIs into flows. As an example, the Firebase Firestore Android APIs use callbacks.
+
+Note: Starting in version 24.3.0, firestore-ktx includes snapshots() extensions that return a Flow, so you don't need to perform this conversion yourself for this specific API.
+To convert these APIs to flows and listen for Firestore database updates, you can use the following code:
+
+
+class FirestoreUserEventsDataSource(
+    private val firestore: FirebaseFirestore
+) {
+    // Method to get user events from the Firestore database
+    fun getUserEvents(): Flow<UserEvents> = callbackFlow {
+
+        // Reference to use in Firestore
+        var eventsCollection: CollectionReference? = null
+        try {
+            eventsCollection = FirebaseFirestore.getInstance()
+                .collection("collection")
+                .document("app")
+        } catch (e: Throwable) {
+            // If Firebase cannot be initialized, close the stream of data
+            // flow consumers will stop collecting and the coroutine will resume
+            close(e)
+        }
+
+        // Registers callback to firestore, which will be called on new events
+        val subscription = eventsCollection?.addSnapshotListener { snapshot, _ ->
+            if (snapshot == null) { return@addSnapshotListener }
+            // Sends events to the flow! Consumers will get the new events
+            try {
+                trySend(snapshot.getEvents())
+            } catch (e: Throwable) {
+                // Event couldn't be sent to the flow
+            }
+        }
+
+        // The callback inside awaitClose will be executed when the flow is
+        // either closed or cancelled.
+        // In this case, remove the callback from Firestore
+        awaitClose { subscription?.remove() }
+    }
+}
+Unlike the flow builder, callbackFlow allows values to be emitted from a different CoroutineContext with the send function or outside a coroutine with the trySend function.
+
+Internally, callbackFlow uses a channel, which is conceptually very similar to a blocking queue. A channel is configured with a capacity, the maximum number of elements that can be buffered. The channel created in callbackFlow has a default capacity of 64 elements. When you try to add a new element to a full channel, send suspends the producer until there's space for the new element, whereas trySend does not add the element to the channel and returns false immediately.
+
+trySend immediately adds the specified element to the channel, only if this doesn't violate its capacity restrictions, and then returns the successful result.

--- a/docs/testing-kotlin-flows-android.md
+++ b/docs/testing-kotlin-flows-android.md
@@ -1,0 +1,244 @@
+Testing Kotlin flows on Android
+
+bookmark_border
+The way you test units or modules that communicate with flow depends on whether the subject under test uses the flow as input or output.
+
+If the subject under test observes a flow, you can generate flows within fake dependencies that you can control from tests.
+If the unit or module exposes a flow, you can read and verify one or multiple items emitted by a flow in the test.
+Note: The Testing Kotlin coroutines on Android page describes the basics of working with the coroutine testing APIs.
+
+Creating a fake producer
+When the subject under test is a consumer of a flow, one common way to test it is by replacing the producer with a fake implementation. For example, given a class that observes a repository that takes data from two data sources in production:
+
+the subject under test and the data layer
+Figure 1. The subject under test and the data layer.
+To make the test deterministic, you can replace the repository and its dependencies with a fake repository that always emits the same fake data:
+
+dependencies are replaced with a fake implementation
+Figure 2. Dependencies are replaced with a fake implementation.
+To emit a predefined series of values in a flow, use the flow builder:
+
+
+class MyFakeRepository : MyRepository {
+    fun observeCount() = flow {
+        emit(ITEM_1)
+    }
+}
+In the test, this fake repository is injected, replacing the real implementation:
+
+
+@Test
+fun myTest() {
+    // Given a class with fake dependencies:
+    val sut = MyUnitUnderTest(MyFakeRepository())
+    // Trigger and verify
+    ...
+}
+Now that you have control over the outputs of the subject under test, you can verify that it works correctly by checking its outputs.
+
+Note: You can use a similar fake repository for bigger tests such as UI tests. Replacing modules for testing depends on how you inject dependencies. See the Hilt testing guide to learn how to replace modules in tests using Hilt.
+Asserting flow emissions in a test
+If the subject under test is exposing a flow, the test needs to make assertions on the elements of the data stream.
+
+Let's assume that the previous example's repository exposes a flow:
+
+repository with fake dependencies that exposes a flow
+Figure 3. A repository (the subject under test) with fake dependencies that exposes a flow.
+With certain tests, you'll only need to check the first emission or a finite number of items coming from the flow.
+
+You can consume the first emission to the flow by calling first(). This function waits until the first item is received and then sends the cancellation signal to the producer.
+
+
+@Test
+fun myRepositoryTest() = runTest {
+    // Given a repository that combines values from two data sources:
+    val repository = MyRepository(fakeSource1, fakeSource2)
+
+    // When the repository emits a value
+    val firstItem = repository.counter.first() // Returns the first item in the flow
+
+    // Then check it's the expected item
+    assertEquals(ITEM_1, firstItem)
+}
+If the test needs to check multiple values, calling toList() causes the flow to wait for the source to emit all its values and then returns those values as a list. This works only for finite data streams.
+
+
+@Test
+fun myRepositoryTest() = runTest {
+    // Given a repository with a fake data source that emits ALL_MESSAGES
+    val messages = repository.observeChatMessages().toList()
+
+    // When all messages are emitted then they should be ALL_MESSAGES
+    assertEquals(ALL_MESSAGES, messages)
+}
+For data streams that require a more complex collection of items or don't return a finite number of items, you can use the Flow API to pick and transform items. Here are some examples:
+
+
+// Take the second item
+outputFlow.drop(1).first()
+
+// Take the first 5 items
+outputFlow.take(5).toList()
+
+// Takes the first item verifying that the flow is closed after that
+outputFlow.single()
+
+// Finite data streams
+// Verify that the flow emits exactly N elements (optional predicate)
+outputFlow.count()
+outputFlow.count(predicate)
+Continuous collection during a test
+Collecting a flow using toList() as seen in the previous example uses collect() internally, and suspends until the entire result list is ready to be returned.
+
+To interleave actions that cause the flow to emit values and assertions on the values that were emitted, you can continuously collect values from a flow during a test.
+
+For example, take the following Repository class to be tested, and an accompanying fake data source implementation that has an emit method to produce values dynamically during the test:
+
+
+class Repository(private val dataSource: DataSource) {
+    fun scores(): Flow<Int> {
+        return dataSource.counts().map { it * 10 }
+    }
+}
+
+class FakeDataSource : DataSource {
+    private val flow = MutableSharedFlow<Int>()
+    suspend fun emit(value: Int) = flow.emit(value)
+    override fun counts(): Flow<Int> = flow
+}
+When using this fake in a test, you can create a collecting coroutine that will continuously receive the values from the Repository. In this example, we're collecting them into a list and then performing assertions on its contents:
+
+
+@Test
+fun continuouslyCollect() = runTest {
+    val dataSource = FakeDataSource()
+    val repository = Repository(dataSource)
+
+    val values = mutableListOf<Int>()
+    backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+        repository.scores().toList(values)
+    }
+
+    dataSource.emit(1)
+    assertEquals(10, values[0]) // Assert on the list contents
+
+    dataSource.emit(2)
+    dataSource.emit(3)
+    assertEquals(30, values[2])
+
+    assertEquals(3, values.size) // Assert the number of items collected
+}
+Because the flow exposed by the Repository here never completes, the toList call that's collecting it never returns. Starting the collecting coroutine in TestScope.backgroundScope ensures that the coroutine gets cancelled before the end of the test. Otherwise, runTest would keep waiting for its completion, causing the test to stop responding and eventually fail.
+
+Notice how UnconfinedTestDispatcher is used for the collecting coroutine here. This ensures that the collecting coroutine is launched eagerly and is ready to receive values after launch returns.
+
+Using Turbine
+The third-party Turbine library offers a convenient API for creating a collecting coroutine, as well as other convenience features for testing Flows:
+
+
+@Test
+fun usingTurbine() = runTest {
+    val dataSource = FakeDataSource()
+    val repository = Repository(dataSource)
+
+    repository.scores().test {
+        // Make calls that will trigger value changes only within test{}
+        dataSource.emit(1)
+        assertEquals(10, awaitItem())
+
+        dataSource.emit(2)
+        awaitItem() // Ignore items if needed, can also use skip(n)
+
+        dataSource.emit(3)
+        assertEquals(30, awaitItem())
+    }
+}
+See the library's documentation for more details.
+
+Testing StateFlows
+StateFlow is an observable data holder, which can be collected to observe the values it holds over time as a stream. Note that this stream of values is conflated, which means that if values are set in a StateFlow rapidly, collectors of that StateFlow are not guaranteed to receive all intermediate values, only the most recent one.
+
+In tests, if you keep conflation in mind, you can collect a StateFlow's values as you can collect any other flow, including with Turbine. Attempting to collect and assert on all intermediate values can be desirable in some test scenarios.
+
+However, we generally recommend treating StateFlow as a data holder and asserting on its value property instead. This way, tests validate the current state of the object at a given point in time, and don't depend on whether or not conflation happens.
+
+For example, take this ViewModel that collects values from a Repository and exposes them to the UI in a StateFlow:
+
+
+class MyViewModel(private val myRepository: MyRepository) : ViewModel() {
+    private val _score = MutableStateFlow(0)
+    val score: StateFlow<Int> = _score.asStateFlow()
+
+    fun initialize() {
+        viewModelScope.launch {
+            myRepository.scores().collect { score ->
+                _score.value = score
+            }
+        }
+    }
+}
+Note: This ViewModel implementation uses a MutableStateFlow directly. To test StateFlow instances created with stateIn, see the next section.
+A fake implementation for this Repository might look like this:
+
+
+class FakeRepository : MyRepository {
+    private val flow = MutableSharedFlow<Int>()
+    suspend fun emit(value: Int) = flow.emit(value)
+    override fun scores(): Flow<Int> = flow
+}
+When testing the ViewModel with this fake, you can emit values from the fake to trigger updates in the StateFlow of the ViewModel, and then assert on the updated value:
+
+
+@Test
+fun testHotFakeRepository() = runTest {
+    val fakeRepository = FakeRepository()
+    val viewModel = MyViewModel(fakeRepository)
+
+    assertEquals(0, viewModel.score.value) // Assert on the initial value
+
+    // Start collecting values from the Repository
+    viewModel.initialize()
+
+    // Then we can send in values one by one, which the ViewModel will collect
+    fakeRepository.emit(1)
+    assertEquals(1, viewModel.score.value)
+
+    fakeRepository.emit(2)
+    fakeRepository.emit(3)
+    assertEquals(3, viewModel.score.value) // Assert on the latest value
+}
+Working with StateFlows created by stateIn
+In the previous section, the ViewModel uses a MutableStateFlow to store the latest value emitted by a flow from the Repository. This is a common pattern, usually implemented in a simpler way by using the stateIn operator, which converts a cold flow into a hot StateFlow:
+
+
+class MyViewModelWithStateIn(myRepository: MyRepository) : ViewModel() {
+    val score: StateFlow<Int> = myRepository.scores()
+        .stateIn(viewModelScope, SharingStarted.WhileSubscribed(5000L), 0)
+}
+The stateIn operator has a SharingStarted parameter, which determines when it becomes active and starts consuming the underlying flow. Options such as SharingStarted.Lazily and SharingStarted.WhileSubscribed are frequently used in view models.
+
+Caution: When testing a StateFlow created with such options, there must be at least one collector present during the test. Otherwise the stateIn operator doesn't start collecting the underlying flow, and the StateFlow's value will never be updated.
+Even if you're asserting on the value of the StateFlow in your test, you'll need to create a collector. This can be an empty collector:
+
+
+@Test
+fun testLazilySharingViewModel() = runTest {
+    val fakeRepository = HotFakeRepository()
+    val viewModel = MyViewModelWithStateIn(fakeRepository)
+
+    // Create an empty collector for the StateFlow
+    backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+        viewModel.score.collect {}
+    }
+
+    assertEquals(0, viewModel.score.value) // Can assert initial value
+
+    // Trigger-assert like before
+    fakeRepository.emit(1)
+    assertEquals(1, viewModel.score.value)
+
+    fakeRepository.emit(2)
+    fakeRepository.emit(3)
+    assertEquals(3, viewModel.score.value)
+}
+Caution: As with any coroutine started in a test to collect a hot flow that never completes, this collecting coroutine needs to be cancelled manually at the end of the test unless you are using backgroundScope (as in the preceding code sample), which is automatically cancelled when the test finishes.

--- a/docs/thinking-in-compose.md
+++ b/docs/thinking-in-compose.md
@@ -1,0 +1,238 @@
+# Thinking in Compose
+
+Jetpack Compose is a modern declarative UI Toolkit for Android. Compose makes it easier to write and maintain your app UI by providing a declarative API that allows you to render your app UI without imperatively mutating frontend views. This terminology needs some explanation, but the implications are important for your app design.
+
+## The declarative programming paradigm
+Historically, an Android view hierarchy has been representable as a tree of UI widgets. As the state of the app changes because of things like user interactions, the UI hierarchy needs to be updated to display the current data. The most common way of updating the UI is to walk the tree using functions like `findViewById()`, and change nodes by calling methods like `button.setText(String)`, `container.addChild(View)`, or `img.setImageBitmap(Bitmap)`. These methods change the internal state of the widget.
+
+Manipulating views manually increases the likelihood of errors. If a piece of data is rendered in multiple places, it’s easy to forget to update one of the views that shows it. It’s also easy to create illegal states, when two updates conflict in an unexpected way. For example, an update might try to set a value of a node that was just removed from the UI. In general, the software maintenance complexity grows with the number of views that require updating.
+
+Over the last several years, the entire industry has started shifting to a declarative UI model, which greatly simplifies the engineering associated with building and updating user interfaces. The technique works by conceptually regenerating the entire screen from scratch, then applying only the necessary changes. This approach avoids the complexity of manually updating a stateful view hierarchy. Compose is a declarative UI framework.
+
+One challenge with regenerating the entire screen is that it is potentially expensive, in terms of time, computing power, and battery usage. To mitigate this cost, Compose intelligently chooses which parts of the UI need to be redrawn at any given time. This does have some implications for how you design your UI components, as discussed in Recomposition.
+
+## A simple composable function
+Using Compose, you can build your user interface by defining a set of composable functions that take in data and emit UI elements. A simple example is a `Greeting` widget, which takes in a `String` and emits a `Text` widget which displays a greeting message.
+
+A few noteworthy things about this function:
+
+- The function is annotated with the `@Composable` annotation. All Composable functions must have this annotation; this annotation informs the Compose compiler that this function is intended to convert data into UI.
+- The function takes in data. Composable functions can accept parameters, which allow the app logic to describe the UI. In this case, our widget accepts a `String` so it can greet the user by name.
+- The function displays text in the UI. It does so by calling the `Text()` composable function, which actually creates the text UI element. Composable functions emit UI hierarchy by calling other composable functions.
+- The function doesn't return anything. Compose functions that emit UI do not need to return anything, because they describe the desired screen state instead of constructing UI widgets.
+
+This function is fast, idempotent, and free of side-effects.
+
+- The function behaves the same way when called multiple times with the same argument, and it does not use other values such as global variables or calls to `random()`.
+- The function describes the UI without any side-effects, such as modifying properties or global variables.
+
+In general, all composable functions should be written with these properties, for reasons discussed in Recomposition.
+
+## The declarative paradigm shift
+With many imperative object-oriented UI toolkits, you initialize the UI by instantiating a tree of widgets. You often do this by inflating an XML layout file. Each widget maintains its own internal state, and exposes getter and setter methods that allow the app logic to interact with the widget.
+
+In Compose's declarative approach, widgets are relatively stateless and don't expose setter or getter functions. In fact, widgets are not exposed as objects. You update the UI by calling the same composable function with different arguments. This makes it easy to provide state to architectural patterns such as a `ViewModel`, as described in the Guide to app architecture. Then, your composables are responsible for transforming the current application state into a UI every time the observable data updates.
+
+When the user interacts with the UI, the UI raises events such as `onClick`. Those events should notify the app logic, which can then change the app's state. When the state changes, the composable functions are called again with the new data. This causes the UI elements to be redrawn—this process is called recomposition.
+
+## Dynamic content
+Because composable functions are written in Kotlin instead of XML, they can be as dynamic as any other Kotlin code. For example, suppose you want to build a UI that greets a list of users:
+
+```kotlin
+@Composable
+fun Greeting(names: List<String>) {
+    for (name in names) {
+        Text("Hello $name")
+    }
+}
+```
+
+This function takes in a list of names and generates a greeting for each user. Composable functions can be quite sophisticated. You can use `if` statements to decide if you want to show a particular UI element. You can use loops. You can call helper functions. You have the full flexibility of the underlying language. This power and flexibility is one of the key advantages of Jetpack Compose.
+
+## Recomposition
+In an imperative UI model, to change a widget, you call a setter on the widget to change its internal state. In Compose, you call the composable function again with new data. Doing so causes the function to be recomposed—the widgets emitted by the function are redrawn, if necessary, with new data. The Compose framework can intelligently recompose only the components that changed.
+
+For example, consider this composable function which displays a button:
+
+```kotlin
+@Composable
+fun ClickCounter(clicks: Int, onClick: () -> Unit) {
+    Button(onClick = onClick) {
+        Text("I've been clicked $clicks times")
+    }
+}
+```
+
+Every time the button is clicked, the caller updates the value of `clicks`. Compose calls the lambda with the `Text` function again to show the new value; this process is called recomposition. Other functions that don't depend on the value are not recomposed.
+
+As we discussed, recomposing the entire UI tree can be computationally expensive, which uses computing power and battery life. Compose solves this problem with this intelligent recomposition.
+
+Recomposition is the process of calling your composable functions again when inputs change. This happens when the function's inputs change. When Compose recomposes based on new inputs, it only calls the functions or lambdas that might have changed, and skips the rest. By skipping all functions or lambdas that don't have changed parameters, Compose can recompose efficiently.
+
+Never depend on side-effects from executing composable functions, since a function's recomposition may be skipped. If you do, users may experience strange and unpredictable behavior in your app. A side-effect is any change that is visible to the rest of your app. For example, these actions are all dangerous side-effects:
+
+- Writing to a property of a shared object
+- Updating an observable in `ViewModel`
+- Updating shared preferences
+
+Composable functions might be re-executed as often as every frame, such as when an animation is being rendered. Composable functions should be fast to avoid jank during animations. If you need to do expensive operations, such as reading from shared preferences, do it in a background coroutine and pass the value result to the composable function as a parameter.
+
+As an example, this code creates a composable to update a value in `SharedPreferences`. The composable shouldn't read or write from shared preferences itself. Instead, this code moves the read and write to a `ViewModel` in a background coroutine. The app logic passes the current value with a callback to trigger an update.
+
+```kotlin
+@Composable
+fun SharedPrefsToggle(
+    text: String,
+    value: Boolean,
+    onValueChanged: (Boolean) -> Unit
+) {
+    Row {
+        Text(text)
+        Checkbox(checked = value, onCheckedChange = onValueChanged)
+    }
+}
+```
+
+This document discusses a number of things to be aware of when you use Compose:
+
+- Recomposition skips as many composable functions and lambdas as possible.
+- Recomposition is optimistic and may be canceled.
+- A composable function might be run quite frequently, as often as every frame of an animation.
+- Composable functions can execute in parallel.
+- Composable functions can execute in any order.
+
+The following sections will cover how to build composable functions to support recomposition. In every case, the best practice is to keep your composable functions fast, idempotent, and side-effect free.
+
+## Recomposition skips as much as possible
+When portions of your UI are invalid, Compose does its best to recompose just the portions that need to be updated. This means it may skip to re-run a single `Button`'s composable without executing any of the composables above or below it in the UI tree.
+
+Every composable function and lambda might recompose by itself. Here's an example that demonstrates how recomposition can skip some elements when rendering a list:
+
+```kotlin
+/**
+ * Display a list of names the user can click with a header
+ */
+@Composable
+fun NamePicker(
+    header: String,
+    names: List<String>,
+    onNameClicked: (String) -> Unit
+) {
+    Column {
+        // this will recompose when [header] changes, but not when [names] changes
+        Text(header, style = MaterialTheme.typography.bodyLarge)
+        HorizontalDivider()
+
+        // LazyColumn is the Compose version of a RecyclerView.
+        // The lambda passed to items() is similar to a RecyclerView.ViewHolder.
+        LazyColumn {
+            items(names) { name ->
+                // When an item's [name] updates, the adapter for that item
+                // will recompose. This will not recompose when [header] changes
+                NamePickerItem(name, onNameClicked)
+            }
+        }
+    }
+}
+
+/**
+ * Display a single name the user can click.
+ */
+@Composable
+private fun NamePickerItem(name: String, onClicked: (String) -> Unit) {
+    Text(name, Modifier.clickable(onClick = { onClicked(name) }))
+}
+```
+
+Each of these scopes might be the only thing to execute during a recomposition. Compose might skip to the `Column` lambda without executing any of its parents when the header changes. And when executing `Column`, Compose might choose to skip the `LazyColumn`'s items if `names` didn't change.
+
+Again, executing all composable functions or lambdas should be side-effect free. When you need to perform a side-effect, trigger it from a callback.
+
+## Recomposition is optimistic
+Recomposition starts whenever Compose thinks that the parameters of a composable might have changed. Recomposition is optimistic, which means Compose expects to finish recomposition before the parameters change again. If a parameter does change before recomposition finishes, Compose might cancel the recomposition and restart it with the new parameter.
+
+When recomposition is canceled, Compose discards the UI tree from the recomposition. If you have any side-effects that depend on the UI being displayed, the side-effect will be applied even if composition is canceled. This can lead to inconsistent app state.
+
+Ensure that all composable functions and lambdas are idempotent and side-effect free to handle optimistic recomposition.
+
+## Composable functions might run quite frequently
+In some cases, a composable function might run for every frame of a UI animation. If the function performs expensive operations, like reading from device storage, the function can cause UI jank.
+
+For example, if your widget tried to read device settings, it could potentially read those settings hundreds of times a second, with disastrous effects on your app's performance.
+
+If your composable function needs data, it should define parameters for the data. You can then move expensive work to another thread, outside of composition, and pass the data to Compose using `mutableStateOf` or `LiveData`.
+
+## Composable functions could be run in parallel
+> **Note:** Composable functions cannot currently be run in parallel, but you should write Compose code in a multithreaded way. In the future, Compose may be multithreaded.
+
+Compose could optimize recomposition by running composable functions in parallel. This would let Compose take advantage of multiple cores, and run composable functions not on the screen at a lower priority.
+
+This optimization would mean a composable function might execute within a pool of background threads. If a composable function calls a function on a `ViewModel`, Compose might call that function from several threads at the same time.
+
+To ensure your application behaves correctly, all composable functions should have no side-effects. Instead, trigger side-effects from callbacks such as `onClick` that always execute on the UI thread.
+
+When a composable function is invoked, the invocation might occur on a different thread from the caller. That means code that modifies variables in a composable lambda should be avoided–both because such code is not thread-safe, and because it is an impermissible side-effect of the composable lambda.
+
+Here's an example showing a composable that displays a list and its count:
+
+```kotlin
+@Composable
+fun ListComposable(myList: List<String>) {
+    Row(horizontalArrangement = Arrangement.SpaceBetween) {
+        Column {
+            for (item in myList) {
+                Text("Item: $item")
+            }
+        }
+        Text("Count: ${myList.size}")
+    }
+}
+```
+
+This code is side-effect free, and transforms the input list to UI. This is great code for displaying a small list. However, if the function writes to a local variable, this code won't be thread-safe or correct:
+
+```kotlin
+@Composable
+fun ListWithBug(myList: List<String>) {
+    var items = 0
+
+    Row(horizontalArrangement = Arrangement.SpaceBetween) {
+        Column {
+            for (item in myList) {
+                Card {
+                    Text("Item: $item")
+                    items++ // Avoid! Side-effect of the column recomposing.
+                }
+            }
+        }
+        Text("Count: $items")
+    }
+}
+```
+
+In this example, `items` is modified with every recomposition. That could be every frame of an animation, or when the list updates. Either way, the UI will display the wrong count. Because of this, writes like this are not supported in Compose; by prohibiting those writes, we allow the framework to change threads to execute composable lambdas.
+
+## Composable functions can execute in any order
+> **Note:** Compose operates on the main thread, but it has been designed from the start with multithreading in mind and we don't guarantee a single threaded model will remain in the future. Because of this, you should always write your composables as if they can be run on multiple threads.
+
+If you look at the code for a composable function, you might assume that the code is run in the order it appears. But this isn't guaranteed to be true. If a composable function contains calls to other composable functions, those functions might run in any order. Compose has the option of recognizing that some UI elements are higher priority than others, and drawing them first.
+
+For example, suppose you have code like this to draw three screens in a tab layout:
+
+```kotlin
+@Composable
+fun ButtonRow() {
+    MyFancyNavigation {
+        StartScreen()
+        MiddleScreen()
+        EndScreen()
+    }
+}
+```
+
+The calls to `StartScreen`, `MiddleScreen`, and `EndScreen` might happen in any order. This means you can't, for example, have `StartScreen()` set some global variable (a side-effect) and have `MiddleScreen()` take advantage of that change. Instead, each of those functions needs to be self-contained.
+
+## Learn more
+To learn more about how to think in Compose and composable functions, check out the following additional resources.
+
+- Videos


### PR DESCRIPTION
## Summary
- document Gemini agent usage
- add coroutine best practices and Kotlin coroutine overview
- document Kotlin flows on Android and reference in root AGENTS
- fix duplicate heading in Gemini agent instructions
- add testing Kotlin flows guide
- add Jetpack Compose best practices and reference in root AGENTS
- add Jetpack Compose state management guide and reference in root AGENTS
- add Thinking in Compose guide and reference in root AGENTS

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c10aeef7dc832da0faadd5ee37c93a