### PR TITLE
test: add navigation host startup route tests

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -164,7 +164,9 @@ dependencies {
 
     // Unit Tests
     testImplementation(dependencyNotation = libs.bundles.unitTest)
+    testImplementation(dependencyNotation = libs.androidx.navigation.testing)
     testRuntimeOnly(dependencyNotation = libs.bundles.unitTestRuntime)
+    testRuntimeOnly(dependencyNotation = libs.junit.vintage.engine)
 
     // Instrumentation Tests
     androidTestImplementation(dependencyNotation = libs.bundles.instrumentationTest)

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/main/ui/components/navigation/AppNavigationHostTest.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/main/ui/components/navigation/AppNavigationHostTest.kt
@@ -1,0 +1,79 @@
+package com.d4rk.android.apps.apptoolkit.app.main.ui.components.navigation
+
+import androidx.compose.foundation.layout.PaddingValues
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.navigation.compose.ComposeNavigator
+import androidx.navigation.testing.TestNavHostController
+import com.d4rk.android.apps.apptoolkit.core.data.datastore.DataStore
+import com.d4rk.android.apps.apptoolkit.app.main.utils.constants.NavigationRoutes
+import com.google.common.truth.Truth.assertThat
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.flow.flowOf
+import org.junit.After
+import org.junit.Rule
+import org.junit.Test
+import org.koin.core.context.startKoin
+import org.koin.core.context.stopKoin
+import org.koin.dsl.module
+
+class AppNavigationHostTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    private lateinit var navController: TestNavHostController
+
+    @After
+    fun tearDown() {
+        stopKoin()
+    }
+
+    @Test
+    fun startDestinationUsesStartupRouteFromDataStore() {
+        val dataStore = mockk<DataStore> {
+            every { getStartupPage(default = any()) } returns flowOf(NavigationRoutes.ROUTE_FAVORITE_APPS)
+        }
+        startKoin { modules(module { single<DataStore> { dataStore } }) }
+
+        composeRule.setContent {
+            val context = LocalContext.current
+            navController = TestNavHostController(context)
+            navController.navigatorProvider.addNavigator(ComposeNavigator())
+            AppNavigationHost(
+                navController = navController,
+                snackbarHostState = SnackbarHostState(),
+                paddingValues = PaddingValues()
+            )
+        }
+
+        composeRule.runOnIdle {
+            assertThat(navController.graph.startDestinationRoute).isEqualTo(NavigationRoutes.ROUTE_FAVORITE_APPS)
+        }
+    }
+
+    @Test
+    fun blankStartupRouteDefaultsToAppsList() {
+        val dataStore = mockk<DataStore> {
+            every { getStartupPage(default = any()) } returns flowOf("")
+        }
+        startKoin { modules(module { single<DataStore> { dataStore } }) }
+
+        composeRule.setContent {
+            val context = LocalContext.current
+            navController = TestNavHostController(context)
+            navController.navigatorProvider.addNavigator(ComposeNavigator())
+            AppNavigationHost(
+                navController = navController,
+                snackbarHostState = SnackbarHostState(),
+                paddingValues = PaddingValues()
+            )
+        }
+
+        composeRule.runOnIdle {
+            assertThat(navController.graph.startDestinationRoute).isEqualTo(NavigationRoutes.ROUTE_APPS_LIST)
+        }
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -61,6 +61,7 @@ androidx-activity-compose = { group = "androidx.activity", name = "activity-comp
 androidx-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "composeMaterial3" }
 androidx-navigation-compose = { group = "androidx.navigation", name = "navigation-compose", version.ref = "navigationCompose" }
+androidx-navigation-testing = { group = "androidx.navigation", name = "navigation-testing", version.ref = "navigationCompose" }
 
 # Lifecycle
 androidx-lifecycle-runtime-ktx = { group = "androidx.lifecycle", name = "lifecycle-runtime-ktx", version.ref = "lifecycle" }
@@ -114,6 +115,7 @@ core = { module = "io.noties.markwon:core", version.ref = "core" }
 test-koin-junit5 = { module = "io.insert-koin:koin-test-junit5", version.ref = "koin" }
 jupiter-api = { module = "org.junit.jupiter:junit-jupiter-api", version.ref = "jupiter" }
 jupiter-engine = { module = "org.junit.jupiter:junit-jupiter-engine", version.ref = "jupiter" }
+junit-vintage-engine = { module = "org.junit.vintage:junit-vintage-engine", version.ref = "jupiter" }
 jupiter-params = { module = "org.junit.jupiter:junit-jupiter-params", version.ref = "jupiter" }
 mockk-api = { module = "io.mockk:mockk", version.ref = "mockk" }
 test-kotlin-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "testCorutines" }


### PR DESCRIPTION
## Summary
- test AppNavigationHost uses startup route from DataStore
- verify default apps list route when startup route blank
- add navigation-testing and JUnit vintage dependencies for tests

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c81ef3fb74832db070bcea7bf2b24c