### PR TITLE
Bind app DataStore for Koin injection

### DIFF
--- a/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppModule.kt
+++ b/app/src/main/java/com/d4rk/android/apps/apptoolkit/core/di/modules/AppModule.kt
@@ -28,7 +28,8 @@ import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 val appModule : Module = module {
-    single<CommonDataStore> { DataStore(context = get(), dispatchers = get()) }
+    single { DataStore(context = get(), dispatchers = get()) }
+    single<CommonDataStore> { get<DataStore>() }
     single<AdsCoreManager> { AdsCoreManager(context = get(), buildInfoProvider = get(), dispatchers = get()) }
     single { KtorClient.createClient(enableLogging = BuildConfig.DEBUG) }
 


### PR DESCRIPTION
## Summary
- register the app-specific DataStore in the Koin module and bind it to the shared CommonDataStore type

## Testing
- `./gradlew test` *(fails: SDK location not found in CI environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6934158cc2f8832da976edea22c3d273)