### PR TITLE
Fix help contact email and URL intent handling

### DIFF
--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModel.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModel.kt
@@ -24,7 +24,15 @@ class TestFavoriteAppsViewModel : TestFavoriteAppsViewModelBase() {
     @Test
     fun `toggle favorite throws after load`() = runTest(dispatcherExtension.testDispatcher) {
         println("\uD83D\uDE80 [TEST] toggle favorite throws after load")
-        val apps = listOf(AppInfo("App", "pkg", "url"))
+        val apps = listOf(
+            AppInfo(
+                name = "App",
+                packageName = "pkg",
+                iconUrl = "url",
+                description = "Description",
+                screenshots = emptyList(),
+            )
+        )
         setup(
             fetchApps = apps,
             initialFavorites = emptySet(),
@@ -46,8 +54,20 @@ class TestFavoriteAppsViewModel : TestFavoriteAppsViewModelBase() {
     @Test
     fun `load favorites emits saved apps`() = runTest(dispatcherExtension.testDispatcher) {
         val apps = listOf(
-            AppInfo("App1", "pkg1", "url1"),
-            AppInfo("App2", "pkg2", "url2")
+            AppInfo(
+                name = "App1",
+                packageName = "pkg1",
+                iconUrl = "url1",
+                description = "Description 1",
+                screenshots = emptyList(),
+            ),
+            AppInfo(
+                name = "App2",
+                packageName = "pkg2",
+                iconUrl = "url2",
+                description = "Description 2",
+                screenshots = emptyList(),
+            )
         )
         setup(
             fetchApps = apps,
@@ -68,7 +88,15 @@ class TestFavoriteAppsViewModel : TestFavoriteAppsViewModelBase() {
 
     @Test
     fun `toggle favorite updates favorites flow`() = runTest(dispatcherExtension.testDispatcher) {
-        val apps = listOf(AppInfo("App", "pkg", "url"))
+        val apps = listOf(
+            AppInfo(
+                name = "App",
+                packageName = "pkg",
+                iconUrl = "url",
+                description = "Description",
+                screenshots = emptyList(),
+            )
+        )
         setup(fetchApps = apps, dispatchers = TestDispatchers(dispatcherExtension.testDispatcher))
 
         viewModel.favorites.test {
@@ -83,7 +111,15 @@ class TestFavoriteAppsViewModel : TestFavoriteAppsViewModelBase() {
 
     @Test
     fun `load favorites with no saved apps shows no data`() = runTest(dispatcherExtension.testDispatcher) {
-        val apps = listOf(AppInfo("App", "pkg", "url"))
+        val apps = listOf(
+            AppInfo(
+                name = "App",
+                packageName = "pkg",
+                iconUrl = "url",
+                description = "Description",
+                screenshots = emptyList(),
+            )
+        )
         setup(fetchApps = apps, initialFavorites = emptySet(), dispatchers = TestDispatchers(dispatcherExtension.testDispatcher))
 
         viewModel.uiState.test {

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModel.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModel.kt
@@ -17,14 +17,30 @@ class TestAppsListViewModel : TestAppsListViewModelBase() {
 
     @Test
     fun `fetch apps - large list`() = runTest(dispatcherExtension.testDispatcher) {
-        val apps = (1..10_000).map { AppInfo("App$it", "pkg$it", "url$it") }
+        val apps = (1..10_000).map {
+            AppInfo(
+                name = "App$it",
+                packageName = "pkg$it",
+                iconUrl = "url$it",
+                description = "Description $it",
+                screenshots = emptyList(),
+            )
+        }
         setup(fetchApps = apps, dispatchers = TestDispatchers(dispatcherExtension.testDispatcher))
         viewModel.uiState.testSuccess(expectedSize = apps.size)
     }
 
     @Test
     fun `toggle favorite updates state`() = runTest(dispatcherExtension.testDispatcher) {
-        val apps = listOf(AppInfo("App", "pkg", "url"))
+        val apps = listOf(
+            AppInfo(
+                name = "App",
+                packageName = "pkg",
+                iconUrl = "url",
+                description = "Description",
+                screenshots = emptyList(),
+            )
+        )
         setup(fetchApps = apps, dispatchers = TestDispatchers(dispatcherExtension.testDispatcher))
         toggleAndAssert(packageName = "pkg", expected = true)
         toggleAndAssert(packageName = "pkg", expected = false)

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/data/repository/DeveloperAppsRepositoryImplTest.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/data/repository/DeveloperAppsRepositoryImplTest.kt
@@ -25,7 +25,15 @@ class DeveloperAppsRepositoryImplTest {
 
     @Test
     fun `fetchDeveloperApps returns apps list`() = runTest {
-        val apps = listOf(AppInfo("App", "pkg", "icon"))
+        val apps = listOf(
+            AppInfo(
+                name = "App",
+                packageName = "pkg",
+                iconUrl = "icon",
+                description = "Description",
+                screenshots = emptyList(),
+            )
+        )
         val response = ApiResponse(AppDataWrapper(apps.map { AppInfoDto(it.name, it.packageName, it.iconUrl) }))
         val json = Json.encodeToString(response)
         val client = HttpClient(MockEngine { request ->
@@ -65,9 +73,27 @@ class DeveloperAppsRepositoryImplTest {
     @Test
     fun `fetchDeveloperApps sorts apps alphabetically ignoring case`() = runTest {
         val unsorted = listOf(
-            AppInfo("zeta", "pkg1", "icon"),
-            AppInfo("Alpha", "pkg2", "icon"),
-            AppInfo("beta", "pkg3", "icon"),
+            AppInfo(
+                name = "zeta",
+                packageName = "pkg1",
+                iconUrl = "icon",
+                description = "Description",
+                screenshots = emptyList(),
+            ),
+            AppInfo(
+                name = "Alpha",
+                packageName = "pkg2",
+                iconUrl = "icon",
+                description = "Description",
+                screenshots = emptyList(),
+            ),
+            AppInfo(
+                name = "beta",
+                packageName = "pkg3",
+                iconUrl = "icon",
+                description = "Description",
+                screenshots = emptyList(),
+            ),
         )
         val response = ApiResponse(AppDataWrapper(unsorted.map { AppInfoDto(it.name, it.packageName, it.iconUrl) }))
         val json = Json.encodeToString(response)

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/usecases/FetchDeveloperAppsUseCaseTest.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/usecases/FetchDeveloperAppsUseCaseTest.kt
@@ -20,7 +20,15 @@ class FetchDeveloperAppsUseCaseTest {
 
     @Test
     fun `use case prepends loading state to repository emissions`() = runTest {
-        val apps = listOf(AppInfo(name = "App", packageName = "pkg", iconUrl = "icon"))
+        val apps = listOf(
+            AppInfo(
+                name = "App",
+                packageName = "pkg",
+                iconUrl = "icon",
+                description = "Description",
+                screenshots = emptyList(),
+            )
+        )
         val repositoryEmissions = listOf(
             DataState.Success(apps),
             DataState.Error<List<AppInfo>, Errors>(error = Errors.Network.REQUEST_TIMEOUT),

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/BuildAppListItemsTest.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/components/BuildAppListItemsTest.kt
@@ -11,7 +11,15 @@ class BuildAppListItemsTest {
 
     @Test
     fun `buildAppListItems inserts ads at configured frequency`() {
-        val apps = (1..8).map { AppInfo("App$it", "pkg$it", "icon$it") }
+        val apps = (1..8).map {
+            AppInfo(
+                name = "App$it",
+                packageName = "pkg$it",
+                iconUrl = "icon$it",
+                description = "Description $it",
+                screenshots = emptyList(),
+            )
+        }
         val items = buildAppListItems(apps, adsEnabled = true, adFrequency = 4)
 
         assertEquals(10, items.size)
@@ -21,7 +29,15 @@ class BuildAppListItemsTest {
 
     @Test
     fun `buildAppListItems adds trailing ad when apps count not multiple of frequency`() {
-        val apps = (1..5).map { AppInfo("App$it", "pkg$it", "icon$it") }
+        val apps = (1..5).map {
+            AppInfo(
+                name = "App$it",
+                packageName = "pkg$it",
+                iconUrl = "icon$it",
+                description = "Description $it",
+                screenshots = emptyList(),
+            )
+        }
         val items = buildAppListItems(apps, adsEnabled = true, adFrequency = 4)
 
         assertEquals(7, items.size)
@@ -31,7 +47,15 @@ class BuildAppListItemsTest {
 
     @Test
     fun `buildAppListItems returns only apps when ads disabled`() {
-        val apps = (1..5).map { AppInfo("App$it", "pkg$it", "icon$it") }
+        val apps = (1..5).map {
+            AppInfo(
+                name = "App$it",
+                packageName = "pkg$it",
+                iconUrl = "icon$it",
+                description = "Description $it",
+                screenshots = emptyList(),
+            )
+        }
         val items = buildAppListItems(apps, adsEnabled = false, adFrequency = 4)
 
         assertEquals(apps.map { AppListItem.App(it) }, items)

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/constants/links/AppLinks.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/constants/links/AppLinks.kt
@@ -17,5 +17,5 @@ object AppLinks {
     const val LEGAL_NOTICES : String = "${AUTHOR_WEBSITE_BASE}#legal-notices"
     const val GPL_V3 : String = "https://www.gnu.org/licenses/gpl-3.0"
 
-    const val CONTACT_EMAIL : String = "contact.mihaicristiancondrea@gmail.com\n"
+    const val CONTACT_EMAIL : String = "contact.mihaicristiancondrea@gmail.com"
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/IntentsHelper.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/IntentsHelper.kt
@@ -30,7 +30,8 @@ object IntentsHelper {
      * @return `true` if the URL could be handled, `false` otherwise.
      */
     fun openUrl(context : Context , url : String) : Boolean {
-        val intent = Intent(Intent.ACTION_VIEW , url.toUri()).apply {
+        val intent = Intent(Intent.ACTION_VIEW , url.trim().toUri()).apply {
+            addCategory(Intent.CATEGORY_BROWSABLE)
             addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
         }
         return intent.resolveActivity(context.packageManager)?.let {


### PR DESCRIPTION
## Summary
- remove the trailing newline from the help contact email constant
- trim and mark VIEW intents as browsable before launching URLs so Issue Reporter links resolve reliably

## Testing
- ./gradlew test *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d8efad19c0832d9d13ad13913f171f