### PR TITLE
test: add clipboard helper coverage

### DIFF
--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/ClipboardHelperTest.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/ClipboardHelperTest.kt
@@ -4,6 +4,7 @@ import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import android.os.Build
+import android.util.Log
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
@@ -41,8 +42,8 @@ class ClipboardHelperTest {
             )
 
             verify(exactly = 1) { clipboardManager.setPrimaryClip(any()) }
-            assertEquals("label", clipDataSlot.captured.description.label)
-            assertEquals("text", clipDataSlot.captured.getItemAt(0).text)
+            assertEquals("label", clipDataSlot.captured.description.label.toString())
+            assertEquals("text", clipDataSlot.captured.getItemAt(0).text.toString())
             assertTrue(callbackInvoked)
         } finally {
             unmockkStatic(Build.VERSION::class)
@@ -50,13 +51,17 @@ class ClipboardHelperTest {
     }
 
     @Test
-    fun `copyTextToClipboard does nothing when clipboard service unavailable`() {
+    fun `copyTextToClipboard does not invoke callback on API above 32`() {
         val context = mockk<Context>()
-        every { context.getSystemService(Context.CLIPBOARD_SERVICE) } returns null
+        val clipboardManager = mockk<ClipboardManager>()
+        every { context.getSystemService(Context.CLIPBOARD_SERVICE) } returns clipboardManager
+
+        val clipDataSlot = slot<ClipData>()
+        justRun { clipboardManager.setPrimaryClip(capture(clipDataSlot)) }
 
         mockkStatic(Build.VERSION::class)
         try {
-            every { Build.VERSION.SDK_INT } returns Build.VERSION_CODES.S_V2
+            every { Build.VERSION.SDK_INT } returns Build.VERSION_CODES.TIRAMISU
 
             var callbackInvoked = false
 
@@ -67,10 +72,37 @@ class ClipboardHelperTest {
                 onShowSnackbar = { callbackInvoked = true },
             )
 
-            verify(exactly = 1) { context.getSystemService(Context.CLIPBOARD_SERVICE) }
+            verify(exactly = 1) { clipboardManager.setPrimaryClip(any()) }
+            assertEquals("label", clipDataSlot.captured.description.label.toString())
+            assertEquals("text", clipDataSlot.captured.getItemAt(0).text.toString())
             assertFalse(callbackInvoked)
         } finally {
             unmockkStatic(Build.VERSION::class)
+        }
+    }
+
+    @Test
+    fun `copyTextToClipboard logs warning when clipboard service unavailable`() {
+        val context = mockk<Context>()
+        every { context.getSystemService(Context.CLIPBOARD_SERVICE) } returns null
+
+        mockkStatic(Log::class)
+        try {
+            every { Log.w("ClipboardHelper", "Clipboard service unavailable") } returns 0
+
+            var callbackInvoked = false
+
+            ClipboardHelper.copyTextToClipboard(
+                context = context,
+                label = "label",
+                text = "text",
+                onShowSnackbar = { callbackInvoked = true },
+            )
+
+            assertFalse(callbackInvoked)
+            verify(exactly = 1) { Log.w("ClipboardHelper", "Clipboard service unavailable") }
+        } finally {
+            unmockkStatic(Log::class)
         }
     }
 }


### PR DESCRIPTION
## Summary
- add clipboard helper unit tests covering API 32-and-below clipboard behaviour
- ensure callbacks are skipped for newer APIs and warnings are emitted when the service is missing

## Testing
- ./gradlew test *(fails: missing Android SDK in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9766d9aa4832d8461634a24d65a35