### PR TITLE
Update CI workflow to run module test tasks

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -6,6 +6,10 @@ on:
   pull_request:
     branches: [ "master" ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
 
@@ -23,4 +27,4 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle
-        run: ./gradlew build
+        run: ./gradlew :app:testDebugUnitTest :app:testReleaseUnitTest :apptoolkit:testDebugUnitTest :apptoolkit:testReleaseUnitTest :app:test :apptoolkit:test


### PR DESCRIPTION
## Summary
- add a workflow concurrency group to cancel outdated CI runs
- run explicit app and apptoolkit unit-test Gradle tasks in CI while keeping JDK 21 setup

## Testing
- ⚠️ `./gradlew test` *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c92131c044832db735cafe9b7d550e