### PR TITLE
Test default analytics for both build modes

### DIFF
--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestConsentManagerHelper.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/TestConsentManagerHelper.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.runTest
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
+import kotlin.test.assertTrue
 import org.junit.Test
 import org.koin.core.context.startKoin
 import org.koin.core.context.stopKoin
@@ -277,19 +278,22 @@ class TestConsentManagerHelper {
     }
 
     @Test
-    fun `defaultAnalyticsGranted false when debug build`() {
-        println("🚀 [TEST] defaultAnalyticsGranted false when debug build")
+    fun `defaultAnalyticsGranted matches inverse of debug mode`() {
+        println("🚀 [TEST] defaultAnalyticsGranted matches inverse of debug mode")
         val provider = mockk<BuildInfoProvider>()
-        every { provider.isDebugBuild } returns true
+        every { provider.isDebugBuild } returnsMany listOf(true, false)
         startKoin { modules(module { single<BuildInfoProvider> { provider } }) }
 
         val field = ConsentManagerHelper::class.java.getDeclaredField("defaultAnalyticsGranted\$delegate")
         field.isAccessible = true
-        field.set(ConsentManagerHelper, lazy { !provider.isDebugBuild })
 
+        field.set(ConsentManagerHelper, lazy { !provider.isDebugBuild })
         assertFalse(ConsentManagerHelper.defaultAnalyticsGranted)
 
+        field.set(ConsentManagerHelper, lazy { !provider.isDebugBuild })
+        assertTrue(ConsentManagerHelper.defaultAnalyticsGranted)
+
         stopKoin()
-        println("🏁 [TEST DONE] defaultAnalyticsGranted false when debug build")
+        println("🏁 [TEST DONE] defaultAnalyticsGranted matches inverse of debug mode")
     }
 }


### PR DESCRIPTION
## Summary
- update the ConsentManagerHelper unit test to mock BuildInfoProvider returning both debug and release states
- assert that defaultAnalyticsGranted flips relative to the mocked build type and add the corresponding assertion import

## Testing
- ./gradlew test *(fails: Android SDK not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c9193a6b68832dabf3dec0f1b27923