### PR TITLE
Add tests for ReviewHelper eligibility logic

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/ReviewHelper.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/ReviewHelper.kt
@@ -3,6 +3,7 @@ package com.d4rk.android.libs.apptoolkit.core.utils.helpers
 import android.app.Activity
 import com.google.android.play.core.review.ReviewManagerFactory
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.tasks.await
 
@@ -42,7 +43,7 @@ object ReviewHelper {
      * Useful for debugging or providing a manual trigger within the app.
      */
     fun forceLaunchInAppReview(activity : Activity , scope : CoroutineScope) {
-        scope.launch {
+        scope.launch(start = CoroutineStart.UNDISPATCHED) {
             launchReview(activity)
         }
     }


### PR DESCRIPTION
## Summary
- add new ReviewHelper tests covering eligibility gating and forced launches
- mock ReviewManager interactions for both success and failure paths
- adjust forceLaunchInAppReview to start undispatched so the launch is always attempted immediately

## Testing
- ./gradlew test *(fails: Android SDK not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c97673661c832dadf455c9a0b19ce6