### PR TITLE
Centralize log tags and add FCM logging

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsScreen.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsScreen.kt
@@ -31,6 +31,7 @@ import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.ui.UiHomeScreen
 import com.d4rk.android.apps.apptoolkit.app.main.ui.components.navigation.RandomAppHandler
 import com.d4rk.android.apps.apptoolkit.app.main.utils.constants.NavigationRoutes
+import com.d4rk.android.apps.apptoolkit.app.logging.FAVORITES_LOG_TAG
 import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
@@ -44,8 +45,6 @@ import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.qualifier.named
-
-private const val FAVORITES_LOG_TAG = "FavoriteAppsRoute"
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListScreen.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListScreen.kt
@@ -28,6 +28,7 @@ import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.ui.UiHomeScreen
 import com.d4rk.android.apps.apptoolkit.app.main.ui.components.navigation.RandomAppHandler
 import com.d4rk.android.apps.apptoolkit.app.main.utils.constants.NavigationRoutes
+import com.d4rk.android.apps.apptoolkit.app.logging.APPS_LIST_LOG_TAG
 import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ads.AdsConfig
 import com.d4rk.android.libs.apptoolkit.core.domain.model.ui.UiStateScreen
@@ -41,8 +42,6 @@ import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.qualifier.named
-
-private const val APPS_LIST_LOG_TAG = "AppsListRoute"
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/logging/LogTags.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/logging/LogTags.kt
@@ -1,0 +1,7 @@
+package com.d4rk.android.apps.apptoolkit.app.logging
+
+const val APPS_LIST_LOG_TAG = "AppsListRoute"
+const val FAVORITES_LOG_TAG = "FavoriteAppsRoute"
+const val FAB_LOG_TAG = "MainFabState"
+const val FAVORITES_REPOSITORY_LOG_TAG = "FavoritesRepositoryImpl"
+const val FAVORITES_CHANGED_LOG_TAG = "FavoritesChangedRcvr"

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainScreen.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/app/main/ui/MainScreen.kt
@@ -46,6 +46,7 @@ import com.d4rk.android.apps.apptoolkit.app.main.ui.components.navigation.Naviga
 import com.d4rk.android.apps.apptoolkit.app.main.ui.components.navigation.RandomAppHandler
 import com.d4rk.android.apps.apptoolkit.app.main.ui.components.navigation.handleNavigationItemClick
 import com.d4rk.android.apps.apptoolkit.app.main.utils.constants.NavigationRoutes
+import com.d4rk.android.apps.apptoolkit.app.logging.FAB_LOG_TAG
 import com.d4rk.android.libs.apptoolkit.app.main.domain.model.BottomBarItem
 import com.d4rk.android.libs.apptoolkit.app.main.ui.components.dialogs.ChangelogDialog
 import com.d4rk.android.libs.apptoolkit.app.main.ui.components.navigation.BottomNavigationBar
