### PR TITLE
Add unit tests for Result wrapper

### DIFF
--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/domain/model/ResultTest.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/domain/model/ResultTest.kt
@@ -1,0 +1,48 @@
+package com.d4rk.android.libs.apptoolkit.core.domain.model
+
+import com.google.common.truth.Truth.assertThat
+import org.junit.Test
+
+class ResultTest {
+
+    @Test
+    fun `Success retains provided data`() {
+        val success = Result.Success("payload")
+
+        assertThat(success.data).isEqualTo("payload")
+        val (captured) = success
+        assertThat(captured).isEqualTo("payload")
+    }
+
+    @Test
+    fun `Error retains provided exception`() {
+        val exception = IllegalStateException("boom")
+
+        val error = Result.Error(exception)
+
+        assertThat(error.exception).isSameInstanceAs(exception)
+        val (captured) = error
+        assertThat(captured).isSameInstanceAs(exception)
+    }
+
+    @Test
+    fun `Success equality depends on wrapped data`() {
+        val first = Result.Success("data")
+        val second = Result.Success("data")
+        val third = Result.Success("other")
+
+        assertThat(first).isEqualTo(second)
+        assertThat(first).isNotEqualTo(third)
+    }
+
+    @Test
+    fun `Error equality compares underlying exception`() {
+        val exception = IllegalArgumentException("invalid")
+        val first = Result.Error(exception)
+        val second = Result.Error(exception)
+        val third = Result.Error(IllegalArgumentException("invalid"))
+
+        assertThat(first).isEqualTo(second)
+        assertThat(first).isNotEqualTo(third)
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests to confirm Result.Success exposes its data and supports destructuring
- add tests verifying Result.Error retains the original exception and equality contracts
- cover equality comparisons for both Result.Success and Result.Error variants

## Testing
- ./gradlew test *(fails: SDK location not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9767dfc0c832dab0259f20e840b77