### PR TITLE
Add helper intents for favorites broadcasts

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/broadcast/FavoritesChangedReceiver.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/broadcast/FavoritesChangedReceiver.kt
@@ -1,6 +1,7 @@
 package com.d4rk.android.apps.apptoolkit.core.broadcast
 
 import android.content.BroadcastReceiver
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.util.Log
@@ -8,12 +9,28 @@ import android.util.Log
 class FavoritesChangedReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent?) {
         val pkg = intent?.getStringExtra(EXTRA_PACKAGE_NAME)
-        Log.d(TAG, "Favorites changed: $pkg")
+        if (pkg.isNullOrEmpty()) {
+            Log.w(TAG, "Favorites changed intent missing package name extra")
+        } else {
+            Log.d(TAG, "Favorites changed: $pkg")
+        }
     }
 
     companion object {
         const val ACTION_FAVORITES_CHANGED = "com.d4rk.android.apps.apptoolkit.action.FAVORITES_CHANGED"
         const val EXTRA_PACKAGE_NAME = "extra_package_name"
         private const val TAG = "FavoritesChangedRcvr"
+
+        fun createIntentWithPackage(context: Context, packageName: String): Intent =
+            baseIntent(context).apply {
+                putExtra(EXTRA_PACKAGE_NAME, packageName)
+            }
+
+        fun createIntentWithoutPackage(context: Context): Intent = baseIntent(context)
+
+        private fun baseIntent(context: Context): Intent =
+            Intent(ACTION_FAVORITES_CHANGED).apply {
+                component = ComponentName(context, FavoritesChangedReceiver::class.java)
+            }
     }
 }

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/data/favorites/FavoritesRepositoryImpl.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/data/favorites/FavoritesRepositoryImpl.kt
@@ -1,8 +1,6 @@
 package com.d4rk.android.apps.apptoolkit.core.data.favorites
 
-import android.content.ComponentName
 import android.content.Context
-import android.content.Intent
 import android.util.Log
 import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.repository.FavoritesRepository
 import com.d4rk.android.apps.apptoolkit.core.broadcast.FavoritesChangedReceiver
@@ -22,10 +20,7 @@ class FavoritesRepositoryImpl(
     override suspend fun toggleFavorite(packageName: String) {
         withContext(dispatchers.io) {
             dataStore.toggleFavoriteApp(packageName)
-            val intent = Intent(FavoritesChangedReceiver.ACTION_FAVORITES_CHANGED).apply {
-                component = ComponentName(context, FavoritesChangedReceiver::class.java)
-                putExtra(FavoritesChangedReceiver.EXTRA_PACKAGE_NAME, packageName)
-            }
+            val intent = FavoritesChangedReceiver.createIntentWithPackage(context, packageName)
             runCatching {
                 context.sendBroadcast(intent)
             }.onFailure { e ->

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/core/broadcast/FavoritesChangedReceiverTest.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/core/broadcast/FavoritesChangedReceiverTest.kt
@@ -8,6 +8,8 @@ import io.mockk.mockk
 import io.mockk.mockkStatic
 import io.mockk.unmockkStatic
 import io.mockk.verify
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertDoesNotThrow
 
@@ -45,15 +47,42 @@ class FavoritesChangedReceiverTest {
         mockkStatic(Log::class)
         try {
             every { Log.d(any(), any()) } returns 0
+            every { Log.w(any(), any()) } returns 0
 
             assertDoesNotThrow {
                 receiver.onReceive(context, intent)
             }
 
             verify(exactly = 1) { intent.getStringExtra(FavoritesChangedReceiver.EXTRA_PACKAGE_NAME) }
-            verify { Log.d(any(), match { "Favorites changed:" in it }) }
+            verify { Log.w(any(), match { "missing package name" in it }) }
         } finally {
             unmockkStatic(Log::class)
         }
+    }
+
+    @Test
+    fun `createIntentWithPackage includes package name extra`() {
+        val context = mockk<Context> {
+            every { packageName } returns "com.example"
+        }
+
+        val packageName = "com.example.app"
+
+        val intent = FavoritesChangedReceiver.createIntentWithPackage(context, packageName)
+
+        assertEquals(FavoritesChangedReceiver.ACTION_FAVORITES_CHANGED, intent.action)
+        assertEquals(packageName, intent.getStringExtra(FavoritesChangedReceiver.EXTRA_PACKAGE_NAME))
+    }
+
+    @Test
+    fun `createIntentWithoutPackage omits package name extra`() {
+        val context = mockk<Context> {
+            every { packageName } returns "com.example"
+        }
+
+        val intent = FavoritesChangedReceiver.createIntentWithoutPackage(context)
+
+        assertEquals(FavoritesChangedReceiver.ACTION_FAVORITES_CHANGED, intent.action)
+        assertFalse(intent.hasExtra(FavoritesChangedReceiver.EXTRA_PACKAGE_NAME))
     }
 }


### PR DESCRIPTION
## Summary
- add helper methods on `FavoritesChangedReceiver` to provide intents both with and without the package extra and improve logging when the extra is missing
- update `FavoritesRepositoryImpl` to reuse the new helper when broadcasting favorite changes
- expand receiver tests to cover the helper intent builders and the missing-extra logging branch

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c976b16da4832d8b4cbb7c2d2d8423