### PR TITLE
Fix onboarding theme default state

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/components/pages/ThemeOnboardingPageTab.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/components/pages/ThemeOnboardingPageTab.kt
@@ -43,8 +43,8 @@ fun ThemeOnboardingPageTab() {
     val context: Context = LocalContext.current
     val dataStore: CommonDataStore = CommonDataStore.getInstance(context = context)
 
-    val defaultThemeModeName: String = stringResource(id = R.string.follow_system)
-    val currentThemeMode: String by dataStore.themeMode.collectAsStateWithLifecycle(initialValue = defaultThemeModeName)
+    val defaultThemeModeKey: String = DataStoreNamesConstants.THEME_MODE_FOLLOW_SYSTEM
+    val currentThemeMode: String by dataStore.themeMode.collectAsStateWithLifecycle(initialValue = defaultThemeModeKey)
     val isAmoledMode: Boolean by dataStore.amoledMode.collectAsStateWithLifecycle(initialValue = false)
 
     val themeChoices: List<OnboardingThemeChoice> = listOf(


### PR DESCRIPTION
## Summary
- ensure the theme onboarding page defaults to the underlying DataStore key instead of the localized label
- keep the selection UI in sync with the persisted preference from the first composition

## Testing
- ./gradlew test *(fails: Android SDK is not available in the CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e001734b4c832d87ae630ee6601300