### PR TITLE
Add dispatcher unit tests

### DIFF
--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/settings/general/domain/repository/TestGeneralSettingsRepository.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/app/settings/general/domain/repository/TestGeneralSettingsRepository.kt
@@ -1,11 +1,14 @@
 package com.d4rk.android.libs.apptoolkit.app.settings.general.domain.repository
 
 import com.d4rk.android.libs.apptoolkit.app.settings.general.data.DefaultGeneralSettingsRepository
+import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import com.d4rk.android.libs.apptoolkit.core.di.TestDispatchers
 import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.UnconfinedDispatcherExtension
 import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.test.runTest
+import kotlin.coroutines.CoroutineContext
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.assertThrows
 import org.junit.jupiter.api.extension.RegisterExtension
@@ -39,5 +42,31 @@ class TestGeneralSettingsRepository {
         assertThrows<IllegalArgumentException> {
             repository.getContentKey("").first()
         }
+    }
+
+    @Test
+    fun `getContentKey uses provided dispatcher`() = runTest(dispatcherExtension.testDispatcher) {
+        val trackingDispatcher = TrackingDispatcher()
+        val repository = DefaultGeneralSettingsRepository(object : DispatcherProvider {
+            override val main = dispatcherExtension.testDispatcher
+            override val io = dispatcherExtension.testDispatcher
+            override val default = trackingDispatcher
+            override val unconfined = dispatcherExtension.testDispatcher
+        })
+
+        val result = repository.getContentKey("value").first()
+
+        assertThat(result).isEqualTo("value")
+        assertThat(trackingDispatcher.dispatchCount).isGreaterThan(0)
+    }
+}
+
+private class TrackingDispatcher : CoroutineDispatcher() {
+    var dispatchCount: Int = 0
+        private set
+
+    override fun dispatch(context: CoroutineContext, block: Runnable) {
+        dispatchCount++
+        block.run()
     }
 }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/di/StandardDispatchersTest.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/di/StandardDispatchersTest.kt
@@ -1,0 +1,33 @@
+package com.d4rk.android.libs.apptoolkit.core.di
+
+import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.StandardDispatcherExtension
+import com.google.common.truth.Truth.assertThat
+import kotlinx.coroutines.Dispatchers
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.extension.ExtendWith
+
+@ExtendWith(StandardDispatcherExtension::class)
+class StandardDispatchersTest {
+
+    private val dispatchers = StandardDispatchers()
+
+    @Test
+    fun `main returns DispatchersMain`() {
+        assertThat(dispatchers.main).isEqualTo(Dispatchers.Main)
+    }
+
+    @Test
+    fun `io returns DispatchersIO`() {
+        assertThat(dispatchers.io).isEqualTo(Dispatchers.IO)
+    }
+
+    @Test
+    fun `default returns DispatchersDefault`() {
+        assertThat(dispatchers.default).isEqualTo(Dispatchers.Default)
+    }
+
+    @Test
+    fun `unconfined returns DispatchersUnconfined`() {
+        assertThat(dispatchers.unconfined).isEqualTo(Dispatchers.Unconfined)
+    }
+}


### PR DESCRIPTION
## Summary
- add coverage for `StandardDispatchers` to verify each property returns the expected coroutine dispatcher
- extend the general settings repository tests to prove production code can swap in a custom dispatcher provider

## Testing
- ./gradlew test *(fails: Android SDK not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9767e3c28832da5f626c8cbb86b6d