### PR TITLE
Handle network errors in developer apps repository

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/repository/DeveloperAppsRepository.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/repository/DeveloperAppsRepository.kt
@@ -1,9 +1,11 @@
 package com.d4rk.android.apps.apptoolkit.app.apps.list.domain.repository
 
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
+import com.d4rk.android.apps.apptoolkit.core.domain.model.network.Errors
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
 import kotlinx.coroutines.flow.Flow
 
 interface DeveloperAppsRepository {
-    fun fetchDeveloperApps(): Flow<List<AppInfo>>
+    fun fetchDeveloperApps(): Flow<DataState<List<AppInfo>, Errors>>
 }
 

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/usecases/FetchDeveloperAppsUseCase.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/usecases/FetchDeveloperAppsUseCase.kt
@@ -2,13 +2,9 @@ package com.d4rk.android.apps.apptoolkit.app.apps.list.domain.usecases
 
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.repository.DeveloperAppsRepository
-import com.d4rk.android.apps.apptoolkit.core.domain.model.network.Errors
-import com.d4rk.android.apps.apptoolkit.core.utils.extensions.toError
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.RootError
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onStart
 
 class FetchDeveloperAppsUseCase(
@@ -17,12 +13,6 @@ class FetchDeveloperAppsUseCase(
 
     operator fun invoke(): Flow<DataState<List<AppInfo>, RootError>> =
         repository.fetchDeveloperApps()
-            .map<List<AppInfo>, DataState<List<AppInfo>, RootError>> { apps ->
-                DataState.Success(data = apps)
-            }
             .onStart { emit(DataState.Loading()) }
-            .catch { throwable ->
-                emit(DataState.Error(error = throwable.toError(default = Errors.UseCase.FAILED_TO_LOAD_APPS)))
-            }
 }
 

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/FakeDeveloperAppsRepository.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/FakeDeveloperAppsRepository.kt
@@ -2,20 +2,25 @@ package com.d4rk.android.apps.apptoolkit.app.apps.list
 
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.repository.DeveloperAppsRepository
+import com.d4rk.android.apps.apptoolkit.core.domain.model.network.Errors
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
 /**
  * Fake implementation of [DeveloperAppsRepository] that returns a predefined list.
- * It can optionally throw an exception when [fetchDeveloperApps] is called.
+ * It can optionally emit an error when [fetchDeveloperApps] is called.
  */
 class FakeDeveloperAppsRepository(
     private val apps: List<AppInfo>,
-    private val fetchThrows: Throwable? = null,
+    private val fetchError: Errors? = null,
 ) : DeveloperAppsRepository {
-    override fun fetchDeveloperApps(): Flow<List<AppInfo>> = flow {
-        fetchThrows?.let { throw it }
-        emit(apps)
+    override fun fetchDeveloperApps(): Flow<DataState<List<AppInfo>, Errors>> = flow {
+        fetchError?.let {
+            emit(DataState.Error(error = it))
+            return@flow
+        }
+        emit(DataState.Success(apps))
     }
 }
 

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModelBase.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModelBase.kt
@@ -9,6 +9,7 @@ import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.ui.UiHomeScreen
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.usecases.FetchDeveloperAppsUseCase
 import com.d4rk.android.apps.apptoolkit.app.apps.list.ui.AppsListViewModel
+import com.d4rk.android.apps.apptoolkit.core.domain.model.network.Errors
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.google.common.truth.Truth.assertThat
@@ -29,11 +30,11 @@ open class TestAppsListViewModelBase {
         initialFavorites: Set<String> = emptySet(),
         favoritesFlow: Flow<Set<String>>? = null,
         toggleError: Throwable? = null,
-        fetchThrows: Throwable? = null,
+        fetchError: Errors? = null,
         dispatchers: DispatcherProvider = TestDispatchers(),
     ) {
         println("\uD83E\uDDEA [SETUP] Initial favorites: $initialFavorites")
-        val developerAppsRepository = FakeDeveloperAppsRepository(fetchApps, fetchThrows)
+        val developerAppsRepository = FakeDeveloperAppsRepository(fetchApps, fetchError)
         val fetchUseCase = FetchDeveloperAppsUseCase(developerAppsRepository)
         val favoritesRepository = FakeFavoritesRepository(initialFavorites, favoritesFlow, toggleError)
         val observeFavoritesUseCase = ObserveFavoritesUseCase(favoritesRepository)

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/usecases/FetchDeveloperAppsUseCaseTest.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/usecases/FetchDeveloperAppsUseCaseTest.kt
@@ -9,7 +9,6 @@ import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
-import java.net.SocketTimeoutException
 import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
@@ -19,7 +18,8 @@ class FetchDeveloperAppsUseCaseTest {
     fun `invoke emits loading then success`() = runTest {
         val apps = listOf(AppInfo(name = "App", packageName = "pkg", iconUrl = "icon"))
         val repository = object : DeveloperAppsRepository {
-            override fun fetchDeveloperApps(): Flow<List<AppInfo>> = flow { emit(apps) }
+            override fun fetchDeveloperApps(): Flow<DataState<List<AppInfo>, Errors>> =
+                flow { emit(DataState.Success(apps)) }
         }
         val useCase = FetchDeveloperAppsUseCase(repository)
 
@@ -34,7 +34,8 @@ class FetchDeveloperAppsUseCaseTest {
     @Test
     fun `invoke emits error when repository fails`() = runTest {
         val repository = object : DeveloperAppsRepository {
-            override fun fetchDeveloperApps(): Flow<List<AppInfo>> = flow { throw SocketTimeoutException("timeout") }
+            override fun fetchDeveloperApps(): Flow<DataState<List<AppInfo>, Errors>> =
+                flow { emit(DataState.Error(error = Errors.Network.REQUEST_TIMEOUT)) }
         }
         val useCase = FetchDeveloperAppsUseCase(repository)
 


### PR DESCRIPTION
## Summary
- propagate network failures from developer apps repository as domain `Errors`
- adapt fetch use case to consume repository `DataState`
- update developer apps tests for new error flow
- refactor network call to use `runCatching`

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c5f2a84398832d95af7e5d7271cbe6