### PR TITLE
feat: share ktor client instance

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppModule.kt
@@ -29,7 +29,7 @@ import org.koin.dsl.module
 val appModule : Module = module {
     single<DataStore> { DataStore(context = get(), dispatchers = get()) }
     single<AdsCoreManager> { AdsCoreManager(context = get(), buildInfoProvider = get(), dispatchers = get()) }
-    single { KtorClient().createClient(enableLogging = BuildConfig.DEBUG) }
+    single { KtorClient.createClient(enableLogging = BuildConfig.DEBUG) }
 
     single<FavoritesRepository> { FavoritesRepositoryImpl(context = get(), dataStore = get(), dispatchers = get()) }
     single { ObserveFavoritesUseCase(repository = get()) }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/client/KtorClient.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/client/KtorClient.kt
@@ -17,33 +17,31 @@ import io.ktor.serialization.kotlinx.json.json
 import kotlinx.serialization.json.Json
 
 /**
- * A class responsible for creating and configuring a Ktor HttpClient.
+ * An object responsible for creating and configuring a Ktor [HttpClient].
  *
- * This class provides a centralized way to create a pre-configured HttpClient instance with
- * common settings such as JSON content negotiation, request timeouts, and default request headers.
+ * It provides a centralized way to create a pre-configured client instance with common settings
+ * such as JSON content negotiation, request timeouts, and default request headers.
  */
-class KtorClient {
+object KtorClient {
 
-    private val requestTimeout : Long = 10_000L
+    private const val requestTimeout: Long = 10_000L
+    private var client: HttpClient? = null
 
     /**
-     * Creates and configures an [HttpClient] for making network requests.
+     * Returns a shared [HttpClient] instance for making network requests.
      *
-     * This function sets up the client with the following:
+     * The client is created once and reused on subsequent calls. It is configured with:
      * - **Android Engine:** Uses the Android engine for network operations.
-     * - **Content Negotiation:** Configures JSON serialization and deserialization with pretty printing, lenient parsing and ignoring unknown keys.
+     * - **Content Negotiation:** Configures JSON serialization and deserialization with lenient parsing and ignoring unknown keys.
      * - **Timeout Configuration:** Sets request, connect and socket timeouts.
      * - **Default Request Configuration:** Sets default content type and accept headers to JSON.
-     *
-     * @return An [HttpClient] instance ready for use.
      */
-    fun createClient(enableLogging: Boolean = false) : HttpClient {
-        return HttpClient(engineFactory = Android) {
+    fun createClient(enableLogging: Boolean = false): HttpClient {
+        return client ?: HttpClient(engineFactory = Android) {
             configureLogging(enableLogging)
 
             install(plugin = ContentNegotiation) {
                 val jsonConfig = Json {
-                    prettyPrint = true
                     isLenient = true
                     ignoreUnknownKeys = true
                 }
@@ -61,7 +59,7 @@ class KtorClient {
                 contentType(type = ContentType.Application.Json)
                 accept(contentType = ContentType.Application.Json)
             }
-        }
+        }.also { client = it }
     }
 
     private fun HttpClientConfig<AndroidEngineConfig>.configureLogging(enableLogging: Boolean) {


### PR DESCRIPTION
## Summary
- make KtorClient a singleton and reuse HttpClient
- remove JSON prettyPrint configuration
- update DI module to use shared client

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c117ee7d34832d9333913dec38179b