### PR TITLE
Inject configurable developer apps base URL

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -87,6 +87,8 @@ android {
         }
     }
 
+    val developerAppsBaseUrl = "https://raw.githubusercontent.com/MihaiCristianCondrea/com.d4rk.apis/refs/heads/main/App%20Toolkit"
+
     buildTypes {
         release {
             val signingFile = rootProject.file("signing.properties")
@@ -96,9 +98,19 @@ android {
                 null
             }
             isDebuggable = false
+            buildConfigField(
+                "String",
+                "DEVELOPER_APPS_BASE_URL",
+                "\"$developerAppsBaseUrl/release\"",
+            )
         }
         debug {
             isDebuggable = true
+            buildConfigField(
+                "String",
+                "DEVELOPER_APPS_BASE_URL",
+                "\"$developerAppsBaseUrl/debug\"",
+            )
         }
     }
 

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/data/repository/DeveloperAppsRepositoryImpl.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/data/repository/DeveloperAppsRepositoryImpl.kt
@@ -1,12 +1,9 @@
 package com.d4rk.android.apps.apptoolkit.app.apps.list.data.repository
 
-import com.d4rk.android.apps.apptoolkit.BuildConfig
 import com.d4rk.android.apps.apptoolkit.app.apps.list.data.model.api.ApiResponse
 import com.d4rk.android.apps.apptoolkit.app.apps.list.data.model.api.toDomain
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.repository.DeveloperAppsRepository
-import com.d4rk.android.apps.apptoolkit.app.apps.list.utils.constants.api.ApiConstants
-import com.d4rk.android.apps.apptoolkit.app.apps.list.utils.constants.api.ApiEnvironments
 import com.d4rk.android.apps.apptoolkit.app.apps.list.utils.constants.api.ApiPaths
 import com.d4rk.android.apps.apptoolkit.core.domain.model.network.Errors
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
@@ -23,13 +20,11 @@ import java.net.SocketTimeoutException
 
 class DeveloperAppsRepositoryImpl(
     private val client: HttpClient,
+    private val baseUrl: String,
 ) : DeveloperAppsRepository {
 
     override fun fetchDeveloperApps(): Flow<DataState<List<AppInfo>, Errors>> = flow {
-        val url = BuildConfig.DEBUG.let { isDebug ->
-            val environment = if (isDebug) ApiEnvironments.ENV_DEBUG else ApiEnvironments.ENV_RELEASE
-            "${ApiConstants.BASE_REPOSITORY_URL}/$environment${ApiPaths.DEVELOPER_APPS_API}"
-        }
+        val url = "$baseUrl${ApiPaths.DEVELOPER_APPS_API}"
         runCatching {
             client.get(url)
         }.onSuccess { httpResponse ->

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppModule.kt
@@ -56,7 +56,14 @@ val appModule : Module = module {
 
     viewModel { MainViewModel(navigationRepository = get()) }
 
-    single<DeveloperAppsRepository> { DeveloperAppsRepositoryImpl(client = get()) }
+    single<String>(qualifier = named(name = "developer_apps_base_url")) { BuildConfig.DEVELOPER_APPS_BASE_URL }
+
+    single<DeveloperAppsRepository> {
+        DeveloperAppsRepositoryImpl(
+            client = get(),
+            baseUrl = get(qualifier = named(name = "developer_apps_base_url")),
+        )
+    }
     single { FetchDeveloperAppsUseCase(repository = get()) }
     viewModel {
         AppsListViewModel(

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/data/repository/DeveloperAppsRepositoryImplTest.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/data/repository/DeveloperAppsRepositoryImplTest.kt
@@ -37,7 +37,7 @@ class DeveloperAppsRepositoryImplTest {
         }) {
             install(ContentNegotiation) { json() }
         }
-        val repository = DeveloperAppsRepositoryImpl(client)
+        val repository = DeveloperAppsRepositoryImpl(client, "https://example.com")
 
         val result = repository.fetchDeveloperApps().first()
         val success = result as DataState.Success
@@ -55,7 +55,7 @@ class DeveloperAppsRepositoryImplTest {
         }) {
             install(ContentNegotiation) { json() }
         }
-        val repository = DeveloperAppsRepositoryImpl(client)
+        val repository = DeveloperAppsRepositoryImpl(client, "https://example.com")
 
         val result = repository.fetchDeveloperApps().first()
         val error = result as DataState.Error
@@ -80,7 +80,7 @@ class DeveloperAppsRepositoryImplTest {
         }) {
             install(ContentNegotiation) { json() }
         }
-        val repository = DeveloperAppsRepositoryImpl(client)
+        val repository = DeveloperAppsRepositoryImpl(client, "https://example.com")
 
         val result = repository.fetchDeveloperApps().first() as DataState.Success
         assertEquals(listOf("Alpha", "beta", "zeta"), result.data.map(AppInfo::name))
@@ -97,7 +97,7 @@ class DeveloperAppsRepositoryImplTest {
         }) {
             install(ContentNegotiation) { json() }
         }
-        val repository = DeveloperAppsRepositoryImpl(client)
+        val repository = DeveloperAppsRepositoryImpl(client, "https://example.com")
 
         val result = repository.fetchDeveloperApps().first()
         val error = result as DataState.Error


### PR DESCRIPTION
## Summary
- Define build config values for developer apps API base URL per build type
- Inject base URL into `DeveloperAppsRepositoryImpl` via constructor
- Provide base URL through Koin modules and update repository tests

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68c6627c030c832d936982b7b5cef3b8