### PR TITLE
Extract shared app action builders

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/common/AppActions.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/common/AppActions.kt
@@ -1,0 +1,45 @@
+package com.d4rk.android.apps.apptoolkit.app.apps.common
+
+import android.content.Context
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
+import com.d4rk.android.libs.apptoolkit.R
+import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
+import com.d4rk.android.libs.apptoolkit.core.utils.helpers.AppInfoHelper
+import com.d4rk.android.libs.apptoolkit.core.utils.helpers.IntentsHelper
+import kotlinx.coroutines.launch
+
+@Composable
+fun buildOnAppClick(dispatchers: DispatcherProvider, context: Context): (AppInfo) -> Unit {
+    val appInfoHelper = remember { AppInfoHelper(dispatchers) }
+    val coroutineScope = rememberCoroutineScope()
+    return remember(context, coroutineScope) {
+        { appInfo ->
+            coroutineScope.launch {
+                if (appInfo.packageName.isNotEmpty()) {
+                    if (appInfoHelper.isAppInstalled(context, appInfo.packageName)) {
+                        if (!appInfoHelper.openApp(context, appInfo.packageName)) {
+                            IntentsHelper.openPlayStoreForApp(context, appInfo.packageName)
+                        }
+                    } else {
+                        IntentsHelper.openPlayStoreForApp(context, appInfo.packageName)
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+fun buildOnShareClick(context: Context): (AppInfo) -> Unit =
+    remember(context) {
+        { appInfo ->
+            IntentsHelper.shareApp(
+                context = context,
+                shareMessageFormat = R.string.summary_share_message,
+                packageName = appInfo.packageName
+            )
+        }
+    }

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsScreen.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsScreen.kt
@@ -6,7 +6,8 @@ import androidx.compose.material.icons.outlined.Android
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
+import com.d4rk.android.apps.apptoolkit.app.apps.common.buildOnAppClick
+import com.d4rk.android.apps.apptoolkit.app.apps.common.buildOnShareClick
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.d4rk.android.apps.apptoolkit.R
@@ -20,9 +21,6 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.rememberAdsEnabled
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.NoDataScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.ScreenStateHandler
-import com.d4rk.android.libs.apptoolkit.core.utils.helpers.AppInfoHelper
-import com.d4rk.android.libs.apptoolkit.core.utils.helpers.IntentsHelper
-import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -36,32 +34,8 @@ fun FavoriteAppsRoute(paddingValues: PaddingValues) {
     val onFavoriteToggle: (String) -> Unit = remember(viewModel) { { pkg -> viewModel.toggleFavorite(pkg) } }
     val onRetry: () -> Unit = remember(viewModel) { { viewModel.onEvent(FavoriteAppsEvent.LoadFavorites) } }
     val dispatchers: DispatcherProvider = koinInject()
-    val appInfoHelper = remember { AppInfoHelper(dispatchers) }
-    val coroutineScope = rememberCoroutineScope()
-    val onAppClick: (AppInfo) -> Unit = remember(context, coroutineScope) {
-        { appInfo ->
-            coroutineScope.launch {
-                if (appInfo.packageName.isNotEmpty()) {
-                    if (appInfoHelper.isAppInstalled(context, appInfo.packageName)) {
-                        if (!appInfoHelper.openApp(context, appInfo.packageName)) {
-                            IntentsHelper.openPlayStoreForApp(context, appInfo.packageName)
-                        }
-                    } else {
-                        IntentsHelper.openPlayStoreForApp(context, appInfo.packageName)
-                    }
-                }
-            }
-        }
-    }
-    val onShareClick: (AppInfo) -> Unit = remember(context) {
-        {
-            IntentsHelper.shareApp(
-                context = context,
-                shareMessageFormat = com.d4rk.android.libs.apptoolkit.R.string.summary_share_message,
-                packageName = it.packageName
-            )
-        }
-    }
+    val onAppClick: (AppInfo) -> Unit = buildOnAppClick(dispatchers, context)
+    val onShareClick: (AppInfo) -> Unit = buildOnShareClick(context)
 
     FavoriteAppsScreen(
         screenState = screenState,

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListScreen.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListScreen.kt
@@ -4,7 +4,8 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.rememberCoroutineScope
+import com.d4rk.android.apps.apptoolkit.app.apps.common.buildOnAppClick
+import com.d4rk.android.apps.apptoolkit.app.apps.common.buildOnShareClick
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.actions.HomeEvent
@@ -17,9 +18,6 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.ads.rememberAdsEnabled
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.NoDataScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.components.layouts.ScreenStateHandler
-import com.d4rk.android.libs.apptoolkit.core.utils.helpers.AppInfoHelper
-import com.d4rk.android.libs.apptoolkit.core.utils.helpers.IntentsHelper
-import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -33,32 +31,8 @@ fun AppsListRoute(paddingValues: PaddingValues) {
     val onFavoriteToggle: (String) -> Unit = remember(viewModel) { { pkg -> viewModel.toggleFavorite(pkg) } }
     val onRetry: () -> Unit = remember(viewModel) { { viewModel.onEvent(HomeEvent.FetchApps) } }
     val dispatchers: DispatcherProvider = koinInject()
-    val appInfoHelper = remember { AppInfoHelper(dispatchers) }
-    val coroutineScope = rememberCoroutineScope()
-    val onAppClick: (AppInfo) -> Unit = remember(context, coroutineScope) {
-        { appInfo ->
-            coroutineScope.launch {
-                if (appInfo.packageName.isNotEmpty()) {
-                    if (appInfoHelper.isAppInstalled(context, appInfo.packageName)) {
-                        if (!appInfoHelper.openApp(context, appInfo.packageName)) {
-                            IntentsHelper.openPlayStoreForApp(context, appInfo.packageName)
-                        }
-                    } else {
-                        IntentsHelper.openPlayStoreForApp(context, appInfo.packageName)
-                    }
-                }
-            }
-        }
-    }
-    val onShareClick: (AppInfo) -> Unit = remember(context) {
-        {
-            IntentsHelper.shareApp(
-                context = context,
-                shareMessageFormat = com.d4rk.android.libs.apptoolkit.R.string.summary_share_message,
-                packageName = it.packageName
-            )
-        }
-    }
+    val onAppClick: (AppInfo) -> Unit = buildOnAppClick(dispatchers, context)
+    val onShareClick: (AppInfo) -> Unit = buildOnShareClick(context)
 
     AppsListScreen(
         screenState = screenState,


### PR DESCRIPTION
## Summary
- centralize app launch and share callbacks in `AppActions`
- reuse shared click handlers in AppsList and Favorites routes

## Testing
- ⚠️ `./gradlew test` *(missing Android SDK)*

------
https://chatgpt.com/codex/tasks/task_e_68c65edc1328832d816c2e8e9dfabc56