@@ -62,8 +63,6 @@ import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.qualifier.named
-
-private const val FAB_LOG_TAG = "MainFabState"
 
 private val FabSupportedRoutes = setOf(
     NavigationRoutes.ROUTE_APPS_LIST,

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/broadcast/FavoritesChangedReceiver.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/broadcast/FavoritesChangedReceiver.kt
@@ -4,16 +4,16 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.util.Log
+import com.d4rk.android.apps.apptoolkit.app.logging.FAVORITES_CHANGED_LOG_TAG
 
 class FavoritesChangedReceiver : BroadcastReceiver() {
     override fun onReceive(context: Context, intent: Intent?) {
         val pkg = intent?.getStringExtra(EXTRA_PACKAGE_NAME)
-        Log.d(TAG, "Favorites changed: $pkg")
+        Log.d(FAVORITES_CHANGED_LOG_TAG, "Favorites changed: $pkg")
     }
 
     companion object {
         const val ACTION_FAVORITES_CHANGED = "com.d4rk.android.apps.apptoolkit.action.FAVORITES_CHANGED"
         const val EXTRA_PACKAGE_NAME = "extra_package_name"
-        private const val TAG = "FavoritesChangedRcvr"
     }
 }

--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/data/favorites/FavoritesRepositoryImpl.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/data/favorites/FavoritesRepositoryImpl.kt
@@ -7,6 +7,7 @@ import android.util.Log
 import com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.repository.FavoritesRepository
 import com.d4rk.android.apps.apptoolkit.core.broadcast.FavoritesChangedReceiver
 import com.d4rk.android.apps.apptoolkit.core.data.datastore.DataStore
+import com.d4rk.android.apps.apptoolkit.app.logging.FAVORITES_REPOSITORY_LOG_TAG
 import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOn
@@ -29,7 +30,7 @@ class FavoritesRepositoryImpl(
             runCatching {
                 context.sendBroadcast(intent)
             }.onFailure { e ->
-                Log.w("FavoritesRepositoryImpl", "Failed to send favorites broadcast", e)
+                Log.w(FAVORITES_REPOSITORY_LOG_TAG, "Failed to send favorites broadcast", e)
             }
         }
 

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/display/DisplaySettingsList.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/display/DisplaySettingsList.kt
@@ -28,6 +28,7 @@ import androidx.core.os.LocaleListCompat
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.display.components.dialogs.SelectLanguageAlertDialog
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.DisplaySettingsProvider
+import com.d4rk.android.libs.apptoolkit.core.logging.DISPLAY_SETTINGS_LOG_TAG
 import com.d4rk.android.libs.apptoolkit.core.ui.components.preferences.PreferenceCategoryItem
 import com.d4rk.android.libs.apptoolkit.core.ui.components.preferences.SettingsPreferenceItem
 import com.d4rk.android.libs.apptoolkit.core.ui.components.preferences.SwitchPreferenceItem
@@ -42,8 +43,6 @@ import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 
-private const val DISPLAY_SETTINGS_TAG : String = "DisplaySettings"
-
 @Composable
 fun DisplaySettingsList(paddingValues : PaddingValues = PaddingValues() , provider : DisplaySettingsProvider) {
     val coroutineScope : CoroutineScope = rememberCoroutineScope()
@@ -56,7 +55,7 @@ fun DisplaySettingsList(paddingValues : PaddingValues = PaddingValues() , provid
         initialValue = DataStoreNamesConstants.THEME_MODE_FOLLOW_SYSTEM
     ) { cause : Throwable? ->
         if (cause != null && cause !is CancellationException) {
-            Log.w(DISPLAY_SETTINGS_TAG , "Theme mode flow completed with an error." , cause)
+            Log.w(DISPLAY_SETTINGS_LOG_TAG , "Theme mode flow completed with an error." , cause)
             dataStore.themeModeState.value = DataStoreNamesConstants.THEME_MODE_FOLLOW_SYSTEM
         }
     }
@@ -79,17 +78,17 @@ fun DisplaySettingsList(paddingValues : PaddingValues = PaddingValues() , provid
 
     val isDynamicColors : Boolean by dataStore.dynamicColors.collectWithLifecycleOnCompletion(initialValue = true) { cause : Throwable? ->
         if (cause != null && cause !is CancellationException) {
-            Log.w(DISPLAY_SETTINGS_TAG , "Dynamic color flow completed with an error." , cause)
+            Log.w(DISPLAY_SETTINGS_LOG_TAG , "Dynamic color flow completed with an error." , cause)
         }
     }
     val bouncyButtons : Boolean by dataStore.bouncyButtons.collectWithLifecycleOnCompletion(initialValue = true) { cause : Throwable? ->
         if (cause != null && cause !is CancellationException) {
-            Log.w(DISPLAY_SETTINGS_TAG , "Bouncy buttons flow completed with an error." , cause)
+            Log.w(DISPLAY_SETTINGS_LOG_TAG , "Bouncy buttons flow completed with an error." , cause)
         }
     }
     val showLabelsOnBottomBar : Boolean by dataStore.getShowBottomBarLabels().collectWithLifecycleOnCompletion(initialValue = true) { cause : Throwable? ->
         if (cause != null && cause !is CancellationException) {
-            Log.w(DISPLAY_SETTINGS_TAG , "Bottom bar label flow completed with an error." , cause)
+            Log.w(DISPLAY_SETTINGS_LOG_TAG , "Bottom bar label flow completed with an error." , cause)
         }
     }
 

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/GeneralSettingsActivity.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/GeneralSettingsActivity.kt
@@ -10,6 +10,7 @@ import androidx.appcompat.app.AppCompatActivity
 import com.d4rk.android.libs.apptoolkit.app.settings.general.domain.actions.GeneralSettingsEvent
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.GeneralSettingsContentProvider
 import com.d4rk.android.libs.apptoolkit.app.theme.style.AppTheme
+import com.d4rk.android.libs.apptoolkit.core.logging.GENERAL_SETTINGS_LOG_TAG
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
@@ -31,7 +32,7 @@ class GeneralSettingsActivity : AppCompatActivity() {
             intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             intent.resolveActivity(context.packageManager)?.let {
                 runCatching { context.startActivity(intent) }
-            } ?: Log.e("GeneralSettingsActivity" , "Unable to resolve activity to handle intent")
+            } ?: Log.e(GENERAL_SETTINGS_LOG_TAG , "Unable to resolve activity to handle intent")
         }
     }
 

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupActivity.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupActivity.kt
@@ -16,6 +16,7 @@ import com.d4rk.android.libs.apptoolkit.app.startup.domain.actions.StartupAction
 import com.d4rk.android.libs.apptoolkit.app.startup.domain.actions.StartupEvent
 import com.d4rk.android.libs.apptoolkit.app.startup.utils.interfaces.providers.StartupProvider
 import com.d4rk.android.libs.apptoolkit.app.theme.style.AppTheme
+import com.d4rk.android.libs.apptoolkit.core.logging.STARTUP_LOG_TAG
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.ConsentFormHelper
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.IntentsHelper
 import com.google.android.ump.ConsentInformation
@@ -25,8 +26,6 @@ import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.launch
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
-
-private const val STARTUP_LOG_TAG : String = "StartupActivity"
 
 class StartupActivity : AppCompatActivity() {
     private val provider : StartupProvider by inject()

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/logging/LogTags.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/logging/LogTags.kt
@@ -1,0 +1,8 @@
+package com.d4rk.android.libs.apptoolkit.core.logging
+
+const val STARTUP_LOG_TAG: String = "StartupActivity"
+const val DISPLAY_SETTINGS_LOG_TAG: String = "DisplaySettings"
+const val CLIPBOARD_HELPER_LOG_TAG: String = "ClipboardHelper"
+const val CONSENT_FORM_HELPER_LOG_TAG: String = "ConsentFormHelper"
+const val GENERAL_SETTINGS_LOG_TAG: String = "GeneralSettingsActivity"
+const val FCM_LOG_TAG: String = "FirebaseNotifications"

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/services/FirebaseNotificationsService.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/services/FirebaseNotificationsService.kt
@@ -1,8 +1,21 @@
 package com.d4rk.android.libs.apptoolkit.core.services
 
+import android.util.Log
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
+import com.d4rk.android.libs.apptoolkit.core.logging.FCM_LOG_TAG
 
 class FirebaseNotificationsService : FirebaseMessagingService() {
+    override fun onNewToken(token: String) {
+        super.onNewToken(token)
+        Log.d(FCM_LOG_TAG, "Refreshed FCM token: $token")
+    }
 
+    override fun onMessageReceived(message: RemoteMessage) {
+        super.onMessageReceived(message)
+        Log.d(FCM_LOG_TAG, "Received FCM message from ${message.from}")
+        if (message.data.isNotEmpty()) {
+            Log.d(FCM_LOG_TAG, "Message data payload size=${message.data.size}")
+        }
+    }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/ClipboardHelper.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/ClipboardHelper.kt
@@ -5,6 +5,7 @@ import android.content.ClipboardManager
 import android.content.Context
 import android.os.Build
 import android.util.Log
+import com.d4rk.android.libs.apptoolkit.core.logging.CLIPBOARD_HELPER_LOG_TAG
 
 /**
  *  A helper object for managing clipboard operations.
@@ -34,7 +35,7 @@ object ClipboardHelper {
                 onShowSnackbar()
             }
         } else {
-            Log.w("ClipboardHelper" , "Clipboard service unavailable")
+            Log.w(CLIPBOARD_HELPER_LOG_TAG , "Clipboard service unavailable")
         }
     }
 }

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/ConsentFormHelper.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/core/utils/helpers/ConsentFormHelper.kt
@@ -3,6 +3,7 @@ package com.d4rk.android.libs.apptoolkit.core.utils.helpers
 import android.app.Activity
 import android.util.Log
 import com.d4rk.android.libs.apptoolkit.R
+import com.d4rk.android.libs.apptoolkit.core.logging.CONSENT_FORM_HELPER_LOG_TAG
 import com.google.android.ump.ConsentForm
 import com.google.android.ump.ConsentInformation
 import com.google.android.ump.ConsentRequestParameters
@@ -48,15 +49,15 @@ object ConsentFormHelper {
                                 if (continuation.isActive) continuation.resume(Unit)
                             }
                         }.onFailure {
-                            Log.e("ConsentFormHelper", "Failed to load consent form", it)
+                            Log.e(CONSENT_FORM_HELPER_LOG_TAG, "Failed to load consent form", it)
                             if (continuation.isActive) continuation.resume(Unit)
                         }
                     }, { t ->
-                        Log.e("ConsentFormHelper", "Failed to load consent form: ${t.message}")
+                        Log.e(CONSENT_FORM_HELPER_LOG_TAG, "Failed to load consent form: ${t.message}")
                         if (continuation.isActive) continuation.resume(Unit)
                     })
                 }.onFailure {
-                    Log.e("ConsentFormHelper", "Failed to load consent form", it)
+                    Log.e(CONSENT_FORM_HELPER_LOG_TAG, "Failed to load consent form", it)
                     if (continuation.isActive) continuation.resume(Unit)
                 }
             }, {


### PR DESCRIPTION
## Summary
- centralize log tag constants for app and library modules
- update existing log statements to use the shared log tag constants
- add logging hooks for Firebase notifications token updates and message handling

## Testing
- ./gradlew test *(fails: Android SDK location not configured in container environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693281ac1bb8832d97be8b0dca466323)