### PR TITLE
Parallelize in-app review data fetch

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainActivity.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainActivity.kt
@@ -107,10 +107,11 @@ class MainActivity : AppCompatActivity() {
 
     private fun checkInAppReview() {
         lifecycleScope.launch {
-            val (sessionCount: Int, hasPrompted: Boolean) = withContext(dispatchers.io) {
-                val sc = dataStore.sessionCount.first()
-                val hp = dataStore.hasPromptedReview.first()
-                sc to hp
+            val (sessionCount: Int, hasPrompted: Boolean) = coroutineScope {
+                val sessionCountDeferred = async(dispatchers.io) { dataStore.sessionCount.first() }
+                val hasPromptedDeferred = async(dispatchers.io) { dataStore.hasPromptedReview.first() }
+                awaitAll(sessionCountDeferred, hasPromptedDeferred)
+                sessionCountDeferred.getCompleted() to hasPromptedDeferred.getCompleted()
             }
             ReviewHelper.launchInAppReviewIfEligible(
                 activity = this@MainActivity,


### PR DESCRIPTION
## Summary
- fetch session count and review prompt state in parallel in `MainActivity`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c11a161688832dba6c301e4b23aa25