### PR TITLE
Update developer apps API to versioned GitHub Pages endpoint

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -90,7 +90,7 @@ android {
     }
 
     val developerAppsBaseUrl =
-        "https://raw.githubusercontent.com/MihaiCristianCondrea/com.d4rk.apis/refs/heads/main/App%20Toolkit"
+        "https://mihaicristiancondrea.github.io/com.d4rk.apis/api/app_toolkit/v1"
 
     buildTypes {
         release {

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/utils/constants/api/ApiConstants.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/utils/constants/api/ApiConstants.kt
@@ -4,8 +4,11 @@ import com.d4rk.android.libs.apptoolkit.core.utils.constants.github.GithubConsta
 
 object ApiHost {
     const val API_REPO: String = "com.d4rk.apis"
-    const val API_BRANCH: String = "main"
-    const val API_FOLDER_PATH: String = "App%20Toolkit"
+    const val API_BASE_PATH: String = "api/app_toolkit"
+}
+
+object ApiVersions {
+    const val V1: String = "v1"
 }
 
 object ApiEnvironments {
@@ -18,5 +21,6 @@ object ApiPaths {
 }
 
 object ApiConstants {
-    const val BASE_REPOSITORY_URL: String = "${GithubConstants.GITHUB_RAW}/${ApiHost.API_REPO}/refs/heads/${ApiHost.API_BRANCH}/${ApiHost.API_FOLDER_PATH}"
+    const val BASE_REPOSITORY_URL: String =
+        "${GithubConstants.GITHUB_PAGES}/${ApiHost.API_REPO}/${ApiHost.API_BASE_PATH}/${ApiVersions.V1}"
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/constants/github/GithubConstants.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/constants/github/GithubConstants.kt
@@ -5,5 +5,6 @@ object GithubConstants {
     const val GITHUB_BASE : String = "https://github.com/$GITHUB_USER/"
     const val GITHUB_ISSUES_SUFFIX : String = "/issues/new"
     const val GITHUB_RAW : String = "https://raw.githubusercontent.com/$GITHUB_USER"
+    const val GITHUB_PAGES : String = "https://mihaicristiancondrea.github.io"
     fun githubChangelog(repository: String) : String = "$GITHUB_RAW/$repository/refs/heads/master/CHANGELOG.md"
 }


### PR DESCRIPTION
## Summary
- switch the developer apps configuration to the new GitHub Pages API structure that includes versioning
- expose the GitHub Pages host constant for reuse when constructing API URLs

## Testing
- ./gradlew test *(fails: SDK location not found in the CI container)*

------
https://chatgpt.com/codex/tasks/task_e_68fdf87bff80832db2630bf0f0c8f4a0