### PR TITLE
Use size constants across UI

### DIFF
--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/IssueReporterScreen.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/IssueReporterScreen.kt
@@ -57,7 +57,6 @@ import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo
@@ -200,7 +199,9 @@ fun IssueReporterScreenContent(
             if (!data.issueUrl.isNullOrEmpty()) {
                 Card(
                     modifier = Modifier.fillMaxWidth(),
-                    elevation = CardDefaults.cardElevation(defaultElevation = 4.dp)
+                    elevation = CardDefaults.cardElevation(
+                        defaultElevation = SizeConstants.ExtraSmallSize
+                    )
                 ) {
                     Column(
                         modifier = Modifier
@@ -212,7 +213,7 @@ fun IssueReporterScreenContent(
                             imageVector = Icons.Outlined.CheckCircleOutline,
                             contentDescription = stringResource(id = R.string.issue_submitted_successfully),
                             tint = MaterialTheme.colorScheme.primary,
-                            modifier = Modifier.size(48.dp)
+                            modifier = Modifier.size(SizeConstants.ExtraExtraLargeSize)
                         )
                         SmallVerticalSpacer()
                         Text(

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/theme/ui/components/WallpaperColorOptionCard.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/theme/ui/components/WallpaperColorOptionCard.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.d4rk.android.libs.apptoolkit.app.theme.domain.model.WallpaperSwatchColors
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 
 @Composable
 fun WallpaperColorOptionCard(
@@ -28,7 +29,7 @@ fun WallpaperColorOptionCard(
     modifier: Modifier = Modifier,
     cardSize: Dp = 72.dp,
     swatchSize: Dp = 44.dp,
-    shape: RoundedCornerShape = RoundedCornerShape(16.dp),
+    shape: RoundedCornerShape = RoundedCornerShape(SizeConstants.LargeSize),
 ) {
     val borderColor = animateColorAsState(
         targetValue = if (selected) MaterialTheme.colorScheme.primary else Color.Transparent,
@@ -47,7 +48,7 @@ fun WallpaperColorOptionCard(
             ),
         shape = shape,
         color = MaterialTheme.colorScheme.surfaceContainer,
-        border = BorderStroke(2.dp, borderColor),
+        border = BorderStroke(SizeConstants.ExtraTinySize, borderColor),
     ) {
         Box(contentAlignment = Alignment.Center) {
             MaterialYouCircleSwatch(

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/components/buttons/AnimatedIconButtonDirection.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/components/buttons/AnimatedIconButtonDirection.kt
@@ -44,8 +44,10 @@ import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
  *
  * Example Usage:
  * ```
+ * import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
+ *
  *  AnimatedButtonDirection(
- *      modifier = Modifier.padding(16.dp),
+ *      modifier = Modifier.padding(SizeConstants.LargeSize),
  *      visible = is */
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/components/layouts/sections/InfoMessageSection.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/components/layouts/sections/InfoMessageSection.kt
@@ -43,9 +43,11 @@ import com.d4rk.android.libs.apptoolkit.core.utils.helpers.IntentsHelper
  *
  * Example Usage:
  * ```
+ * import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
+ *
  * InfoMessageSection(
  *     message = "This is an important information message.",
- *     modifier = Modifier.padding(16.dp),
+ *     modifier = Modifier.padding(SizeConstants.LargeSize),
  *     learnMoreText = "Learn More",
  *     learnMoreUrl = "https://www.example.com"
  * )

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/components/preferences/PreferenceItem.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/components/preferences/PreferenceItem.kt
@@ -101,7 +101,7 @@ fun PreferenceItem(
  * @param summary The optional [String] to display as the summary of the preference item.
  *               If null, no summary will be displayed.
  * @param rippleEffectDp The [Dp] value to control the size of the ripple effect when the item is clicked.
- *                      Defaults to 2.dp.
+ *                      Defaults to [SizeConstants.ExtraTinySize].
  * @param onClick The lambda function to execute when the preference item is clicked.
  *                Defaults to an empty lambda, meaning no action will be performed by default.
  */

--- a/docs/compose/compose-state.md
+++ b/docs/compose/compose-state.md
@@ -16,12 +16,14 @@ Jetpack Compose helps you be explicit about where and how you store and use stat
 Compose is declarative and as such the only way to update it is by calling the same composable with new arguments. These arguments are representations of the UI state. Any time a state is updated a recomposition takes place. As a result, things like `TextField` don’t automatically update like they do in imperative XML based views. A composable has to explicitly be told the new state in order for it to update accordingly.
 
 ```kotlin
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
+
 @Composable
 private fun HelloContent() {
-    Column(modifier = Modifier.padding(16.dp)) {
+    Column(modifier = Modifier.padding(SizeConstants.LargeSize)) {
         Text(
             text = "Hello!",
-            modifier = Modifier.padding(bottom = 8.dp),
+            modifier = Modifier.padding(bottom = SizeConstants.SmallSize),
             style = MaterialTheme.typography.bodyMedium
         )
         OutlinedTextField(
@@ -79,14 +81,16 @@ import androidx.compose.runtime.setValue
 You can use the remembered value as a parameter for other composables or even as logic in statements to change which composables are displayed. For example, if you don't want to display the greeting if the name is empty, use the state in an `if` statement:
 
 ```kotlin
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
+
 @Composable
 fun HelloContent() {
-    Column(modifier = Modifier.padding(16.dp)) {
+    Column(modifier = Modifier.padding(SizeConstants.LargeSize)) {
         var name by remember { mutableStateOf("") }
         if (name.isNotEmpty()) {
             Text(
                 text = "Hello, $name!",
-                modifier = Modifier.padding(bottom = 8.dp),
+                modifier = Modifier.padding(bottom = SizeConstants.SmallSize),
                 style = MaterialTheme.typography.bodyMedium
             )
         }
@@ -205,6 +209,8 @@ State that is hoisted this way has some important properties:
 In the example case, you extract the `name` and the `onValueChange` out of `HelloContent` and move them up the tree to a `HelloScreen` composable that calls `HelloContent`.
 
 ```kotlin
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
+
 @Composable
 fun HelloScreen() {
     var name by rememberSaveable { mutableStateOf("") }
@@ -214,10 +220,10 @@ fun HelloScreen() {
 
 @Composable
 fun HelloContent(name: String, onNameChange: (String) -> Unit) {
-    Column(modifier = Modifier.padding(16.dp)) {
+    Column(modifier = Modifier.padding(SizeConstants.LargeSize)) {
         Text(
             text = "Hello, $name",
-            modifier = Modifier.padding(bottom = 8.dp),
+            modifier = Modifier.padding(bottom = SizeConstants.SmallSize),
             style = MaterialTheme.typography.bodyMedium
         )
         OutlinedTextField(value = name, onValueChange = onNameChange, label = { Text("Name") })

--- a/docs/core/ui-components.md
+++ b/docs/core/ui-components.md
@@ -63,9 +63,11 @@ TextField(
 Arrange UI elements with layout composables such as `Column`, `Row`, and `Box`.
 
 ```kotlin
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
+
 Column(
-    modifier = Modifier.padding(16.dp),
-    verticalArrangement = Arrangement.spacedBy(8.dp)
+    modifier = Modifier.padding(SizeConstants.LargeSize),
+    verticalArrangement = Arrangement.spacedBy(SizeConstants.SmallSize)
 ) {
     Text("Header", style = MaterialTheme.typography.titleLarge)
     Button(onClick = { /* action */ }) { Text("Tap") }


### PR DESCRIPTION
## Summary
- replace hardcoded padding, elevation, and icon sizing with SizeConstants in shared UI components
- update documentation snippets to demonstrate SizeConstants instead of literal dp values
- align KDoc references to point to SizeConstants defaults

## Testing
- `./gradlew test` *(fails: SDK location not found in container environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_694789b3defc832d8f2c02adcfec758d)