### PR TITLE
Add FavoriteAppsViewModel tests for datastore updates and error handling

### DIFF
--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModel.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModel.kt
@@ -1,14 +1,18 @@
 package com.d4rk.android.apps.apptoolkit.app.apps.favorites
 
+import com.d4rk.android.apps.apptoolkit.R
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
 import com.d4rk.android.apps.apptoolkit.app.core.utils.dispatchers.StandardDispatcherExtension
 import com.d4rk.android.apps.apptoolkit.app.core.utils.dispatchers.TestDispatchers
 import app.cash.turbine.test
+import com.d4rk.android.apps.apptoolkit.core.domain.model.network.Errors
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
+import com.d4rk.android.libs.apptoolkit.core.utils.helpers.UiTextHelper
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.extension.RegisterExtension
 
@@ -90,6 +94,95 @@ class TestFavoriteAppsViewModel : TestFavoriteAppsViewModelBase() {
             awaitItem() // Initial loading
             val state = awaitItem()
             assertThat(state.screenState).isInstanceOf(ScreenState.NoData::class.java)
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `datastore updates move screen from no data to success`() = runTest(dispatcherExtension.testDispatcher) {
+        val apps = listOf(AppInfo("App", "pkg", "url"))
+        val favoritesFlow = MutableStateFlow(emptySet<String>())
+        setup(
+            fetchApps = apps,
+            favoritesFlow = favoritesFlow,
+            dispatchers = TestDispatchers(dispatcherExtension.testDispatcher),
+        )
+
+        viewModel.uiState.test {
+            val loading = awaitItem()
+            assertThat(loading.screenState).isInstanceOf(ScreenState.IsLoading::class.java)
+
+            val noData = awaitItem()
+            assertThat(noData.screenState).isInstanceOf(ScreenState.NoData::class.java)
+
+            favoritesFlow.value = setOf("pkg")
+            runCurrent()
+
+            val success = awaitItem()
+            assertThat(success.screenState).isInstanceOf(ScreenState.Success::class.java)
+            assertThat(success.data?.apps?.map { it.packageName }).containsExactly("pkg")
+            assertThat(viewModel.favorites.value).containsExactly("pkg")
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `fetch apps error updates state and shows snackbar`() = runTest(dispatcherExtension.testDispatcher) {
+        val apps = listOf(AppInfo("App", "pkg", "url"))
+        setup(
+            fetchApps = apps,
+            fetchError = Errors.UseCase.FAILED_TO_LOAD_APPS,
+            dispatchers = TestDispatchers(dispatcherExtension.testDispatcher),
+        )
+
+        viewModel.uiState.test {
+            val loading = awaitItem()
+            assertThat(loading.screenState).isInstanceOf(ScreenState.IsLoading::class.java)
+
+            val errorState = awaitItem()
+            assertThat(errorState.screenState).isInstanceOf(ScreenState.Error::class.java)
+            assertThat(errorState.data).isNull()
+
+            val snackbarState = awaitItem()
+            assertThat(snackbarState.screenState).isInstanceOf(ScreenState.Error::class.java)
+            val snackbar = snackbarState.snackbar
+            assertThat(snackbar).isNotNull()
+            assertThat(snackbar?.isError).isTrue()
+            assertThat(snackbar?.message).isEqualTo(UiTextHelper.StringResource(R.string.error_an_error_occurred))
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
+
+    @Test
+    fun `toggle favorite failure updates state and snackbar`() = runTest(dispatcherExtension.testDispatcher) {
+        val apps = listOf(AppInfo("App", "pkg", "url"))
+        setup(
+            fetchApps = apps,
+            initialFavorites = setOf("pkg"),
+            toggleError = RuntimeException("fail"),
+            dispatchers = TestDispatchers(dispatcherExtension.testDispatcher),
+        )
+
+        viewModel.uiState.test {
+            val loading = awaitItem()
+            assertThat(loading.screenState).isInstanceOf(ScreenState.IsLoading::class.java)
+
+            val success = awaitItem()
+            assertThat(success.screenState).isInstanceOf(ScreenState.Success::class.java)
+            assertThat(success.data?.apps?.map { it.packageName }).containsExactly("pkg")
+
+            viewModel.toggleFavorite("pkg")
+            runCurrent()
+
+            val errorState = awaitItem()
+            assertThat(errorState.screenState).isInstanceOf(ScreenState.Error::class.java)
+            assertThat(viewModel.favorites.value).containsExactly("pkg")
+
+            val snackbarState = awaitItem()
+            val snackbar = snackbarState.snackbar
+            assertThat(snackbar).isNotNull()
+            assertThat(snackbar?.isError).isTrue()
+            assertThat(snackbar?.message).isEqualTo(UiTextHelper.StringResource(R.string.error_failed_to_update_favorite))
             cancelAndIgnoreRemainingEvents()
         }
     }

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModelBase.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModelBase.kt
@@ -8,6 +8,7 @@ import com.d4rk.android.apps.apptoolkit.app.apps.favorites.ui.FavoriteAppsViewMo
 import com.d4rk.android.apps.apptoolkit.app.apps.list.FakeDeveloperAppsRepository
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.usecases.FetchDeveloperAppsUseCase
+import com.d4rk.android.apps.apptoolkit.core.domain.model.network.Errors
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.Flow
@@ -24,10 +25,11 @@ open class TestFavoriteAppsViewModelBase {
         initialFavorites: Set<String> = emptySet(),
         favoritesFlow: Flow<Set<String>>? = null,
         toggleError: Throwable? = null,
+        fetchError: Errors? = null,
         dispatchers: DispatcherProvider = TestDispatchers(),
     ) {
         println("\uD83E\uDDEA [SETUP] Initial favorites: $initialFavorites")
-        val developerAppsRepository = FakeDeveloperAppsRepository(fetchApps)
+        val developerAppsRepository = FakeDeveloperAppsRepository(fetchApps, fetchError)
         val fetchUseCase = FetchDeveloperAppsUseCase(developerAppsRepository)
         val favoritesRepository = FakeFavoritesRepository(initialFavorites, favoritesFlow, toggleError)
         val observeFavoritesUseCase = ObserveFavoritesUseCase(favoritesRepository)


### PR DESCRIPTION
## Summary
- allow injecting fetch errors in the favorite apps test base
- add FavoriteAppsViewModel tests that simulate datastore updates and fetch failures
- verify error state and snackbar emissions when toggling favorites fails

## Testing
- ./gradlew test *(fails: Android SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c976b0744c832dbd08411db623e079