### PR TITLE
Add ScreenViewModel accessor tests

### DIFF
--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/ui/base/ScreenViewModelTest.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/ui/base/ScreenViewModelTest.kt
@@ -1,0 +1,66 @@
+package com.d4rk.android.libs.apptoolkit.core.ui.base
+
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.ScreenState
+import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
+import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.ActionEvent
+import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.UiEvent
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.flow.MutableStateFlow
+import org.junit.jupiter.api.Test
+
+class ScreenViewModelTest {
+
+    @Test
+    fun `screenState exposes mutable state flow updates`() {
+        val initial = UiStateScreen(
+            screenState = ScreenState.IsLoading(),
+            data = TestData(value = "initial"),
+        )
+        val viewModel = TestScreenViewModel(initial)
+
+        val stateFlow = viewModel.exposedState()
+        val updated = UiStateScreen(
+            screenState = ScreenState.Success(),
+            data = TestData(value = "updated"),
+        )
+
+        stateFlow.value = updated
+
+        assertThat(viewModel.uiState.value).isEqualTo(updated)
+    }
+
+    @Test
+    fun `screenData returns current state data`() {
+        val initial = UiStateScreen(
+            screenState = ScreenState.Success(),
+            data = TestData(value = "initial"),
+        )
+        val viewModel = TestScreenViewModel(initial)
+
+        assertThat(viewModel.exposedData()).isEqualTo(TestData(value = "initial"))
+
+        val updated = UiStateScreen(
+            screenState = ScreenState.Success(),
+            data = TestData(value = "updated"),
+        )
+        viewModel.overwriteState(updated)
+
+        assertThat(viewModel.exposedData()).isEqualTo(TestData(value = "updated"))
+    }
+}
+
+private data class TestData(val value: String)
+
+private class TestScreenViewModel(initial: UiStateScreen<TestData>) :
+    ScreenViewModel<TestData, UiEvent, ActionEvent>(initial) {
+
+    fun exposedState(): MutableStateFlow<UiStateScreen<TestData>> = screenState
+
+    fun overwriteState(newState: UiStateScreen<TestData>) {
+        screenState.value = newState
+    }
+
+    fun exposedData(): TestData? = screenData
+
+    override fun onEvent(event: UiEvent) = Unit
+}


### PR DESCRIPTION
## Summary
- add unit tests to verify ScreenViewModel exposes mutable state updates
- confirm screenData always returns the most recent data held by the state flow

## Testing
- ./gradlew test *(fails: Android SDK not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9768a09a4832d98f9cb74e66068e3