### PR TITLE
fix: reapply CTA click confirm on XML native ads

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NativeAdViewBinder.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/ui/components/ads/NativeAdViewBinder.kt
@@ -80,7 +80,6 @@ object NativeAdViewBinder {
         nativeAdView.iconView = iconView
         nativeAdView.adChoicesView = adChoicesView
         nativeAdView.advertiserView = labelView
-        callToActionView?.let(nativeAdView::setClickConfirmingView)
 
         adChoicesView?.isVisible = true
 
@@ -138,6 +137,7 @@ object NativeAdViewBinder {
             debugNativeAds("registerNativeAdViewCompat unavailable - falling back to setNativeAd")
             nativeAdView.setNativeAd(nativeAd)
         }
+        callToActionView?.let(nativeAdView::setClickConfirmingView)
         logClickableState("labelView (after setNativeAd)", labelView)
         logClickableState("headlineView (after setNativeAd)", headlineView)
         logClickableState("ctaView (after setNativeAd)", callToActionView)


### PR DESCRIPTION
## Summary
- ensure `NativeAdViewBinder` reapplies the call-to-action view as the click confirming view after binding so XML-based native ad layouts keep AdMob click handling

## Testing
- ./gradlew test *(fails: Android SDK not available in CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f896dcdcf8832dab410e4290c22e9c