### PR TITLE
Sanitize app media URLs before mapping to domain

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/data/model/api/AppInfoDto.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/data/model/api/AppInfoDto.kt
@@ -1,6 +1,8 @@
 package com.d4rk.android.apps.apptoolkit.app.apps.list.data.model.api
 
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
+import com.d4rk.android.apps.apptoolkit.app.apps.list.utils.constants.PlayStoreUrls
+import com.d4rk.android.libs.apptoolkit.core.utils.extensions.sanitizeUrlOrNull
 import kotlinx.serialization.SerialName
 import kotlinx.serialization.Serializable
 
@@ -16,7 +18,9 @@ data class AppInfoDto(
 fun AppInfoDto.toDomain(): AppInfo = AppInfo(
     name = name,
     packageName = packageName,
-    iconUrl = iconUrl,
+    iconUrl = iconUrl.sanitizeUrlOrNull() ?: PlayStoreUrls.DEFAULT_ICON_URL,
     description = description ?: "",
-    screenshots = screenshots ?: emptyList()
+    screenshots = screenshots
+        ?.mapNotNull { it.sanitizeUrlOrNull() }
+        ?: emptyList()
 )

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/data/model/api/AppInfoDtoTest.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/list/data/model/api/AppInfoDtoTest.kt
@@ -1,0 +1,51 @@
+package com.d4rk.android.apps.apptoolkit.app.apps.list.data.model.api
+
+import com.d4rk.android.apps.apptoolkit.app.apps.list.utils.constants.PlayStoreUrls
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+import org.junit.jupiter.api.Test
+
+class AppInfoDtoTest {
+
+    @Test
+    fun `toDomain trims urls and drops blank screenshots`() {
+        val dto = AppInfoDto(
+            name = "App Toolkit",
+            packageName = "com.d4rk.apptoolkit",
+            iconUrl = "  https://example.com/icon.png  ",
+            description = "Test description",
+            screenshots = listOf(
+                " https://example.com/screenshot1.png ",
+                "\t\n  ",
+                "https://example.com/screenshot2.png"
+            )
+        )
+
+        val domain = dto.toDomain()
+
+        assertEquals("https://example.com/icon.png", domain.iconUrl)
+        assertEquals(
+            listOf(
+                "https://example.com/screenshot1.png",
+                "https://example.com/screenshot2.png"
+            ),
+            domain.screenshots
+        )
+    }
+
+    @Test
+    fun `toDomain falls back to default icon when sanitized url is blank`() {
+        val dto = AppInfoDto(
+            name = "App Toolkit",
+            packageName = "com.d4rk.apptoolkit",
+            iconUrl = "   ",
+            description = null,
+            screenshots = listOf("  ")
+        )
+
+        val domain = dto.toDomain()
+
+        assertEquals(PlayStoreUrls.DEFAULT_ICON_URL, domain.iconUrl)
+        assertTrue(domain.screenshots.isEmpty())
+    }
+}

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/extensions/UrlExtensions.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/extensions/UrlExtensions.kt
@@ -1,0 +1,19 @@
+package com.d4rk.android.libs.apptoolkit.core.utils.extensions
+
+import android.net.Uri
+
+/**
+ * Sanitizes a URL string by trimming whitespace and returning `null` for blank inputs.
+ */
+fun String?.sanitizeUrlOrNull(): String? {
+    if (this == null) return null
+    val sanitized = trim()
+    return sanitized.takeUnless { it.isEmpty() }
+}
+
+/**
+ * Produces a [Uri] from a sanitized string, or `null` when the input is blank or invalid.
+ */
+fun String?.sanitizeUriOrNull(): Uri? = sanitizeUrlOrNull()?.let { url ->
+    runCatching { Uri.parse(url) }.getOrNull()
+}


### PR DESCRIPTION
## Summary
- add shared extensions to sanitize URL strings and optionally convert them to Uri values
- sanitize icon and screenshot URLs when converting AppInfoDto to its domain model and fall back to the default icon when blank
- add unit coverage ensuring whitespace and empty screenshot entries are removed by the mapper

## Testing
- ./gradlew test *(fails: Android SDK is not configured in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68daa6a8725c832d901a33e6ca67c45c