### PR TITLE
docs: add KDoc for core managers

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/datastore/CommonDataStore.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/datastore/CommonDataStore.kt
@@ -78,16 +78,24 @@ open class CommonDataStore(
     }
 
     private val startupPageKey = stringPreferencesKey(name = DataStoreNamesConstants.DATA_STORE_STARTUP_PAGE)
+
+    /**
+     * Observes the preferred startup route.
+     *
+     * @param default value emitted when the preference has not been set yet.
+     */
     fun getStartupPage(default: String = "") : Flow<String> = dataStore.data.map { preferences ->
         preferences[startupPageKey] ?: default
     }
 
+    /** Stores whether the app has completed its first-time startup flow. */
     override suspend fun saveStartup(isFirstTime : Boolean) {
         dataStore.edit { preferences : MutablePreferences ->
             preferences[startupKey] = isFirstTime
         }
     }
 
+    /** Persists the route that should be opened when the app launches. */
     suspend fun saveStartupPage(route: String) {
         dataStore.edit { prefs: MutablePreferences ->
             prefs[startupPageKey] = route


### PR DESCRIPTION
## Summary
- document BaseCoreManager lifecycle and startup flow
- document AdsCoreManager and ad loading helper
- describe CommonDataStore startup preferences

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6846e8c70832da019bacfd16c85ad