### PR TITLE
Add unit tests for Errors extensions and refine mappings

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/utils/extensions/Errors.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/utils/extensions/Errors.kt
@@ -1,7 +1,9 @@
 package com.d4rk.android.apps.apptoolkit.core.utils.extensions
 
 import android.database.sqlite.SQLiteException
+import com.d4rk.android.apps.apptoolkit.R as AppR
 import com.d4rk.android.apps.apptoolkit.core.domain.model.network.Errors
+import com.d4rk.android.libs.apptoolkit.R as ToolkitR
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
 import kotlinx.serialization.SerializationException
 import java.net.ConnectException
@@ -11,8 +13,18 @@ import java.sql.SQLException
 
 fun Errors.asUiText() : UiTextHelper {
     return when (this) {
-        // Network errors
-        else -> UiTextHelper.StringResource(com.d4rk.android.libs.apptoolkit.R.string.unknown_error)
+        Errors.Network.REQUEST_TIMEOUT ,
+        Errors.Network.NO_INTERNET ,
+        Errors.Database.DATABASE_OPERATION_FAILED -> UiTextHelper.StringResource(ToolkitR.string.io_error)
+
+        Errors.Network.SERIALIZATION ,
+        Errors.UseCase.NO_DATA -> UiTextHelper.StringResource(ToolkitR.string.initialization_error)
+
+        Errors.UseCase.FAILED_TO_LOAD_APPS -> UiTextHelper.StringResource(AppR.string.error_failed_to_load_apps)
+
+        Errors.UseCase.ILLEGAL_ARGUMENT -> UiTextHelper.StringResource(ToolkitR.string.illegal_argument_error)
+
+        else -> UiTextHelper.StringResource(ToolkitR.string.unknown_error)
 
     }
 }

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/core/utils/extensions/ErrorsTest.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/core/utils/extensions/ErrorsTest.kt
@@ -1,0 +1,86 @@
+package com.d4rk.android.apps.apptoolkit.core.utils.extensions
+
+import android.database.sqlite.SQLiteException
+import com.d4rk.android.apps.apptoolkit.R as AppR
+import com.d4rk.android.apps.apptoolkit.core.domain.model.network.Errors
+import com.d4rk.android.libs.apptoolkit.R as ToolkitR
+import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
+import kotlinx.serialization.SerializationException
+import org.junit.Test
+import java.net.ConnectException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+import java.sql.SQLException
+import kotlin.test.assertEquals
+
+class ErrorsTest {
+
+    @Test
+    fun `asUiText maps network and database issues to io message`() {
+        val expected = FakeUiText.StringResource(ToolkitR.string.io_error)
+
+        assertEquals(expected, Errors.Network.REQUEST_TIMEOUT.asUiText().toFake())
+        assertEquals(expected, Errors.Network.NO_INTERNET.asUiText().toFake())
+        assertEquals(expected, Errors.Database.DATABASE_OPERATION_FAILED.asUiText().toFake())
+    }
+
+    @Test
+    fun `asUiText maps serialization and no data errors to initialization message`() {
+        val expected = FakeUiText.StringResource(ToolkitR.string.initialization_error)
+
+        assertEquals(expected, Errors.Network.SERIALIZATION.asUiText().toFake())
+        assertEquals(expected, Errors.UseCase.NO_DATA.asUiText().toFake())
+    }
+
+    @Test
+    fun `asUiText maps use case errors to specific text`() {
+        assertEquals(
+            FakeUiText.StringResource(AppR.string.error_failed_to_load_apps),
+            Errors.UseCase.FAILED_TO_LOAD_APPS.asUiText().toFake(),
+        )
+        assertEquals(
+            FakeUiText.StringResource(ToolkitR.string.illegal_argument_error),
+            Errors.UseCase.ILLEGAL_ARGUMENT.asUiText().toFake(),
+        )
+    }
+
+    @Test
+    fun `asUiText falls back to unknown error for unhandled types`() {
+        val unknownError = object : Errors {}
+
+        assertEquals(
+            FakeUiText.StringResource(ToolkitR.string.unknown_error),
+            unknownError.asUiText().toFake(),
+        )
+    }
+
+    @Test
+    fun `toError maps known throwable types`() {
+        assertEquals(Errors.Network.NO_INTERNET, UnknownHostException().toError())
+        assertEquals(Errors.Network.NO_INTERNET, ConnectException().toError())
+        assertEquals(Errors.Network.REQUEST_TIMEOUT, SocketTimeoutException().toError())
+        assertEquals(Errors.Network.SERIALIZATION, SerializationException("boom").toError())
+        assertEquals(Errors.Database.DATABASE_OPERATION_FAILED, SQLException().toError())
+        assertEquals(Errors.Database.DATABASE_OPERATION_FAILED, SQLiteException().toError())
+        assertEquals(Errors.UseCase.ILLEGAL_ARGUMENT, IllegalArgumentException().toError())
+    }
+
+    @Test
+    fun `toError returns provided default for unknown throwable`() {
+        val default = Errors.UseCase.FAILED_TO_LOAD_APPS
+
+        assertEquals(default, IllegalStateException().toError(default))
+    }
+
+    private fun UiTextHelper.toFake() : FakeUiText {
+        return when (this) {
+            is UiTextHelper.DynamicString -> FakeUiText.DynamicString(content)
+            is UiTextHelper.StringResource -> FakeUiText.StringResource(resourceId)
+        }
+    }
+
+    private sealed interface FakeUiText {
+        data class DynamicString(val value : String) : FakeUiText
+        data class StringResource(val id : Int) : FakeUiText
+    }
+}


### PR DESCRIPTION
## Summary
- map each core `Errors` variant to a concrete `UiTextHelper.StringResource`
- cover the `Errors.asUiText` and `Throwable.toError` helpers with JVM unit tests using fake UI text stubs

## Testing
- `./gradlew test --console=plain` *(fails: SDK packages missing / licenses not accepted in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c91915333c832da6d2e53c538cb02c