### PR TITLE
Add dispatcher extension tests and docs

### DIFF
--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/core/utils/dispatchers/StandardDispatcherExtensionTest.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/core/utils/dispatchers/StandardDispatcherExtensionTest.kt
@@ -1,0 +1,44 @@
+package com.d4rk.android.apps.apptoolkit.app.core.utils.dispatchers
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.StandardTestDispatcher
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertNotSame
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+class StandardDispatcherExtensionTest {
+
+    private val extension = StandardDispatcherExtension()
+
+    @Test
+    fun `beforeEach sets Main dispatcher to a StandardTestDispatcher`() {
+        extension.beforeEach(null)
+
+        try {
+            assertInstanceOf(StandardTestDispatcher::class.java, extension.testDispatcher)
+            assertSame(extension.testDispatcher, Dispatchers.Main)
+        } finally {
+            extension.afterEach(null)
+        }
+    }
+
+    @Test
+    fun `beforeEach provides a fresh dispatcher for every invocation`() {
+        extension.beforeEach(null)
+        val firstDispatcher = extension.testDispatcher
+        extension.afterEach(null)
+
+        extension.beforeEach(null)
+        val secondDispatcher = extension.testDispatcher
+
+        try {
+            assertInstanceOf(StandardTestDispatcher::class.java, firstDispatcher)
+            assertInstanceOf(StandardTestDispatcher::class.java, secondDispatcher)
+            assertNotSame(firstDispatcher, secondDispatcher)
+            assertSame(secondDispatcher, Dispatchers.Main)
+        } finally {
+            extension.afterEach(null)
+        }
+    }
+}

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/core/utils/dispatchers/UnconfinedDispatcherExtensionTest.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/core/utils/dispatchers/UnconfinedDispatcherExtensionTest.kt
@@ -1,0 +1,27 @@
+package com.d4rk.android.apps.apptoolkit.app.core.utils.dispatchers
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+class UnconfinedDispatcherExtensionTest {
+
+    private val extension = UnconfinedDispatcherExtension()
+
+    @Test
+    fun `beforeEach pins Main dispatcher to the shared UnconfinedTestDispatcher`() {
+        val sharedDispatcher = extension.testDispatcher
+
+        extension.beforeEach(null)
+
+        try {
+            assertInstanceOf(UnconfinedTestDispatcher::class.java, sharedDispatcher)
+            assertSame(sharedDispatcher, extension.testDispatcher)
+            assertSame(sharedDispatcher, Dispatchers.Main)
+        } finally {
+            extension.afterEach(null)
+        }
+    }
+}

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/dispatchers/StandardDispatcherExtensionTest.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/dispatchers/StandardDispatcherExtensionTest.kt
@@ -1,0 +1,44 @@
+package com.d4rk.android.libs.apptoolkit.core.utils.dispatchers
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.StandardTestDispatcher
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertNotSame
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+class StandardDispatcherExtensionTest {
+
+    private val extension = StandardDispatcherExtension()
+
+    @Test
+    fun `beforeEach sets Main dispatcher to a StandardTestDispatcher`() {
+        extension.beforeEach(null)
+
+        try {
+            assertInstanceOf(StandardTestDispatcher::class.java, extension.testDispatcher)
+            assertSame(extension.testDispatcher, Dispatchers.Main)
+        } finally {
+            extension.afterEach(null)
+        }
+    }
+
+    @Test
+    fun `beforeEach provides a fresh dispatcher for every invocation`() {
+        extension.beforeEach(null)
+        val firstDispatcher = extension.testDispatcher
+        extension.afterEach(null)
+
+        extension.beforeEach(null)
+        val secondDispatcher = extension.testDispatcher
+
+        try {
+            assertInstanceOf(StandardTestDispatcher::class.java, firstDispatcher)
+            assertInstanceOf(StandardTestDispatcher::class.java, secondDispatcher)
+            assertNotSame(firstDispatcher, secondDispatcher)
+            assertSame(secondDispatcher, Dispatchers.Main)
+        } finally {
+            extension.afterEach(null)
+        }
+    }
+}

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/dispatchers/UnconfinedDispatcherExtensionTest.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/dispatchers/UnconfinedDispatcherExtensionTest.kt
@@ -1,0 +1,27 @@
+package com.d4rk.android.libs.apptoolkit.core.utils.dispatchers
+
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import org.junit.jupiter.api.Assertions.assertInstanceOf
+import org.junit.jupiter.api.Assertions.assertSame
+import org.junit.jupiter.api.Test
+
+class UnconfinedDispatcherExtensionTest {
+
+    private val extension = UnconfinedDispatcherExtension()
+
+    @Test
+    fun `beforeEach pins Main dispatcher to the shared UnconfinedTestDispatcher`() {
+        val sharedDispatcher = extension.testDispatcher
+
+        extension.beforeEach(null)
+
+        try {
+            assertInstanceOf(UnconfinedTestDispatcher::class.java, sharedDispatcher)
+            assertSame(sharedDispatcher, extension.testDispatcher)
+            assertSame(sharedDispatcher, Dispatchers.Main)
+        } finally {
+            extension.afterEach(null)
+        }
+    }
+}

--- a/docs/tests/coroutine-dispatcher-extensions.md
+++ b/docs/tests/coroutine-dispatcher-extensions.md
@@ -1,0 +1,36 @@
+# Coroutine dispatcher extensions for tests
+
+The test sources expose a pair of JUnit 5 extensions that prepare the `Dispatchers.Main` dispatcher before each test and reset it afterwards:
+
+- `StandardDispatcherExtension` creates a fresh `StandardTestDispatcher` for every test case. Use it when your subject under test relies on cooperative scheduling or when you need to manually advance virtual time.
+- `UnconfinedDispatcherExtension` exposes a shared `UnconfinedTestDispatcher`. Use it for tests that benefit from eager execution without explicit scheduler control.
+
+Both modules (`app` and `apptoolkit`) host their own copy of these helpers so they can be imported from their respective packages.
+
+## Usage pattern
+
+```kotlin
+class ExampleViewModelTest {
+
+    companion object {
+        @JvmField
+        @RegisterExtension
+        val dispatcherExtension = StandardDispatcherExtension()
+    }
+
+    @Test
+    fun `example assertion`() = runTest(dispatcherExtension.testDispatcher) {
+        val dispatchers = TestDispatchers(dispatcherExtension.testDispatcher)
+        // exercise and verify subject under test
+    }
+}
+```
+
+Key points:
+
+- Always opt-in via `@RegisterExtension` to ensure `Dispatchers.Main` is configured before the test body executes.
+- Pass `dispatcherExtension.testDispatcher` to `runTest` so coroutine work shares the same scheduler managed by the extension.
+- Inject the dispatcher into collaborators via `TestDispatchers` (in the `app` module) or by wiring the dispatcher directly in your fake dependencies.
+- Prefer the standard dispatcher for deterministic scheduling; switch to the unconfined variant when you explicitly need eager execution.
+
+The helper tests in `app` and `apptoolkit` assert that these extensions install the expected dispatcher instances, protecting against regressions should the implementations change.


### PR DESCRIPTION
## Summary
- add unit tests that verify StandardDispatcherExtension wires a fresh StandardTestDispatcher into Dispatchers.Main in both modules
- cover UnconfinedDispatcherExtension to ensure it shares the expected UnconfinedTestDispatcher
- document the dispatcher extension usage pattern for future coroutine-based tests

## Testing
- ./gradlew test *(fails: Android SDK not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68c976954f50832dac8f016503a2678b