### PR TITLE
Add KDoc for core library components

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/di/DispatcherProvider.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/di/DispatcherProvider.kt
@@ -2,9 +2,23 @@ package com.d4rk.android.libs.apptoolkit.core.di
 
 import kotlinx.coroutines.CoroutineDispatcher
 
+/**
+ * Abstraction for providing coroutine dispatchers.
+ *
+ * Having an interface allows production code to use the standard dispatchers
+ * while tests can supply their own implementations to control threading.
+ */
 interface DispatcherProvider {
-    val main: CoroutineDispatcher
-    val io: CoroutineDispatcher
-    val default: CoroutineDispatcher
-    val unconfined: CoroutineDispatcher
+    /** Dispatcher for work on the main thread. */
+    val main : CoroutineDispatcher
+
+    /** Dispatcher for IO-bound tasks such as network or disk operations. */
+    val io : CoroutineDispatcher
+
+    /** Dispatcher for CPU-intensive work. */
+    val default : CoroutineDispatcher
+
+    /** Dispatcher that is not confined to any specific thread. */
+    val unconfined : CoroutineDispatcher
 }
+

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/di/Qualifiers.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/di/Qualifiers.kt
@@ -2,5 +2,9 @@ package com.d4rk.android.libs.apptoolkit.core.di
 
 import javax.inject.Qualifier
 
+/**
+ * Qualifier used to inject the GitHub token required for authenticated
+ * API requests.
+ */
 @Qualifier
 annotation class GithubToken

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/di/StandardDispatchers.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/di/StandardDispatchers.kt
@@ -3,9 +3,17 @@ package com.d4rk.android.libs.apptoolkit.core.di
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
 
+/**
+ * Default implementation of [DispatcherProvider] that returns the standard
+ * coroutine dispatchers from [Dispatchers].
+ *
+ * Use this provider in production code where the default dispatchers are
+ * sufficient. Tests can supply a custom implementation to control threading.
+ */
 class StandardDispatchers : DispatcherProvider {
-    override val main: CoroutineDispatcher get() = Dispatchers.Main
-    override val io: CoroutineDispatcher get() = Dispatchers.IO
-    override val default: CoroutineDispatcher get() = Dispatchers.Default
-    override val unconfined: CoroutineDispatcher get() = Dispatchers.Unconfined
+    override val main : CoroutineDispatcher get() = Dispatchers.Main
+    override val io : CoroutineDispatcher get() = Dispatchers.IO
+    override val default : CoroutineDispatcher get() = Dispatchers.Default
+    override val unconfined : CoroutineDispatcher get() = Dispatchers.Unconfined
 }
+

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/base/BaseViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/base/BaseViewModel.kt
@@ -13,19 +13,37 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.launch
 
