### PR TITLE
Fix favorite apps flow completion handling

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/domain/usecases/ObserveFavoriteAppsUseCase.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/domain/usecases/ObserveFavoriteAppsUseCase.kt
@@ -6,8 +6,11 @@ import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.RootError
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.combine
+import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flowOn
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onCompletion
+import kotlinx.coroutines.flow.transformLatest
 
 /**
  * Use case that combines the list of developer apps with the current set of
@@ -19,19 +22,28 @@ class ObserveFavoriteAppsUseCase(
     private val dispatchers: DispatcherProvider,
 ) {
     suspend operator fun invoke(): Flow<DataState<List<AppInfo>, RootError>> {
-        return combine(
-            fetchDeveloperAppsUseCase().flowOn(dispatchers.io),
-            observeFavoritesUseCase()
-        ) { dataState, favorites ->
-            when (dataState) {
-                is DataState.Success -> {
-                    val apps = dataState.data.filter { favorites.contains(it.packageName) }
-                    DataState.Success(apps)
+        return fetchDeveloperAppsUseCase()
+            .transformLatest { dataState ->
+                when (dataState) {
+                    is DataState.Success -> {
+                        val favoritesFlow = observeFavoritesUseCase()
+                            .onCompletion { cause ->
+                                if (cause == null) {
+                                    emit(emptySet())
+                                }
+                            }
+                            .map { favorites ->
+                                val favoriteApps = dataState.data.filter { favorites.contains(it.packageName) }
+                                DataState.Success(favoriteApps)
+                            }
+                        emitAll(favoritesFlow)
+                    }
+
+                    is DataState.Error -> emit(DataState.Error(data = dataState.data, error = dataState.error))
+                    is DataState.Loading -> emit(DataState.Loading(data = dataState.data))
                 }
-                is DataState.Error -> dataState
-                is DataState.Loading -> DataState.Loading()
             }
-        }.flowOn(dispatchers.io)
+            .flowOn(dispatchers.io)
     }
 }
 

--- a/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModel.kt
+++ b/app/src/test/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModel.kt
@@ -129,4 +129,37 @@ class TestFavoriteAppsViewModel : TestFavoriteAppsViewModelBase() {
             cancelAndIgnoreRemainingEvents()
         }
     }
+
+    @Test
+    fun `removing last favorite shows no data state`() = runTest(dispatcherExtension.testDispatcher) {
+        val apps = listOf(
+            AppInfo(
+                name = "App",
+                packageName = "pkg",
+                iconUrl = "url",
+                description = "Description",
+                screenshots = emptyList(),
+            )
+        )
+        setup(
+            fetchApps = apps,
+            initialFavorites = setOf("pkg"),
+            dispatchers = TestDispatchers(dispatcherExtension.testDispatcher)
+        )
+
+        viewModel.uiState.test {
+            awaitItem() // Initial loading
+            val success = awaitItem()
+            assertThat(success.screenState).isInstanceOf(ScreenState.Success::class.java)
+            assertThat(success.data?.apps?.map { it.packageName }).containsExactly("pkg")
+
+            viewModel.toggleFavorite("pkg")
+
+            val noData = awaitItem()
+            assertThat(noData.screenState).isInstanceOf(ScreenState.NoData::class.java)
+            assertThat(noData.data?.apps).isEmpty()
+
+            cancelAndIgnoreRemainingEvents()
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- rework the favorite apps observer to transform fetch results with the favorites stream so UI updates remain reactive
- use onCompletion to emit a clearing update only when the favorites flow finishes successfully
- add a regression test covering the no-data state after removing the final favorite

## Testing
- ./gradlew test *(fails: SDK location not found in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f24bb66e7c832db4e693b90d7f8983