### PR TITLE
Add Robolectric tests for MainActivity consent flow

### DIFF
--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainActivityTest.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainActivityTest.kt
@@ -1,0 +1,134 @@
+
+package com.d4rk.android.apps.apptoolkit.app.main.ui
+
+import androidx.lifecycle.lifecycleScope
+import com.d4rk.android.apps.apptoolkit.core.data.datastore.DataStore
+import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
+import com.d4rk.android.libs.apptoolkit.core.utils.helpers.ConsentFormHelper
+import com.google.android.ump.ConsentInformation
+import com.google.android.ump.UserMessagingPlatform
+import io.mockk.Runs
+import io.mockk.every
+import io.mockk.just
+import io.mockk.mockk
+import io.mockk.mockkObject
+import io.mockk.mockkStatic
+import io.mockk.unmockkAll
+import io.mockk.verify
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertDoesNotThrow
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+import org.robolectric.Robolectric
+import org.robolectric.junit5.RobolectricExtension
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@ExtendWith(RobolectricExtension::class)
+class MainActivityTest {
+
+    private var mainDispatcherSet: Boolean = false
+
+    @BeforeEach
+    fun setUp() {
+        mockkStatic(UserMessagingPlatform::class)
+        mockkObject(ConsentFormHelper)
+    }
+
+    @AfterEach
+    fun tearDown() {
+        if (mainDispatcherSet) {
+            Dispatchers.resetMain()
+            mainDispatcherSet = false
+        }
+        unmockkAll()
+    }
+
+    @Test
+    fun `checkUserConsent shows consent form when consent info is available`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        Dispatchers.setMain(dispatcher)
+        mainDispatcherSet = true
+
+        val activity = Robolectric.buildActivity(MainActivity::class.java).get().apply {
+            overrideDispatcherProvider(TestDispatcherProvider(dispatcher))
+            overrideDataStore(mockk(relaxed = true))
+        }
+
+        val consentInfo = mockk<ConsentInformation>()
+        every { UserMessagingPlatform.getConsentInformation(activity) } returns consentInfo
+        every { ConsentFormHelper.showConsentFormIfRequired(activity, consentInfo) } just Runs
+
+        invokeCheckUserConsent(activity)
+        advanceUntilIdle()
+
+        verify(exactly = 1) { UserMessagingPlatform.getConsentInformation(activity) }
+        verify(exactly = 1) { ConsentFormHelper.showConsentFormIfRequired(activity, consentInfo) }
+    }
+
+    @Test
+    fun `checkUserConsent completes when consent information throws`() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        Dispatchers.setMain(dispatcher)
+        mainDispatcherSet = true
+
+        val activity = Robolectric.buildActivity(MainActivity::class.java).get().apply {
+            overrideDispatcherProvider(TestDispatcherProvider(dispatcher))
+            overrideDataStore(mockk(relaxed = true))
+        }
+
+        val failure = IllegalStateException("failed to load consent information")
+        every { UserMessagingPlatform.getConsentInformation(activity) } throws failure
+        every { ConsentFormHelper.showConsentFormIfRequired(any(), any()) } just Runs
+
+        assertDoesNotThrow {
+            invokeCheckUserConsent(activity)
+            advanceUntilIdle()
+        }
+
+        verify(exactly = 1) { UserMessagingPlatform.getConsentInformation(activity) }
+        verify(exactly = 0) { ConsentFormHelper.showConsentFormIfRequired(any(), any()) }
+
+        val parentJob = activity.lifecycleScope.coroutineContext[Job]
+        assertNotNull(parentJob)
+        assertTrue(parentJob.children.none { it.isActive })
+    }
+}
+
+private fun MainActivity.overrideDispatcherProvider(provider: DispatcherProvider) {
+    val field = MainActivity::class.java.getDeclaredField("dispatchers$delegate")
+    field.isAccessible = true
+    field.set(this, lazyOf(provider))
+}
+
+private fun MainActivity.overrideDataStore(dataStore: DataStore) {
+    val field = MainActivity::class.java.getDeclaredField("dataStore$delegate")
+    field.isAccessible = true
+    field.set(this, lazyOf(dataStore))
+}
+
+private fun invokeCheckUserConsent(activity: MainActivity) {
+    val method = MainActivity::class.java.getDeclaredMethod("checkUserConsent")
+    method.isAccessible = true
+    method.invoke(activity)
+}
+
+private class TestDispatcherProvider(
+    private val dispatcher: CoroutineDispatcher
+) : DispatcherProvider {
+    override val main: CoroutineDispatcher = dispatcher
+    override val io: CoroutineDispatcher = dispatcher
+    override val default: CoroutineDispatcher = dispatcher
+    override val unconfined: CoroutineDispatcher = dispatcher
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,7 @@ testTurbine = "1.2.1"
 truth = "1.7.0"
 testManifestTestJunit4Android = "1.9.1"
 slf4j = "2.0.17"
+robolectric = "4.14.1"
 
 [libraries]
 # AndroidX & Material
@@ -120,6 +121,7 @@ test-kotlin-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-te
 test-turbine = { module = "app.cash.turbine:turbine", version.ref = "testTurbine" }
 androidx-truth = { module = "androidx.test.ext:truth", version.ref = "truth" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 
 # Instrumentation Tests (androidTest folder)
 mockk-android = { module = "io.mockk:mockk-android", version.ref = "mockk" }
@@ -154,6 +156,7 @@ unitTest = [
     "test-kotlin-coroutines",
     "test-turbine",
     "test-koin-junit5",
+    "robolectric",
     "androidx-truth",
     "ktor-client-mock",
     "slf4j-simple"


### PR DESCRIPTION
## Summary
- add Robolectric-based unit coverage for MainActivity's consent flow, mocking UserMessagingPlatform to validate success and failure paths
- register the Robolectric dependency for unit tests via the shared Gradle version catalog

## Testing
- ./gradlew test *(fails: SDK location not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c8478e30d0832da864ab24d00ccfd2