### PR TITLE
Organize catalog bundles

### DIFF
--- a/apptoolkit/build.gradle.kts
+++ b/apptoolkit/build.gradle.kts
@@ -60,78 +60,39 @@ android {
 
 dependencies {
 
-    //AndroidX
-    api(dependencyNotation = libs.androidx.core.ktx)
-    api(dependencyNotation = libs.androidx.appcompat)
-    api(dependencyNotation = libs.androidx.core.splashscreen)
-    api(dependencyNotation = libs.androidx.multidex)
-    api(dependencyNotation = libs.androidx.work.runtime.ktx)
+    // AndroidX
+    api(dependencyNotation = libs.bundles.androidx.core)
 
     // Compose
     api(dependencyNotation = platform(libs.androidx.compose.bom))
-    api(dependencyNotation = libs.androidx.activity.compose)
-    api(dependencyNotation = libs.androidx.runtime.livedata)
-    api(dependencyNotation = libs.androidx.ui.tooling.preview)
-    api(dependencyNotation = libs.androidx.material3)
-    api(dependencyNotation = libs.androidx.material.icons.extended)
-    api(dependencyNotation = libs.androidx.datastore.preferences)
-    api(dependencyNotation = libs.androidx.navigation.compose)
+    api(dependencyNotation = libs.bundles.androidx.compose)
+
+    // Lifecycle
+    api(dependencyNotation = libs.bundles.androidx.lifecycle)
 
     // Firebase
     api(dependencyNotation = platform(libs.firebase.bom))
-    api(dependencyNotation = libs.firebase.analytics)
-    api(dependencyNotation = libs.firebase.crashlytics)
-    api(dependencyNotation = libs.firebase.perf)
-    api(dependencyNotation = libs.firebase.appcheck.playintegrity)
+    api(dependencyNotation = libs.bundles.firebase)
 
-    // Google
-    api(dependencyNotation = libs.play.services.ads)
-    api(dependencyNotation = libs.user.messaging.platform)
-    api(dependencyNotation = libs.material)
-    api(dependencyNotation = libs.app.update.ktx)
-    api(dependencyNotation = libs.billing)
-    api(dependencyNotation = libs.review.ktx)
-    api(dependencyNotation = libs.integrity)
+    // Google Play services & Play Store APIs
+    api(dependencyNotation = libs.bundles.google.play)
 
-    // Images
-    api(dependencyNotation = libs.coil.compose)
-    api(dependencyNotation = libs.coil.gif)
-    api(dependencyNotation = libs.coil.network.okhttp)
+    // Image loading
+    api(dependencyNotation = libs.bundles.coil)
 
-    // Kotlin
-    api(dependencyNotation = libs.kotlinx.coroutines.android)
-    api(dependencyNotation = libs.kotlinx.coroutines.play.services)
-    api(dependencyNotation = libs.kotlinx.serialization.json)
+    // Kotlin Coroutines & Serialization
+    api(dependencyNotation = libs.bundles.kotlinx)
 
-    // Ktor
+    // Networking (Ktor)
     api(dependencyNotation = platform(libs.ktor.bom))
-    api(dependencyNotation = libs.ktor.client.android)
-    api(dependencyNotation = libs.ktor.client.serialization)
-    api(dependencyNotation = libs.ktor.client.logging)
-    api(dependencyNotation = libs.ktor.client.content.negotiation)
-    api(dependencyNotation = libs.ktor.serialization.kotlinx.json)
+    api(dependencyNotation = libs.bundles.ktor)
 
-    // Koin
+    // Dependency Injection
     api(dependencyNotation = libs.bundles.koin)
 
-    // Konfetti
-    api(dependencyNotation = libs.konfetti.compose)
-
-    // Lottie
-    api(dependencyNotation = libs.lottie.compose)
-
-    // Lifecycle
-    api(dependencyNotation = libs.androidx.lifecycle.runtime.ktx)
-    api(dependencyNotation = libs.androidx.lifecycle.livedata.ktx)
-    api(dependencyNotation = libs.androidx.lifecycle.process)
-    api(dependencyNotation = libs.androidx.lifecycle.viewmodel.ktx)
-    api(dependencyNotation = libs.androidx.lifecycle.viewmodel.compose)
-    implementation(dependencyNotation = libs.androidx.lifecycle.runtime.compose)
-
-    // About
-    api(dependencyNotation = libs.aboutlibraries.compose.m3)
-    api(dependencyNotation = libs.core)
-    api(dependencyNotation = libs.compose.markdown)
+    // UI utilities
+    api(dependencyNotation = libs.bundles.ui.effects)
+    api(dependencyNotation = libs.bundles.ui.richtext)
 
     // Unit Tests
     testImplementation(dependencyNotation = libs.bundles.unitTest)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -145,10 +145,75 @@ googleFirebase = { id = "com.google.firebase.crashlytics", version.ref = "google
 mannodermaus = { id = "de.mannodermaus.android-junit5", version.ref = "mannodermaus" }
 
 [bundles]
+androidx-core = [
+    "androidx-core-ktx",
+    "androidx-appcompat",
+    "androidx-core-splashscreen",
+    "androidx-work-runtime-ktx",
+    "androidx-multidex",
+    "androidx-datastore-preferences",
+]
+androidx-compose = [
+    "androidx-activity-compose",
+    "androidx-runtime-livedata",
+    "androidx-ui-tooling-preview",
+    "androidx-material3",
+    "androidx-material-icons-extended",
+    "androidx-navigation-compose",
+]
+androidx-lifecycle = [
+    "androidx-lifecycle-runtime-ktx",
+    "androidx-lifecycle-livedata-ktx",
+    "androidx-lifecycle-process",
+    "androidx-lifecycle-viewmodel-ktx",
+    "androidx-lifecycle-viewmodel-compose",
+    "androidx-lifecycle-runtime-compose",
+]
+firebase = [
+    "firebase-analytics",
+    "firebase-crashlytics",
+    "firebase-perf",
+    "firebase-appcheck-playintegrity",
+]
+google-play = [
+    "play-services-ads",
+    "user-messaging-platform",
+    "material",
+    "app-update-ktx",
+    "billing",
+    "review-ktx",
+    "integrity",
+]
+coil = [
+    "coil-compose",
+    "coil-gif",
+    "coil-network-okhttp",
+]
+kotlinx = [
+    "kotlinx-coroutines-android",
+    "kotlinx-coroutines-play-services",
+    "kotlinx-serialization-json",
+]
+ktor = [
+    "ktor-client-android",
+    "ktor-client-serialization",
+    "ktor-client-logging",
+    "ktor-client-content-negotiation",
+    "ktor-serialization-kotlinx-json",
+]
+ui-effects = [
+    "konfetti-compose",
+    "lottie-compose",
+]
+ui-richtext = [
+    "aboutlibraries-compose-m3",
+    "core",
+    "compose-markdown",
+]
 koin = [
     "koin-core",
     "koin-compose-viewmodel",
-    "koin-android"
+    "koin-android",
 ]
 
 # For local tests on the JVM (test sourceSet)


### PR DESCRIPTION
## Summary
- group production dependencies into reusable version catalog bundles by feature area
- simplify the apptoolkit module build by consuming the new bundles instead of individual entries

## Testing
- ./gradlew test *(fails: requires Android SDK path configuration in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cbc63dbb1c832db546629c0e45bdb5