### PR TITLE
Add fake repository tests for favorites use cases

### DIFF
--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/domain/usecases/FavoritesUseCasesTest.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/domain/usecases/FavoritesUseCasesTest.kt
@@ -1,9 +1,13 @@
 package com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases
 
-import com.d4rk.android.apps.apptoolkit.app.apps.favorites.FakeFavoritesRepository
 import app.cash.turbine.test
+import com.d4rk.android.apps.apptoolkit.app.apps.favorites.FakeFavoritesRepository
+import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.repository.FavoritesRepository
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
 
 class FavoritesUseCasesTest {
@@ -33,5 +37,52 @@ class FavoritesUseCasesTest {
             assertThat(awaitItem()).isEmpty()
             cancelAndIgnoreRemainingEvents()
         }
+    }
+
+    @Test
+    fun `toggle favorite use case invokes repository exactly once`() = runTest {
+        val repository = RecordingFavoritesRepository()
+        val useCase = ToggleFavoriteUseCase(repository)
+
+        val result = useCase("pkg")
+
+        assertThat(result).isEqualTo(Unit)
+        assertThat(repository.toggleCalls).isEqualTo(1)
+        assertThat(repository.lastToggleParam).isEqualTo("pkg")
+        assertThat(repository.observeCalls).isEqualTo(0)
+    }
+
+    @Test
+    fun `observe favorites use case returns repository flow and invokes repository exactly once`() = runTest {
+        val expectedFlow = flowOf(setOf("pkg"))
+        val repository = RecordingFavoritesRepository(observeResult = expectedFlow)
+        val useCase = ObserveFavoritesUseCase(repository)
+
+        val result = useCase()
+
+        assertThat(result).isSameInstanceAs(expectedFlow)
+        assertThat(repository.observeCalls).isEqualTo(1)
+        assertThat(repository.toggleCalls).isEqualTo(0)
+    }
+}
+
+private class RecordingFavoritesRepository(
+    private val observeResult: Flow<Set<String>> = flowOf(emptySet()),
+) : FavoritesRepository {
+    var observeCalls = 0
+        private set
+    var toggleCalls = 0
+        private set
+    var lastToggleParam: String? = null
+        private set
+
+    override fun observeFavorites(): Flow<Set<String>> {
+        observeCalls += 1
+        return observeResult
+    }
+
+    override suspend fun toggleFavorite(packageName: String) {
+        toggleCalls += 1
+        lastToggleParam = packageName
     }
 }


### PR DESCRIPTION
## Summary
- add counting fake favorites repository for unit tests
- ensure ToggleFavoriteUseCase and ObserveFavoritesUseCase invoke repositories once and return expected data

## Testing
- ./gradlew test *(fails: SDK location not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9768b2cc4832d801240f88e179709