### PR TITLE
Render FAQ answers with HTML formatting

### DIFF
--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/data/DefaultHelpRepository.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/data/DefaultHelpRepository.kt
@@ -2,7 +2,6 @@ package com.d4rk.android.libs.apptoolkit.app.help.data
 
 import android.content.Context
 import android.util.Log
-import androidx.core.text.HtmlCompat
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.help.domain.data.model.FaqCatalog
 import com.d4rk.android.libs.apptoolkit.app.help.domain.data.model.FaqQuestion
@@ -78,10 +77,7 @@ class DefaultHelpRepository(
                 UiHelpQuestion(
                     id = index,
                     question = question.question,
-                    answer = HtmlCompat.fromHtml(
-                        question.answer,
-                        HtmlCompat.FROM_HTML_MODE_COMPACT
-                    ).toString().trim(),
+                    answer = question.answer.trim(),
                 )
             }.filter { it.question.isNotBlank() && it.answer.isNotBlank() }
 

--- a/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/ui/components/QuestionCard.kt
+++ b/apptoolkit/src/main/java/com/d4rk/android/libs/apptoolkit/app/help/ui/components/QuestionCard.kt
@@ -1,7 +1,9 @@
 package com.d4rk.android.libs.apptoolkit.app.help.ui.components
 
+import android.text.method.LinkMovementMethod
 import android.view.SoundEffectConstants
 import android.view.View
+import android.widget.TextView
 import androidx.compose.animation.animateContentSize
 import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.foundation.background
@@ -28,10 +30,16 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.rotate
+import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.unit.isSpecified
+import androidx.compose.ui.viewinterop.AndroidView
+import androidx.core.text.HtmlCompat
 import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.OutlinedIconButton
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.LargeHorizontalSpacer
@@ -84,11 +92,31 @@ fun QuestionCard(title : String , summary : String , isExpanded : Boolean , onTo
             }
             if (isExpanded) {
                 SmallVerticalSpacer()
-                Text(
+                HtmlText(
                     text = summary ,
                     style = MaterialTheme.typography.bodyMedium ,
                 )
             }
         }
     }
+}
+
+@Composable
+private fun HtmlText(text : String , modifier : Modifier = Modifier , style : TextStyle) {
+    val context = LocalContext.current
+    val color = MaterialTheme.colorScheme.onSurface
+    val fontSize = if (style.fontSize.isSpecified) style.fontSize.value else MaterialTheme.typography.bodyMedium.fontSize.value
+    AndroidView(
+        modifier = modifier.fillMaxWidth() ,
+        factory = {
+            TextView(context).apply {
+                movementMethod = LinkMovementMethod.getInstance()
+            }
+        } ,
+        update = { textView : TextView ->
+            textView.text = HtmlCompat.fromHtml(text , HtmlCompat.FROM_HTML_MODE_COMPACT)
+            textView.setTextColor(color.toArgb())
+            textView.textSize = fontSize
+        }
+    )
 }


### PR DESCRIPTION
## Summary
- preserve FAQ answers with their HTML markup from the catalog
- render FAQ answer text using a Compose-friendly HTML TextView helper

## Testing
- ./gradlew test --console=plain *(fails: SDK location not found)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_693a8ffe7350832dbfc07c95b615ee0a)