+/**
+ * Base class for ViewModels used throughout the toolkit.
+ *
+ * The class exposes state updates via [uiState] and one-off events via
+ * [actionEvent]. Concrete implementations handle incoming events through
+ * [onEvent] and can emit new actions with [sendAction].
+ *
+ * @param S type representing the UI state
+ * @param E type of events coming from the UI layer
+ * @param A type of one-off actions to be processed by the UI
+ * @param initialState initial value of the state
+ */
 abstract class BaseViewModel<S : UiState , E : UiEvent , A : ActionEvent>(initialState : S) : ViewModel() {
 
     protected val _uiState : MutableStateFlow<S> = MutableStateFlow(value = initialState)
+
+    /** Current state exposed to the UI as a [StateFlow]. */
     val uiState : StateFlow<S> = _uiState.asStateFlow()
 
     private val _actionEvent = MutableSharedFlow<A>(extraBufferCapacity = 1)
-    val actionEvent: SharedFlow<A> = _actionEvent.asSharedFlow()
+
+    /** One-off actions that the UI should react to. */
+    val actionEvent : SharedFlow<A> = _actionEvent.asSharedFlow()
 
     protected val currentState : S
         get() = uiState.value
 
+    /** Handles a new UI [event]. */
     abstract fun onEvent(event : E)
 
+    /** Emits an [action] for the UI to handle. */
     protected fun sendAction(action : A) {
         viewModelScope.launch {
             _actionEvent.emit(action)

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/base/ScreenViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/base/ScreenViewModel.kt
@@ -5,11 +5,25 @@ import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.ActionEvent
 import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.UiEvent
 import kotlinx.coroutines.flow.MutableStateFlow
 
+/**
+ * Base ViewModel for screens that expose [UiStateScreen] as state.
+ *
+ * Provides convenient accessors for the current screen state and the
+ * underlying data object [T].
+ *
+ * @param T type of data rendered on the screen
+ * @param E events emitted by the UI
+ * @param A one-off actions to be handled by the UI
+ * @param initialState starting state of the screen
+ */
 abstract class ScreenViewModel<T , E : UiEvent , A : ActionEvent>(
     initialState : UiStateScreen<T>
 ) : BaseViewModel<UiStateScreen<T> , E , A>(initialState) {
+    /** Mutable state backing the screen. */
     protected val screenState : MutableStateFlow<UiStateScreen<T>>
         get() = _uiState
+
+    /** Convenience accessor for the current data stored in the state. */
     protected val screenData : T?
         get() = currentState.data
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/base/handling/ActionEvent.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/base/handling/ActionEvent.kt
@@ -1,3 +1,6 @@
 package com.d4rk.android.libs.apptoolkit.core.ui.base.handling
 
+/**
+ * Marker interface for one-off actions that the UI should perform.
+ */
 interface ActionEvent

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/base/handling/UiEvent.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/base/handling/UiEvent.kt
@@ -1,3 +1,6 @@
 package com.d4rk.android.libs.apptoolkit.core.ui.base.handling
 
+/**
+ * Marker interface for events coming from the UI layer.
+ */
 interface UiEvent

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/base/handling/UiState.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/base/handling/UiState.kt
@@ -1,3 +1,6 @@
 package com.d4rk.android.libs.apptoolkit.core.ui.base.handling
 
+/**
+ * Marker interface representing the state exposed by a ViewModel.
+ */
 interface UiState

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/ReviewHelper.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/ReviewHelper.kt
@@ -6,14 +6,27 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 
+/**
+ * Helper for launching the Google Play in-app review flow.
+ *
+ * The helper exposes convenience methods that encapsulate the eligibility
+ * checks and coroutine handling required to show the review dialog.
+ */
 object ReviewHelper {
 
+    /**
+     * Triggers the in-app review dialog if the user meets the eligibility criteria.
+     *
+     * The review is only requested when [sessionCount] is at least three and the
+     * user has not been prompted before. When the review dialog is shown,
+     * [onReviewLaunched] is invoked.
+     */
     fun launchInAppReviewIfEligible(
-        activity: Activity,
-        sessionCount: Int,
-        hasPromptedBefore: Boolean,
-        scope: CoroutineScope,
-        onReviewLaunched: () -> Unit
+        activity : Activity,
+        sessionCount : Int,
+        hasPromptedBefore : Boolean,
+        scope : CoroutineScope,
+        onReviewLaunched : () -> Unit
     ) {
         if (sessionCount < 3 || hasPromptedBefore) return
         scope.launch {
@@ -24,17 +37,26 @@ object ReviewHelper {
         }
     }
 
-    fun forceLaunchInAppReview(activity: Activity, scope: CoroutineScope) {
+    /**
+     * Forces the in-app review dialog to be displayed regardless of eligibility.
+     * Useful for debugging or providing a manual trigger within the app.
+     */
+    fun forceLaunchInAppReview(activity : Activity , scope : CoroutineScope) {
         scope.launch {
             launchReview(activity)
         }
     }
 
-    suspend fun launchReview(activity: Activity): Boolean {
+    /**
+     * Requests and launches the review flow.
+     *
+     * @return `true` if the review dialog was shown, `false` otherwise.
+     */
+    suspend fun launchReview(activity : Activity) : Boolean {
         val reviewManager = ReviewManagerFactory.create(activity)
         return runCatching {
             val reviewInfo = reviewManager.requestReviewFlow().await()
-            reviewManager.launchReviewFlow(activity, reviewInfo).await()
+            reviewManager.launchReviewFlow(activity , reviewInfo).await()
             true
         }.getOrDefault(false)
     }


### PR DESCRIPTION
## Summary
- document dispatcher provider and standard dispatchers
- document base and screen view models plus action/ui state interfaces
- add in-app review helper KDoc

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c67f366384832dbde07efe8e4db88b