### PR TITLE
docs: add KDoc for core UI helpers

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/layouts/LoadingScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/layouts/LoadingScreen.kt
@@ -20,6 +20,18 @@ import androidx.compose.ui.unit.dp
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.MediumVerticalSpacer
 
+/**
+ * Fullscreen wrapper that displays an animated [LoadingIndicator].
+ *
+ * This composable is typically used while data is being loaded. Optional
+ * text can be shown beneath the indicator, and the indicator size or padding
+ * can be customized through the provided parameters.
+ *
+ * @param modifier Modifier applied to the root [Column].
+ * @param paddingValues Additional padding around the content.
+ * @param indicatorSize Size of the circular loading indicator.
+ * @param showText When true a localized "loading" label is rendered.
+ */
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun LoadingScreen(

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/layouts/NoDataScreen.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/layouts/NoDataScreen.kt
@@ -34,17 +34,21 @@ import org.koin.compose.koinInject
 import org.koin.core.qualifier.named
 
 /**
- * A composable function that displays a screen indicating that no data is available.
- * It can optionally display a retry button to allow the user to attempt to fetch data again.
+ * Displays a placeholder screen when no data is available.
  *
- * @param text The string resource ID for the text to be displayed. Defaults to R.string.try_again.
- * @param icon The [ImageVector] to be displayed as an icon. Defaults to Icons.Default.Info.
- * @param showRetry A boolean indicating whether to show the retry button. Defaults to false.
- * @param onRetry A lambda function to be executed when the retry button is clicked. Defaults to an empty lambda.
+ * A progress indicator with an optional [icon] is shown in the center of the
+ * screen. A retry button and ad banner can be toggled through [showRetry] and
+ * [showAd] respectively. When [isError] is true error colors are used.
  *
- * Example Usage:
- * ```
- * NoDataScreen(text = R.string.no_items_found, icon = Icons.Default.Warning */
+ * @param text Label for the retry action button.
+ * @param textMessage Message describing the empty state.
+ * @param icon Icon rendered at the center of the indicator.
+ * @param showRetry Whether to display the retry button.
+ * @param onRetry Callback invoked when the retry button is pressed.
+ * @param showAd Whether an [AdBanner] should be displayed.
+ * @param isError Shows the indicator with error styling when true.
+ * @param adsConfig Configuration used for the ad banner instance.
+ */
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun NoDataScreen(

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/layouts/NonLazyGrid.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/layouts/NonLazyGrid.kt
@@ -10,9 +10,24 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 
+/**
+ * Simple grid that measures and places all items without lazy behaviour.
+ *
+ * The grid arranges [itemCount] items into the given number of [columns] and
+ * invokes [content] for each index. Useful for small grids where the overhead
+ * of a `Lazy` component is unnecessary.
+ *
+ * @param columns Number of columns in the grid.
+ * @param itemCount Total number of items to show.
+ * @param modifier Modifier applied to the container.
+ * @param content Composable lambda called for each item index.
+ */
 @Composable
 fun NonLazyGrid(
-    columns : Int , itemCount : Int , modifier : Modifier = Modifier, content : @Composable (Int) -> Unit,
+    columns : Int ,
+    itemCount : Int ,
+    modifier : Modifier = Modifier,
+    content : @Composable (Int) -> Unit,
 ) {
     Column(  modifier = modifier) {
         val rows : Int = (itemCount + columns - 1) / columns

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/layouts/ScreenStateHandler.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/layouts/ScreenStateHandler.kt
@@ -16,8 +16,27 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import kotlinx.coroutines.delay
 
+/**
+ * Switches between different UI states with a fade animation.
+ *
+ * The handler observes [screenState] and renders the provided content
+ * based on its [ScreenState]. Loading and empty states receive their own
+ * composables while successful data is passed to [onSuccess].
+ *
+ * @param screenState The state holder describing screen status and data.
+ * @param onLoading Composable displayed while loading.
+ * @param onEmpty Composable shown when there is no data.
+ * @param onSuccess Composable invoked with loaded data on success.
+ * @param onError Optional composable shown when an error occurs.
+ */
 @Composable
-fun <T> ScreenStateHandler(screenState : UiStateScreen<T> , onLoading : @Composable () -> Unit , onEmpty : @Composable () -> Unit , onSuccess : @Composable (T) -> Unit , onError : (@Composable () -> Unit)? = null) {
+fun <T> ScreenStateHandler(
+    screenState : UiStateScreen<T> ,
+    onLoading : @Composable () -> Unit ,
+    onEmpty : @Composable () -> Unit ,
+    onSuccess : @Composable (T) -> Unit ,
+    onError : (@Composable () -> Unit)? = null
+) {
     var currentScreenState : ScreenState by remember { mutableStateOf(value = screenState.screenState) }
 
     LaunchedEffect(screenState.screenState) {

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/snackbar/DefaultSnackbarHandler.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/snackbar/DefaultSnackbarHandler.kt
@@ -13,8 +13,25 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiSnackbar
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.UiEvent
 
+/**
+ * Utility that shows snackbars described by [UiStateScreen.snackbar].
+ *
+ * The snackbar is displayed using [snackbarHostState]. When it is dismissed,
+ * [getDismissEvent] is invoked to build an event that is forwarded to
+ * [onEvent]. This allows view models to react once the snackbar disappears.
+ *
+ * @param screenState Screen state containing the snackbar information.
+ * @param snackbarHostState Host state that renders the snackbar.
+ * @param getDismissEvent Factory for an event triggered on dismissal.
+ * @param onEvent Callback receiving the event created by [getDismissEvent].
+ */
 @Composable
-fun <T , E : UiEvent> DefaultSnackbarHandler(screenState : UiStateScreen<T> , snackbarHostState : SnackbarHostState , getDismissEvent : (() -> E)? = null , onEvent : ((E) -> Unit)? = null) {
+fun <T , E : UiEvent> DefaultSnackbarHandler(
+    screenState : UiStateScreen<T> ,
+    snackbarHostState : SnackbarHostState ,
+    getDismissEvent : (() -> E)? = null ,
+    onEvent : ((E) -> Unit)? = null
+) {
     val context : Context = LocalContext.current
 
     LaunchedEffect(key1 = screenState.snackbar?.timeStamp) {

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/snackbar/DefaultSnackbarHost.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/snackbar/DefaultSnackbarHost.kt
@@ -27,6 +27,15 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.CustomSnackbarVisua
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 
+/**
+ * Material 3 [SnackbarHost] tailored for [CustomSnackbarVisuals].
+ *
+ * The host renders a dismiss action with sound and haptic feedback and
+ * applies custom colors when the snackbar represents an error.
+ *
+ * @param snackbarState State that holds the current snackbar data.
+ * @param modifier Modifier applied to the [SnackbarHost].
+ */
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun DefaultSnackbarHost(snackbarState : SnackbarHostState , modifier : Modifier = Modifier) {


### PR DESCRIPTION
## Summary
- document LoadingScreen and NoDataScreen
- add KDoc for ScreenStateHandler, NonLazyGrid and snackbar helpers

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c6860aa118832d987fbdaeec69cdb4