### PR TITLE
docs: add kdoc for library components

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/extensions/Errors.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/extensions/Errors.kt
@@ -8,6 +8,16 @@ import java.net.SocketTimeoutException
 import java.net.UnknownHostException
 import java.sql.SQLException
 
+/**
+ * Converts a [Throwable] into a domain specific [Errors] value.
+ *
+ * The mapping centralizes error handling by translating common
+ * networking, serialization and database failures into
+ * semantic categories understood by the rest of the toolkit.
+ *
+ * @param default value returned when the [Throwable] type is not recognized
+ * @return [Errors] describing the failure
+ */
 fun Throwable.toError(default : Errors = Errors.UseCase.NO_DATA) : Errors {
     return when (this) {
         is UnknownHostException -> Errors.Network.NO_INTERNET

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/ConsentManagerHelper.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/ConsentManagerHelper.kt
@@ -14,6 +14,13 @@ import kotlinx.coroutines.flow.first
 import org.koin.core.component.KoinComponent
 import org.koin.core.component.inject
 
+/**
+ * Helper responsible for applying user consent preferences to Firebase services.
+ *
+ * It reads persisted flags from [CommonDataStore] and propagates them to
+ * Analytics, Crashlytics and Performance so data collection respects the
+ * user's choices.
+ */
 object ConsentManagerHelper : KoinComponent {
 
     private val configProvider: BuildInfoProvider by inject()
@@ -99,6 +106,11 @@ object ConsentManagerHelper : KoinComponent {
         updateAnalyticsCollectionFromDatastore(dataStore = dataStore)
     }
 
+    /**
+     * Applies the persisted "Usage and Diagnostics" preference to Firebase SDKs.
+     *
+     * @param dataStore source of the user's consent setting
+     */
     suspend fun updateAnalyticsCollectionFromDatastore(dataStore: CommonDataStore) {
         val usageAndDiagnosticsGranted: Boolean = dataStore.usageAndDiagnostics(default = defaultAnalyticsGranted).first()
         Firebase.analytics.setAnalyticsCollectionEnabled(usageAndDiagnosticsGranted)

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/interfaces/DismissibleSnackbarViewModel.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/interfaces/DismissibleSnackbarViewModel.kt
@@ -2,6 +2,12 @@ package com.d4rk.android.libs.apptoolkit.core.utils.interfaces
 
 import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.UiEvent
 
+/**
+ * Contract for ViewModels that can instruct the UI to dismiss a snackbar.
+ *
+ * @param E type of [UiEvent] used to trigger the dismissal
+ */
 interface DismissibleSnackbarViewModel<E : UiEvent> {
+    /** Event emitted when the current snackbar should be cleared. */
     fun getDismissSnackbarEvent() : E
 }


### PR DESCRIPTION
## Summary
- document throwable-to-error mapping
- clarify snackbar dismissal event contract
- explain consent manager's Firebase integration

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c68531ce04832db2fcdde97013bb67