### PR TITLE
Add tests for FetchDeveloperAppsUseCase flow and error handling

### DIFF
--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/usecases/FetchDeveloperAppsUseCaseTest.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/usecases/FetchDeveloperAppsUseCaseTest.kt
@@ -4,47 +4,57 @@ import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.repository.DeveloperAppsRepository
 import com.d4rk.android.apps.apptoolkit.core.domain.model.network.Errors
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flow
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.RootError
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.flow.asFlow
 import kotlinx.coroutines.flow.toList
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 import kotlin.test.assertEquals
-import kotlin.test.assertTrue
+import kotlin.test.assertFailsWith
+import kotlin.test.assertSame
 
 class FetchDeveloperAppsUseCaseTest {
 
     @Test
-    fun `invoke emits loading then success`() = runTest {
+    fun `use case prepends loading state to repository emissions`() = runTest {
         val apps = listOf(AppInfo(name = "App", packageName = "pkg", iconUrl = "icon"))
-        val repository = object : DeveloperAppsRepository {
-            override fun fetchDeveloperApps(): Flow<DataState<List<AppInfo>, Errors>> =
-                flow { emit(DataState.Success(apps)) }
+        val repositoryEmissions = listOf<DataState<List<AppInfo>, Errors>>(
+            DataState.Success<List<AppInfo>, Errors>(apps),
+            DataState.Error<List<AppInfo>, Errors>(error = Errors.Network.REQUEST_TIMEOUT),
+        )
+        val repository = mockk<DeveloperAppsRepository> {
+            every { fetchDeveloperApps() } returns repositoryEmissions.asFlow()
         }
         val useCase = FetchDeveloperAppsUseCase(repository)
 
-        val emissions = useCase().toList()
+        val result = useCase().toList()
 
-        assertEquals(2, emissions.size)
-        assertTrue(emissions[0] is DataState.Loading)
-        val success = emissions[1] as DataState.Success
-        assertEquals(apps, success.data)
+        val expected = mutableListOf<DataState<List<AppInfo>, RootError>>(
+            DataState.Loading<List<AppInfo>, RootError>(),
+        )
+        expected.addAll(repositoryEmissions)
+
+        assertEquals(expected, result)
+        verify(exactly = 1) { repository.fetchDeveloperApps() }
     }
 
     @Test
-    fun `invoke emits error when repository fails`() = runTest {
-        val repository = object : DeveloperAppsRepository {
-            override fun fetchDeveloperApps(): Flow<DataState<List<AppInfo>, Errors>> =
-                flow { emit(DataState.Error(error = Errors.Network.REQUEST_TIMEOUT)) }
+    fun `use case propagates synchronous repository exceptions`() = runTest {
+        val exception = IllegalStateException("boom")
+        val repository = mockk<DeveloperAppsRepository> {
+            every { fetchDeveloperApps() } throws exception
         }
         val useCase = FetchDeveloperAppsUseCase(repository)
 
-        val emissions = useCase().toList()
+        val thrown = assertFailsWith<IllegalStateException> {
+            useCase()
+        }
 
-        assertEquals(2, emissions.size)
-        assertTrue(emissions[0] is DataState.Loading)
-        val errorState = emissions[1] as DataState.Error
-        assertEquals(Errors.Network.REQUEST_TIMEOUT, errorState.error)
+        assertSame(exception, thrown)
+        verify(exactly = 1) { repository.fetchDeveloperApps() }
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure the fetch use case emits a loading state before the repository flow
- verify synchronous repository exceptions are propagated to callers

## Testing
- ./gradlew test *(fails: Android SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c891ae4208832d811f889f46d561bd