### PR TITLE
Adjust ad spacing in app details sheet

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/common/AppDetailsBottomSheet.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/common/AppDetailsBottomSheet.kt
@@ -141,10 +141,10 @@ fun AppDetailsBottomSheet(
             }
         }
 
-        LargeVerticalSpacer()
         AppDetailsNativeAd(
             modifier = Modifier
-                .fillMaxWidth(),
+                .fillMaxWidth()
+                .padding(top = SizeConstants.LargeSize),
             adsConfig = adsConfig
         )
 


### PR DESCRIPTION
## Summary
- remove the unconditional spacer before the app details native ad
- apply top padding directly to the ad so spacing appears only when it renders

## Testing
- ./gradlew test *(fails: Android SDK not configured in CI container)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691443e46dfc832da168fb423f6b8e11)