### PR TITLE
Add coroutine tests for consent form helper

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/ConsentFormHelper.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/ConsentFormHelper.kt
@@ -2,10 +2,12 @@ package com.d4rk.android.libs.apptoolkit.core.utils.helpers
 
 import android.app.Activity
 import android.util.Log
-import com.google.android.ump.ConsentForm
 import com.google.android.ump.ConsentInformation
 import com.google.android.ump.ConsentRequestParameters
+import com.google.android.ump.ConsentForm
+import com.google.android.ump.FormError
 import com.google.android.ump.UserMessagingPlatform
+import kotlinx.coroutines.CancellableContinuation
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.resume
 
@@ -18,6 +20,65 @@ import kotlin.coroutines.resume
  */
 object ConsentFormHelper {
 
+    internal fun interface ConsentFormHandle {
+        fun show(activity: Activity, onDismissed: (Throwable?) -> Unit)
+    }
+
+    internal interface ConsentSdk {
+        val consentStatus: ConsentInformation.ConsentStatus
+
+        fun requestConsentInfoUpdate(
+            activity: Activity,
+            params: ConsentRequestParameters,
+            onSuccess: () -> Unit,
+            onFailure: (Throwable) -> Unit,
+        )
+
+        fun loadConsentForm(
+            activity: Activity,
+            onFormLoaded: (ConsentFormHandle) -> Unit,
+            onFailure: (Throwable) -> Unit,
+        )
+    }
+
+    private class RealConsentSdk(
+        private val consentInfo: ConsentInformation,
+    ) : ConsentSdk {
+
+        override val consentStatus: ConsentInformation.ConsentStatus
+            get() = consentInfo.consentStatus
+
+        override fun requestConsentInfoUpdate(
+            activity: Activity,
+            params: ConsentRequestParameters,
+            onSuccess: () -> Unit,
+            onFailure: (Throwable) -> Unit,
+        ) {
+            consentInfo.requestConsentInfoUpdate(activity, params, { onSuccess() }, onFailure)
+        }
+
+        override fun loadConsentForm(
+            activity: Activity,
+            onFormLoaded: (ConsentFormHandle) -> Unit,
+            onFailure: (Throwable) -> Unit,
+        ) {
+            UserMessagingPlatform.loadConsentForm(activity, { consentForm: ConsentForm ->
+                onFormLoaded(RealConsentForm(consentForm))
+            }, onFailure)
+        }
+    }
+
+    private class RealConsentForm(
+        private val consentForm: ConsentForm,
+    ) : ConsentFormHandle {
+
+        override fun show(activity: Activity, onDismissed: (Throwable?) -> Unit) {
+            consentForm.show(activity) { error: FormError? ->
+                onDismissed(error)
+            }
+        }
+    }
+
     /**
      * Request consent information and display the consent form if required.
      * The function returns once the form has been displayed or it has been
@@ -27,39 +88,14 @@ object ConsentFormHelper {
         activity: Activity,
         consentInfo: ConsentInformation,
     ) {
-        val params: ConsentRequestParameters =
-            ConsentRequestParameters.Builder().setTagForUnderAgeOfConsent(false).build()
+        showConsentFormIfRequired(activity = activity, consentSdk = RealConsentSdk(consentInfo))
+    }
 
-        suspendCancellableCoroutine { continuation ->
-            consentInfo.requestConsentInfoUpdate(activity, params, {
-                if (consentInfo.consentStatus != ConsentInformation.ConsentStatus.REQUIRED &&
-                    consentInfo.consentStatus != ConsentInformation.ConsentStatus.UNKNOWN) {
-                    if (continuation.isActive) continuation.resume(Unit)
-                    return@requestConsentInfoUpdate
-                }
-
-                runCatching {
-                    UserMessagingPlatform.loadConsentForm(activity, { consentForm: ConsentForm ->
-                        runCatching {
-                            consentForm.show(activity) {
-                                if (continuation.isActive) continuation.resume(Unit)
-                            }
-                        }.onFailure {
-                            Log.e("ConsentFormHelper", "Failed to load consent form", it)
-                            if (continuation.isActive) continuation.resume(Unit)
-                        }
-                    }, { t ->
-                        Log.e("ConsentFormHelper", "Failed to load consent form: ${t.message}")
-                        if (continuation.isActive) continuation.resume(Unit)
-                    })
-                }.onFailure {
-                    Log.e("ConsentFormHelper", "Failed to load consent form", it)
-                    if (continuation.isActive) continuation.resume(Unit)
-                }
-            }, {
-                if (continuation.isActive) continuation.resume(Unit)
-            })
-        }
+    internal suspend fun showConsentFormIfRequired(
+        activity: Activity,
+        consentSdk: ConsentSdk,
+    ) {
+        requestAndMaybeShow(activity = activity, consentSdk = consentSdk, checkStatus = true)
     }
 
     /**
@@ -71,29 +107,62 @@ object ConsentFormHelper {
         activity: Activity,
         consentInfo: ConsentInformation,
     ) {
+        showConsentForm(activity = activity, consentSdk = RealConsentSdk(consentInfo))
+    }
+
+    internal suspend fun showConsentForm(
+        activity: Activity,
+        consentSdk: ConsentSdk,
+    ) {
+        requestAndMaybeShow(activity = activity, consentSdk = consentSdk, checkStatus = false)
+    }
+
+    private suspend fun requestAndMaybeShow(
+        activity: Activity,
+        consentSdk: ConsentSdk,
+        checkStatus: Boolean,
+    ) {
         val params: ConsentRequestParameters =
             ConsentRequestParameters.Builder().setTagForUnderAgeOfConsent(false).build()
 
         suspendCancellableCoroutine { continuation ->
-            consentInfo.requestConsentInfoUpdate(activity, params, {
-                runCatching {
-                    UserMessagingPlatform.loadConsentForm(activity, { consentForm: ConsentForm ->
-                        runCatching {
-                            consentForm.show(activity) {
-                                if (continuation.isActive) continuation.resume(Unit)
-                            }
-                        }.onFailure {
-                            if (continuation.isActive) continuation.resume(Unit)
-                        }
-                    }, {
-                        if (continuation.isActive) continuation.resume(Unit)
-                    })
-                }.onFailure {
+            consentSdk.requestConsentInfoUpdate(activity, params, {
+                if (checkStatus &&
+                    consentSdk.consentStatus != ConsentInformation.ConsentStatus.REQUIRED &&
+                    consentSdk.consentStatus != ConsentInformation.ConsentStatus.UNKNOWN) {
                     if (continuation.isActive) continuation.resume(Unit)
+                    return@requestConsentInfoUpdate
                 }
+
+                loadAndShow(activity, consentSdk, continuation)
             }, {
                 if (continuation.isActive) continuation.resume(Unit)
             })
+        }
+    }
+
+    private fun loadAndShow(
+        activity: Activity,
+        consentSdk: ConsentSdk,
+        continuation: CancellableContinuation<Unit>,
+    ) {
+        runCatching {
+            consentSdk.loadConsentForm(activity, { consentForm: ConsentFormHandle ->
+                runCatching {
+                    consentForm.show(activity) {
+                        if (continuation.isActive) continuation.resume(Unit)
+                    }
+                }.onFailure {
+                    Log.e("ConsentFormHelper", "Failed to load consent form", it)
+                    if (continuation.isActive) continuation.resume(Unit)
+                }
+            }, { error ->
+                Log.e("ConsentFormHelper", "Failed to load consent form: ${error.message}")
+                if (continuation.isActive) continuation.resume(Unit)
+            })
+        }.onFailure {
+            Log.e("ConsentFormHelper", "Failed to load consent form", it)
+            if (continuation.isActive) continuation.resume(Unit)
         }
     }
 }

--- a/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/ConsentFormHelperTest.kt
+++ b/apptoolkit/src/test/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/ConsentFormHelperTest.kt
@@ -1,0 +1,172 @@
+package com.d4rk.android.libs.apptoolkit.core.utils.helpers
+
+import android.app.Activity
+import com.google.android.ump.ConsentInformation
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.test.runTest
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class ConsentFormHelperTest {
+
+    @Test
+    fun `showConsentFormIfRequired skips loading when consent already obtained`() = runTest {
+        val sdk = FakeConsentSdk(initialStatus = ConsentInformation.ConsentStatus.OBTAINED).apply {
+            statusAfterRequest = ConsentInformation.ConsentStatus.OBTAINED
+        }
+
+        ConsentFormHelper.showConsentFormIfRequired(activity = FakeActivity(), consentSdk = sdk)
+
+        assertEquals(1, sdk.requestCount)
+        assertEquals(0, sdk.loadCount)
+        assertEquals(0, sdk.showCount)
+    }
+
+    @Test
+    fun `showConsentFormIfRequired loads form when consent is required`() = runTest {
+        val sdk = FakeConsentSdk(initialStatus = ConsentInformation.ConsentStatus.UNKNOWN).apply {
+            statusAfterRequest = ConsentInformation.ConsentStatus.REQUIRED
+        }
+
+        ConsentFormHelper.showConsentFormIfRequired(activity = FakeActivity(), consentSdk = sdk)
+
+        assertEquals(1, sdk.requestCount)
+        assertEquals(1, sdk.loadCount)
+        assertEquals(1, sdk.showCount)
+        assertEquals(1, sdk.dismissCallbackCount)
+    }
+
+    @Test
+    fun `showConsentFormIfRequired resumes when request fails`() = runTest {
+        val sdk = FakeConsentSdk(initialStatus = ConsentInformation.ConsentStatus.REQUIRED).apply {
+            requestFailure = RuntimeException("network")
+        }
+
+        ConsentFormHelper.showConsentFormIfRequired(activity = FakeActivity(), consentSdk = sdk)
+
+        assertEquals(1, sdk.requestCount)
+        assertEquals(0, sdk.loadCount)
+        assertEquals(0, sdk.showCount)
+    }
+
+    @Test
+    fun `showConsentFormIfRequired resumes when load fails`() = runTest {
+        val sdk = FakeConsentSdk(initialStatus = ConsentInformation.ConsentStatus.REQUIRED).apply {
+            loadFailure = RuntimeException("load")
+        }
+
+        ConsentFormHelper.showConsentFormIfRequired(activity = FakeActivity(), consentSdk = sdk)
+
+        assertEquals(1, sdk.loadCount)
+        assertEquals(0, sdk.showCount)
+    }
+
+    @Test
+    fun `showConsentFormIfRequired resumes when show throws`() = runTest {
+        val sdk = FakeConsentSdk(initialStatus = ConsentInformation.ConsentStatus.REQUIRED).apply {
+            showException = IllegalStateException("show")
+        }
+
+        ConsentFormHelper.showConsentFormIfRequired(activity = FakeActivity(), consentSdk = sdk)
+
+        assertEquals(1, sdk.showCount)
+        assertEquals(0, sdk.dismissCallbackCount)
+    }
+
+    @Test
+    fun `showConsentForm always requests and loads regardless of status`() = runTest {
+        val sdk = FakeConsentSdk(initialStatus = ConsentInformation.ConsentStatus.OBTAINED).apply {
+            statusAfterRequest = ConsentInformation.ConsentStatus.OBTAINED
+        }
+
+        ConsentFormHelper.showConsentForm(activity = FakeActivity(), consentSdk = sdk)
+
+        assertEquals(1, sdk.requestCount)
+        assertEquals(1, sdk.loadCount)
+        assertEquals(1, sdk.showCount)
+        assertEquals(1, sdk.dismissCallbackCount)
+    }
+
+    @Test
+    fun `showConsentForm resumes after load exception`() = runTest {
+        val sdk = FakeConsentSdk(initialStatus = ConsentInformation.ConsentStatus.REQUIRED).apply {
+            loadException = IllegalStateException("boom")
+        }
+
+        ConsentFormHelper.showConsentForm(activity = FakeActivity(), consentSdk = sdk)
+
+        assertEquals(1, sdk.loadCount)
+        assertEquals(0, sdk.showCount)
+    }
+
+    @Test
+    fun `showConsentForm resumes after dismiss error`() = runTest {
+        val sdk = FakeConsentSdk(initialStatus = ConsentInformation.ConsentStatus.REQUIRED).apply {
+            dismissError = RuntimeException("dismiss")
+        }
+
+        ConsentFormHelper.showConsentForm(activity = FakeActivity(), consentSdk = sdk)
+
+        assertEquals(1, sdk.showCount)
+        assertEquals(1, sdk.dismissCallbackCount)
+    }
+
+    private class FakeConsentSdk(
+        initialStatus: ConsentInformation.ConsentStatus,
+    ) : ConsentFormHelper.ConsentSdk {
+
+        override var consentStatus: ConsentInformation.ConsentStatus = initialStatus
+            private set
+
+        var statusAfterRequest: ConsentInformation.ConsentStatus? = null
+        var requestCount: Int = 0
+        var loadCount: Int = 0
+        var showCount: Int = 0
+        var dismissCallbackCount: Int = 0
+
+        var requestFailure: Throwable? = null
+        var loadFailure: Throwable? = null
+        var loadException: Throwable? = null
+        var showException: Throwable? = null
+        var dismissError: Throwable? = null
+
+        override fun requestConsentInfoUpdate(
+            activity: Activity,
+            params: com.google.android.ump.ConsentRequestParameters,
+            onSuccess: () -> Unit,
+            onFailure: (Throwable) -> Unit,
+        ) {
+            requestCount++
+            requestFailure?.let { failure ->
+                onFailure(failure)
+            } ?: run {
+                statusAfterRequest?.let { consentStatus = it }
+                onSuccess()
+            }
+        }
+
+        override fun loadConsentForm(
+            activity: Activity,
+            onFormLoaded: (ConsentFormHelper.ConsentFormHandle) -> Unit,
+            onFailure: (Throwable) -> Unit,
+        ) {
+            loadCount++
+            loadException?.let { throw it }
+            loadFailure?.let { failure ->
+                onFailure(failure)
+            } ?: onFormLoaded(FakeConsentForm())
+        }
+
+        private inner class FakeConsentForm : ConsentFormHelper.ConsentFormHandle {
+            override fun show(activity: Activity, onDismissed: (Throwable?) -> Unit) {
+                showCount++
+                showException?.let { throw it }
+                dismissCallbackCount++
+                onDismissed(dismissError)
+            }
+        }
+    }
+
+    private class FakeActivity : Activity()
+}


### PR DESCRIPTION
## Summary
- refactor ConsentFormHelper to delegate to an injectable consent SDK and share load/show handling
- add a coroutine-based fake consent SDK test suite that covers status checks and continuation resumption

## Testing
- `./gradlew test` *(fails: SDK location not found in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68c9766e6c1c832d85c4b216d750436a