### PR TITLE
Expose ad frequency

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -65,6 +65,7 @@ android {
             ""
         }
         buildConfigField("String", "GITHUB_TOKEN", "\"$githubToken\"")
+        buildConfigField("int", "APPS_LIST_AD_FREQUENCY", "4")
     }
 
     signingConfigs {

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/AppsList.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/AppsList.kt
@@ -17,6 +17,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
+import com.d4rk.android.apps.apptoolkit.BuildConfig
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppListItem
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.ui.UiHomeScreen
@@ -37,6 +38,7 @@ fun AppsList(
     onFavoriteToggle: (String) -> Unit,
     onAppClick: (AppInfo) -> Unit,
     onShareClick: (AppInfo) -> Unit,
+    adFrequency: Int = BuildConfig.APPS_LIST_AD_FREQUENCY,
 ) {
     val apps: List<AppInfo> = uiHomeScreen.apps
     val context = LocalContext.current
@@ -47,8 +49,7 @@ fun AppsList(
         derivedStateOf { if (isTabletOrLandscape) 4 else 2 }
     }
     val listState = rememberLazyGridState()
-    val adFrequency = 4
-    val items by remember(apps, adsEnabled) {
+    val items by remember(apps, adsEnabled, adFrequency) {
         derivedStateOf { buildAppListItems(apps, adsEnabled, adFrequency) }
     }
     val adsConfig: AdsConfig = koinInject(qualifier = named("apps_list_banner_ad"))
@@ -167,7 +168,7 @@ private fun AdListItem(
     )
 }
 
-private fun buildAppListItems(
+internal fun buildAppListItems(
     apps: List<AppInfo>,
     adsEnabled: Boolean,
     adFrequency: Int

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/BuildAppListItemsTest.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/BuildAppListItemsTest.kt
@@ -1,0 +1,38 @@
+package com.d4rk.android.apps.apptoolkit.app.apps.list.ui.components
+
+import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
+import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppListItem
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.Test
+
+class BuildAppListItemsTest {
+
+    @Test
+    fun `buildAppListItems inserts ads at configured frequency`() {
+        val apps = (1..8).map { AppInfo("App$it", "pkg$it", "icon$it") }
+        val items = buildAppListItems(apps, adsEnabled = true, adFrequency = 4)
+
+        assertEquals(10, items.size)
+        assertTrue(items[4] is AppListItem.Ad)
+        assertTrue(items[9] is AppListItem.Ad)
+    }
+
+    @Test
+    fun `buildAppListItems adds trailing ad when apps count not multiple of frequency`() {
+        val apps = (1..5).map { AppInfo("App$it", "pkg$it", "icon$it") }
+        val items = buildAppListItems(apps, adsEnabled = true, adFrequency = 4)
+
+        assertEquals(7, items.size)
+        assertTrue(items[4] is AppListItem.Ad)
+        assertTrue(items[6] is AppListItem.Ad)
+    }
+
+    @Test
+    fun `buildAppListItems returns only apps when ads disabled`() {
+        val apps = (1..5).map { AppInfo("App$it", "pkg$it", "icon$it") }
+        val items = buildAppListItems(apps, adsEnabled = false, adFrequency = 4)
+
+        assertEquals(apps.map { AppListItem.App(it) }, items)
+    }
+}


### PR DESCRIPTION
## Summary
- allow ad frequency to be configured for AppsList from BuildConfig
- add tests for ad insertion pattern

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c66838f3cc832d84e7eb695d1203e6