### PR TITLE
Add clipboard helper unit tests

### DIFF
--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/ClipboardHelperTest.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/ClipboardHelperTest.kt
@@ -1,0 +1,76 @@
+package com.d4rk.android.libs.apptoolkit.core.utils.helpers
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.os.Build
+import io.mockk.every
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.slot
+import io.mockk.unmockkStatic
+import io.mockk.verify
+import org.junit.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class ClipboardHelperTest {
+
+    @Test
+    fun `copyTextToClipboard copies text and invokes callback for API 32`() {
+        val context = mockk<Context>()
+        val clipboardManager = mockk<ClipboardManager>()
+        every { context.getSystemService(Context.CLIPBOARD_SERVICE) } returns clipboardManager
+
+        val clipDataSlot = slot<ClipData>()
+        justRun { clipboardManager.setPrimaryClip(capture(clipDataSlot)) }
+
+        mockkStatic(Build.VERSION::class)
+        try {
+            every { Build.VERSION.SDK_INT } returns Build.VERSION_CODES.S_V2
+
+            var callbackInvoked = false
+
+            ClipboardHelper.copyTextToClipboard(
+                context = context,
+                label = "label",
+                text = "text",
+                onShowSnackbar = { callbackInvoked = true },
+            )
+
+            verify(exactly = 1) { clipboardManager.setPrimaryClip(any()) }
+            assertEquals("label", clipDataSlot.captured.description.label)
+            assertEquals("text", clipDataSlot.captured.getItemAt(0).text)
+            assertTrue(callbackInvoked)
+        } finally {
+            unmockkStatic(Build.VERSION::class)
+        }
+    }
+
+    @Test
+    fun `copyTextToClipboard does nothing when clipboard service unavailable`() {
+        val context = mockk<Context>()
+        every { context.getSystemService(Context.CLIPBOARD_SERVICE) } returns null
+
+        mockkStatic(Build.VERSION::class)
+        try {
+            every { Build.VERSION.SDK_INT } returns Build.VERSION_CODES.S_V2
+
+            var callbackInvoked = false
+
+            ClipboardHelper.copyTextToClipboard(
+                context = context,
+                label = "label",
+                text = "text",
+                onShowSnackbar = { callbackInvoked = true },
+            )
+
+            verify(exactly = 1) { context.getSystemService(Context.CLIPBOARD_SERVICE) }
+            assertFalse(callbackInvoked)
+        } finally {
+            unmockkStatic(Build.VERSION::class)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests covering ClipboardHelper clipboard copy behavior
- verify callbacks fire on API 32 and skip when the clipboard service is missing

## Testing
- ./gradlew test *(fails: Android SDK not configured in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9193a6db4832da12d65a9d8145f51