### PR TITLE
Bind CommonDataStore for ads settings

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppModule.kt
@@ -21,13 +21,14 @@ import com.d4rk.android.libs.apptoolkit.app.main.domain.repository.NavigationRep
 import com.d4rk.android.libs.apptoolkit.app.onboarding.utils.interfaces.providers.OnboardingProvider
 import com.d4rk.android.libs.apptoolkit.data.client.KtorClient
 import com.d4rk.android.libs.apptoolkit.data.core.ads.AdsCoreManager
+import com.d4rk.android.libs.apptoolkit.data.datastore.CommonDataStore
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.viewModel
 import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 val appModule : Module = module {
-    single<DataStore> { DataStore(context = get(), dispatchers = get()) }
+    single<CommonDataStore> { DataStore(context = get(), dispatchers = get()) }
     single<AdsCoreManager> { AdsCoreManager(context = get(), buildInfoProvider = get(), dispatchers = get()) }
     single { KtorClient.createClient(enableLogging = BuildConfig.DEBUG) }
 


### PR DESCRIPTION
## Summary
- bind the shared DataStore implementation to CommonDataStore so ads dependencies resolve
- fix AdsSettingsViewModel injection crash on the ads settings screen

## Testing
- ./gradlew test *(fails: Android SDK not configured in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69340deac66c832d810eb918d072c00c)