### PR TITLE
Align error constants and enforce marker interface

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/domain/model/network/Errors.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/domain/model/network/Errors.kt
@@ -5,14 +5,24 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Error
 sealed interface Errors : Error {
 
     enum class Network : Errors {
-        REQUEST_TIMEOUT , NO_INTERNET , SERIALIZATION
+        REQUEST_TIMEOUT,
+        NO_INTERNET,
+        SERIALIZATION,
     }
 
     enum class UseCase : Errors {
-        NO_DATA , FAILED_TO_LOAD_APPS , ILLEGAL_ARGUMENT ,
+        NO_DATA,
+        FAILED_TO_LOAD_APPS,
+        FAILED_TO_LAUNCH_REVIEW,
+        FAILED_TO_LOAD_FAQS,
+        FAILED_TO_REQUEST_REVIEW,
+        FAILED_TO_UPDATE_APP,
+        FAILED_TO_LOAD_SKU_DETAILS,
+        FAILED_TO_LOAD_CONSENT_INFO,
+        ILLEGAL_ARGUMENT,
     }
 
     enum class Database : Errors {
-        DATABASE_OPERATION_FAILED
+        DATABASE_OPERATION_FAILED,
     }
 }

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/core/domain/model/network/ErrorsConsistencyTest.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/core/domain/model/network/ErrorsConsistencyTest.kt
@@ -1,0 +1,27 @@
+package com.d4rk.android.apps.apptoolkit.core.domain.model.network
+
+import com.d4rk.android.apps.apptoolkit.core.domain.model.network.Errors as AppErrors
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Errors as LibErrors
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ErrorsConsistencyTest {
+
+    @Test
+    fun `network error constants are shared between modules`() {
+        assertEquals(enumNames<LibErrors.Network>(), enumNames<AppErrors.Network>())
+    }
+
+    @Test
+    fun `use case error constants are shared between modules`() {
+        assertEquals(enumNames<LibErrors.UseCase>(), enumNames<AppErrors.UseCase>())
+    }
+
+    @Test
+    fun `database error constants are shared between modules`() {
+        assertEquals(enumNames<LibErrors.Database>(), enumNames<AppErrors.Database>())
+    }
+}
+
+private inline fun <reified T : Enum<T>> enumNames(): Set<String> =
+    enumValues<T>().map { it.name }.toSet()

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/domain/model/network/Errors.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/domain/model/network/Errors.kt
@@ -3,14 +3,24 @@ package com.d4rk.android.libs.apptoolkit.core.domain.model.network
 sealed interface Errors : Error {
 
     enum class Network : Errors {
-        REQUEST_TIMEOUT , NO_INTERNET , SERIALIZATION
+        REQUEST_TIMEOUT,
+        NO_INTERNET,
+        SERIALIZATION,
     }
 
     enum class UseCase : Errors {
-        NO_DATA , FAILED_TO_LAUNCH_REVIEW , FAILED_TO_LOAD_FAQS , FAILED_TO_REQUEST_REVIEW , FAILED_TO_UPDATE_APP , FAILED_TO_LOAD_SKU_DETAILS , FAILED_TO_LOAD_CONSENT_INFO
+        NO_DATA,
+        FAILED_TO_LOAD_APPS,
+        FAILED_TO_LAUNCH_REVIEW,
+        FAILED_TO_LOAD_FAQS,
+        FAILED_TO_REQUEST_REVIEW,
+        FAILED_TO_UPDATE_APP,
+        FAILED_TO_LOAD_SKU_DETAILS,
+        FAILED_TO_LOAD_CONSENT_INFO,
+        ILLEGAL_ARGUMENT,
     }
 
     enum class Database : Errors {
-        DATABASE_OPERATION_FAILED
+        DATABASE_OPERATION_FAILED,
     }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/constants/error/ErrorType.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/constants/error/ErrorType.kt
@@ -1,41 +1,20 @@
 package com.d4rk.android.libs.apptoolkit.core.utils.constants.error
 
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Error
+
 /**
- * @brief Enum class representing different types of errors that can occur during program execution.
+ * Enum class representing different categories of recoverable failures within the toolkit.
  *
- * This enum provides a standardized way to identify and handle various error conditions,
- * making it easier to debug and manage errors in a consistent manner.
- *
- * Each enumerator represents a specific error scenario and should be used to
- * clearly indicate the cause of a failure or exception.
- *
- * @note Adding new error types requires updating the error handling logic in the program.
- *
- * @enum ErrorType
- * @brief Enumeration of possible error types.
- *
- * @var SECURITY_EXCEPTION
- * @brief An error related to security, such as unauthorized access or permission issues.
- *
- * @var IO_EXCEPTION
- * @brief An error related to input/output operations, such as file access issues, network errors, or stream corruption.
- *
- * @var ACTIVITY_NOT_FOUND
- * @brief An error indicating that a requested activity, resource, or component could not be found.
- *
- * @var ILLEGAL_ARGUMENT
- * @brief An error caused by an invalid or inappropriate argument passed to a function or method.
- *
- * @var SQLITE_EXCEPTION
- * @brief An error specific to SQLite database operations, such as query failures or database corruption.
- *
- * @var FILE_NOT_FOUND
- * @brief An error indicating that a specified file could not be located.
- *
- * @var UNKNOWN_ERROR
- * @brief A generic error that doesn't fit into the other defined categories. Should be avoided if possible,
- *        and more specific error types should be created instead to provide better error context.
+ * The values defined here act as lightweight identifiers that can be surfaced to the UI layer or
+ * logged for analytics. Declaring the enum as a subtype of [Error] ensures every constant is
+ * compatible with APIs that expect the toolkit's marker error interface.
  */
-enum class ErrorType {
-    SECURITY_EXCEPTION , IO_EXCEPTION , ACTIVITY_NOT_FOUND , ILLEGAL_ARGUMENT , SQLITE_EXCEPTION , FILE_NOT_FOUND , UNKNOWN_ERROR ,
+enum class ErrorType : Error {
+    SECURITY_EXCEPTION,
+    IO_EXCEPTION,
+    ACTIVITY_NOT_FOUND,
+    ILLEGAL_ARGUMENT,
+    SQLITE_EXCEPTION,
+    FILE_NOT_FOUND,
+    UNKNOWN_ERROR,
 }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/constants/error/ErrorTypeTest.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/constants/error/ErrorTypeTest.kt
@@ -1,0 +1,15 @@
+package com.d4rk.android.libs.apptoolkit.core.utils.constants.error
+
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Error
+import kotlin.test.Test
+import kotlin.test.assertTrue
+
+class ErrorTypeTest {
+
+    @Test
+    fun `all error types implement the marker interface`() {
+        ErrorType.entries.forEach { errorType ->
+            assertTrue(errorType is Error)
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- align the app and library `Errors` enums so every use-case constant is available in both modules
- mark `ErrorType` as implementing the shared `Error` interface and add coverage to verify the contract
- add regression tests that confirm the error constants remain in sync across modules

## Testing
- ./gradlew test *(fails: Android SDK is not available in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9767dc078832daf47f5cb08150795