### PR TITLE
Keep app details sheet open after toggling favorites

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsScreen.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsScreen.kt
@@ -104,7 +104,6 @@ fun FavoriteAppsRoute(paddingValues: PaddingValues) {
                 },
                 onFavoriteClick = {
                     coroutineScope.launch {
-                        selectedApp = null
                         onFavoriteToggle(app.packageName)
                     }
                 }

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListScreen.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListScreen.kt
@@ -101,7 +101,6 @@ fun AppsListRoute(paddingValues: PaddingValues) {
                 },
                 onFavoriteClick = {
                     coroutineScope.launch {
-                        selectedApp = null
                         onFavoriteToggle(app.packageName)
                     }
                 }


### PR DESCRIPTION
## Summary
- stop clearing the selected app when toggling favorites from the details sheet so the bottom sheet stays visible

## Testing
- `./gradlew test` *(fails: SDK location not found in container)*

------
https://chatgpt.com/codex/tasks/task_e_68dd3414da14832d8a29df342e0cfb6f