### PR TITLE
test: add theme datastore test

### DIFF
--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/data/datastore/CommonDataStoreThemeTest.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/data/datastore/CommonDataStoreThemeTest.kt
@@ -1,0 +1,38 @@
+package com.d4rk.android.libs.apptoolkit.data.datastore
+
+import android.content.Context
+import androidx.test.core.app.ApplicationProvider
+import com.d4rk.android.libs.apptoolkit.core.di.TestDispatchers
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.datastore.DataStoreNamesConstants
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Test
+
+class CommonDataStoreThemeTest {
+
+    @Test
+    fun `saving theme mode emits value and updates state`() = runTest {
+        val context = ApplicationProvider.getApplicationContext<Context>()
+        val commonDataStore = CommonDataStore(context, TestDispatchers(testScheduler))
+
+        val job = launch {
+            commonDataStore.themeMode.collect { mode ->
+                commonDataStore.themeModeState.value = mode
+            }
+        }
+
+        val expected = DataStoreNamesConstants.THEME_MODE_DARK
+        commonDataStore.saveThemeMode(expected)
+        advanceUntilIdle()
+
+        val actual = commonDataStore.themeMode.first()
+        assertThat(actual).isEqualTo(expected)
+        assertThat(commonDataStore.themeModeState.value).isEqualTo(expected)
+
+        job.cancel()
+        commonDataStore.close()
+    }
+}
+


### PR DESCRIPTION
## Summary
- add unit test verifying theme mode persistence in CommonDataStore

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c81ef53160832d96308eb8d7d9c7d2