### PR TITLE
Optimize recomposition and navigation state

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/components/navigation/AppNavigationHost.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/components/navigation/AppNavigationHost.kt
@@ -25,7 +25,9 @@ import org.koin.compose.koinInject
 
 @Composable
 fun AppNavigationHost(
-    navController : NavHostController , snackbarHostState : SnackbarHostState , onFabVisibilityChanged : (Boolean) -> Unit , paddingValues : PaddingValues
+    navController: NavHostController,
+    snackbarHostState: SnackbarHostState,
+    paddingValues: PaddingValues
 ) {
     val dataStore : DataStore = koinInject()
     val startupRoute by dataStore.getStartupPage(default = NavigationRoutes.ROUTE_APPS_LIST).collectAsStateWithLifecycle(initialValue = NavigationRoutes.ROUTE_APPS_LIST)


### PR DESCRIPTION
## Summary
- Drop unused FAB state and effect to prevent needless recompositions in MainScaffoldContent
- Calculate current navigation route with `derivedStateOf` for more efficient recomposition
- Simplify AppNavigationHost API by removing unused FAB visibility callback

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c18de66150832d867d560f0c49f0fb