### PR TITLE
test: add DataStore unit test

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -165,6 +165,8 @@ dependencies {
     // Unit Tests
     testImplementation(dependencyNotation = libs.bundles.unitTest)
     testRuntimeOnly(dependencyNotation = libs.bundles.unitTestRuntime)
+    testImplementation(dependencyNotation = libs.robolectric)
+    testImplementation(dependencyNotation = libs.junit4)
 
     // Instrumentation Tests
     androidTestImplementation(dependencyNotation = libs.bundles.instrumentationTest)

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/core/data/datastore/DataStoreTest.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/core/data/datastore/DataStoreTest.kt
@@ -1,0 +1,50 @@
+package com.d4rk.android.apps.apptoolkit.core.data.datastore
+
+import android.app.Application
+import androidx.datastore.preferences.preferencesDataStoreFile
+import androidx.test.core.app.ApplicationProvider
+import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.datastore.DataStoreNamesConstants
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+
+@OptIn(ExperimentalCoroutinesApi::class)
+@RunWith(RobolectricTestRunner::class)
+class DataStoreTest {
+
+    @Test
+    fun dataStorePersistsThemeModePreference() = runTest {
+        val dispatcher = StandardTestDispatcher(testScheduler)
+        val context = ApplicationProvider.getApplicationContext<Application>()
+        val dispatchers = TestDispatcherProvider(dispatcher)
+        val dataStore = DataStore(context = context, dispatchers = dispatchers)
+
+        try {
+            val expectedTheme = "dark"
+
+            dataStore.saveThemeMode(mode = expectedTheme)
+            val storedTheme = dataStore.themeMode.first()
+
+            assertEquals(expectedTheme, storedTheme)
+        } finally {
+            dataStore.close()
+            context.preferencesDataStoreFile(DataStoreNamesConstants.DATA_STORE_SETTINGS).delete()
+        }
+    }
+
+    private class TestDispatcherProvider(
+        private val dispatcher: CoroutineDispatcher,
+    ) : DispatcherProvider {
+        override val main: CoroutineDispatcher get() = dispatcher
+        override val io: CoroutineDispatcher get() = dispatcher
+        override val default: CoroutineDispatcher get() = dispatcher
+        override val unconfined: CoroutineDispatcher get() = dispatcher
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -41,6 +41,8 @@ testTurbine = "1.2.1"
 truth = "1.7.0"
 testManifestTestJunit4Android = "1.9.1"
 slf4j = "2.0.17"
+robolectric = "4.9.2"
+junit4 = "4.13.2"
 
 [libraries]
 # AndroidX & Material
@@ -120,6 +122,8 @@ test-kotlin-coroutines = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-te
 test-turbine = { module = "app.cash.turbine:turbine", version.ref = "testTurbine" }
 androidx-truth = { module = "androidx.test.ext:truth", version.ref = "truth" }
 slf4j-simple = { module = "org.slf4j:slf4j-simple", version.ref = "slf4j" }
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+junit4 = { module = "junit:junit", version.ref = "junit4" }
 
 # Instrumentation Tests (androidTest folder)
 mockk-android = { module = "io.mockk:mockk-android", version.ref = "mockk" }


### PR DESCRIPTION
## Summary
- add a Robolectric-based unit test that instantiates the app DataStore with test dispatchers and verifies it saves and reads preferences through the CommonDataStore API
- wire the project with Robolectric and JUnit4 dependencies so the JVM test can obtain an Application context

## Testing
- ./gradlew test --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68c891b0cb78832d89113582c6d84feb