### PR TITLE
Improve MainViewModel unit tests

### DIFF
--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainViewModelTest.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainViewModelTest.kt
@@ -2,80 +2,106 @@ package com.d4rk.android.apps.apptoolkit.app.main.ui
 
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.dp
-import app.cash.turbine.test
+import com.d4rk.android.apps.apptoolkit.app.main.domain.model.ui.UiMainScreen
 import com.d4rk.android.libs.apptoolkit.app.main.domain.repository.NavigationRepository
 import com.d4rk.android.libs.apptoolkit.core.domain.model.navigation.NavigationDrawerItem
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
+import com.google.common.truth.Truth.assertThat
+import io.mockk.clearAllMocks
+import io.mockk.every
+import io.mockk.mockk
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
-import kotlinx.coroutines.flow.flatMapConcat
+import kotlinx.coroutines.cancelAndJoin
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.merge
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
 import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
-import kotlin.test.assertEquals
 
 @OptIn(ExperimentalCoroutinesApi::class)
 class MainViewModelTest {
 
-    private class FakeMainRepository : NavigationRepository {
-        val itemsFlow = MutableSharedFlow<List<NavigationDrawerItem>>(replay = 1)
-        private val errorFlow = MutableSharedFlow<Throwable>(replay = 1)
+    private val dispatcher = StandardTestDispatcher()
+    private lateinit var navigationRepository: NavigationRepository
 
-        override fun getNavigationDrawerItems(): Flow<List<NavigationDrawerItem>> =
-            merge(
-                itemsFlow,
-                errorFlow.flatMapConcat { throwable -> flow { throw throwable } }
-            )
+    @BeforeEach
+    fun setUp() {
+        navigationRepository = mockk()
+        Dispatchers.setMain(dispatcher)
+    }
 
-        suspend fun emitItems(items: List<NavigationDrawerItem>) {
-            itemsFlow.emit(items)
-        }
-
-        suspend fun emitError(throwable: Throwable) {
-            errorFlow.emit(throwable)
-        }
+    @AfterEach
+    fun tearDown() {
+        clearAllMocks()
+        Dispatchers.resetMain()
     }
 
     @Test
-    fun `emitting items updates navigation drawer items`() = runTest {
-        val repository = FakeMainRepository()
-        val viewModel = MainViewModel(repository)
-        advanceUntilIdle()
-        val icon = ImageVector.Builder(
-            name = "test",
-            defaultWidth = 24.dp,
-            defaultHeight = 24.dp,
-            viewportWidth = 24f,
-            viewportHeight = 24f
-        ).build()
-        val items = listOf(NavigationDrawerItem(title = 1, selectedIcon = icon, route = "route"))
+    fun `loadNavigationItems updates navigation drawer items`() = runTest(dispatcher.scheduler) {
+        val expectedItems = listOf(
+            NavigationDrawerItem(title = 1, selectedIcon = createIcon(), route = "route-1"),
+            NavigationDrawerItem(title = 2, selectedIcon = createIcon(), route = "route-2"),
+        )
 
-        viewModel.uiState.test {
-            awaitItem() // initial state
-            repository.emitItems(items)
-            val updated = awaitItem()
-            assertEquals(items, updated.data?.navigationDrawerItems)
-            cancelAndIgnoreRemainingEvents()
-        }
+        every { navigationRepository.getNavigationDrawerItems() } returns flowOf(expectedItems)
+
+        val viewModel = TestMainViewModel(navigationRepository)
+        val collectedStates = mutableListOf<UiMainScreen?>()
+        val job = launch { viewModel.exposedScreenState().collect { collectedStates.add(it.data) } }
+
+        advanceUntilIdle()
+
+        assertThat(collectedStates).isNotEmpty()
+        val latestState = collectedStates.last()
+        assertThat(latestState).isNotNull()
+        assertThat(latestState!!.navigationDrawerItems).isEqualTo(expectedItems)
+        assertThat(latestState.showSnackbar).isFalse()
+
+        job.cancelAndJoin()
     }
 
     @Test
-    fun `emitting error shows snackbar`() = runTest {
-        val repository = FakeMainRepository()
-        val viewModel = MainViewModel(repository)
-        advanceUntilIdle()
-        val error = RuntimeException("boom")
-
-        viewModel.uiState.test {
-            awaitItem() // initial state
-            repository.emitError(error)
-            val updated = awaitItem()
-            assertEquals(true, updated.data?.showSnackbar)
-            assertEquals("boom", updated.data?.snackbarMessage)
-            cancelAndIgnoreRemainingEvents()
+    fun `loadNavigationItems failure shows snackbar`() = runTest(dispatcher.scheduler) {
+        val errorMessage = "Failed to fetch navigation"
+        every { navigationRepository.getNavigationDrawerItems() } returns flow {
+            throw IllegalStateException(errorMessage)
         }
+
+        val viewModel = TestMainViewModel(navigationRepository)
+        val collectedStates = mutableListOf<UiMainScreen?>()
+        val job = launch { viewModel.exposedScreenState().collect { collectedStates.add(it.data) } }
+
+        advanceUntilIdle()
+
+        assertThat(collectedStates).isNotEmpty()
+        val latestState = collectedStates.last()
+        assertThat(latestState).isNotNull()
+        assertThat(latestState!!.showSnackbar).isTrue()
+        assertThat(latestState.snackbarMessage).isEqualTo(errorMessage)
+
+        job.cancelAndJoin()
+    }
+
+    private fun createIcon(): ImageVector = ImageVector.Builder(
+        name = "test",
+        defaultWidth = 24.dp,
+        defaultHeight = 24.dp,
+        viewportWidth = 24f,
+        viewportHeight = 24f
+    ).build()
+
+    private class TestMainViewModel(
+        navigationRepository: NavigationRepository,
+    ) : MainViewModel(navigationRepository) {
+        fun exposedScreenState(): MutableStateFlow<UiStateScreen<UiMainScreen>> = screenState
     }
 }
-


### PR DESCRIPTION
## Summary
- replace `MainViewModelTest` with MockK-based tests that exercise the repository integration
- assert that navigation drawer items propagate into the screen state when the repository emits data
- verify snackbar visibility and message when the repository flow throws an exception

## Testing
- `./gradlew test` *(fails: Android SDK not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c84788b804832d84033a311f7bf4a4