### PR TITLE
Increase issue reporter network timeout

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/client/KtorClient.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/data/client/KtorClient.kt
@@ -24,7 +24,8 @@ import kotlinx.serialization.json.Json
  */
 object KtorClient {
 
-    private const val requestTimeout: Long = 10_000L
+    // Using a 30s timeout gives GitHub's API enough time to respond on slower networks.
+    private const val requestTimeout: Long = 30_000L
     private var client: HttpClient? = null
 
     /**


### PR DESCRIPTION
## Summary
- increase the Ktor client's timeout window to 30 seconds so GitHub API calls have longer to complete
- document the intent behind the higher timeout to aid future adjustments

## Testing
- ./gradlew test *(fails: SDK location not found in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68fa4ff3c318832daab211d862ccdf08