### PR TITLE
Use shared size constants across UI

### DIFF
--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/AppCard.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/AppCard.kt
@@ -31,7 +31,6 @@ import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
 import com.d4rk.android.libs.apptoolkit.core.ui.components.buttons.IconButton
@@ -66,7 +65,7 @@ fun AppCard(
             Row(
                 modifier = Modifier.align(Alignment.TopEnd),
                 horizontalArrangement = Arrangement.spacedBy(
-                    space = 0.dp,
+                    space = SizeConstants.ZeroSize,
                     alignment = Alignment.End
                 )
             ) {

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/AppDetailsBottomSheet.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/AppDetailsBottomSheet.kt
@@ -39,7 +39,6 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.d4rk.android.apps.apptoolkit.R
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
@@ -198,7 +197,7 @@ fun AppDetailsBottomSheet(
                                 contentDescription = null,
                                 contentScale = ContentScale.Crop,
                                 modifier = Modifier
-                                    .height(240.dp)
+                                    .height(SizeConstants.TwoHundredFortySize)
                                     .aspectRatio(9f / 16f)
                                     .clip(RoundedCornerShape(SizeConstants.LargeSize))
                             )

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/screens/loading/HomeLoadingScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/screens/loading/HomeLoadingScreen.kt
@@ -11,7 +11,6 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.WindowItemFit
 
@@ -32,7 +31,7 @@ fun HomeLoadingScreen(
     }
 
     val fittedRows: Int = WindowItemFit.count(
-        itemHeight = 180.dp,
+        itemHeight = SizeConstants.OneEightySize,
         itemSpacing = SizeConstants.LargeSize,
         paddingValues = paddingValues
     )

--- a/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainViewModelTest.kt
+++ b/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainViewModelTest.kt
@@ -1,11 +1,11 @@
 package com.d4rk.android.apps.apptoolkit.app.main.ui
 
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.unit.dp
 import com.d4rk.android.apps.apptoolkit.app.core.utils.dispatchers.StandardDispatcherExtension
 import com.d4rk.android.apps.apptoolkit.app.main.ui.states.MainUiState
 import com.d4rk.android.libs.apptoolkit.app.main.domain.repository.NavigationRepository
 import com.d4rk.android.libs.apptoolkit.core.domain.model.navigation.NavigationDrawerItem
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import io.mockk.clearAllMocks
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -107,8 +107,8 @@ class MainViewModelTest {
     private fun createIcon(): ImageVector =
         ImageVector.Builder(
             name = "navigation_icon",
-            defaultWidth = 24.dp,
-            defaultHeight = 24.dp,
+            defaultWidth = SizeConstants.TwentyFourSize,
+            defaultHeight = SizeConstants.TwentyFourSize,
             viewportWidth = 24f,
             viewportHeight = 24f
         ).build()

--- a/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/components/navigation/NavigationItemClickTest.kt
+++ b/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/components/navigation/NavigationItemClickTest.kt
@@ -3,11 +3,11 @@ package com.d4rk.android.apps.apptoolkit.app.main.ui.components.navigation
 import android.content.Context
 import androidx.compose.material3.DrawerState
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.unit.dp
 import com.d4rk.android.libs.apptoolkit.app.help.ui.HelpActivity
 import com.d4rk.android.libs.apptoolkit.app.main.utils.constants.NavigationDrawerRoutes
 import com.d4rk.android.libs.apptoolkit.app.settings.settings.ui.SettingsActivity
 import com.d4rk.android.libs.apptoolkit.core.domain.model.navigation.NavigationDrawerItem
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.core.utils.helpers.IntentsHelper
 import io.mockk.Called
 import io.mockk.Runs
@@ -38,8 +38,8 @@ class NavigationItemClickTest {
         title = 0,
         selectedIcon = ImageVector.Builder(
             name = "test",
-            defaultWidth = 24.dp,
-            defaultHeight = 24.dp,
+            defaultWidth = SizeConstants.TwentyFourSize,
+            defaultHeight = SizeConstants.TwentyFourSize,
             viewportWidth = 24f,
             viewportHeight = 24f
         ).build(),
@@ -158,4 +158,3 @@ class NavigationItemClickTest {
         verify { IntentsHelper wasNot Called }
     }
 }
-

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/main/ui/components/navigation/LeftNavigationRail.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/main/ui/components/navigation/LeftNavigationRail.kt
@@ -34,10 +34,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import com.d4rk.android.libs.apptoolkit.app.main.domain.model.BottomBarItem
 import com.d4rk.android.libs.apptoolkit.core.domain.model.navigation.NavigationDrawerItem
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 
@@ -80,7 +80,7 @@ fun LeftNavigationRail(
     content: @Composable BoxScope.() -> Unit,
 ) {
     val railWidth: Dp by animateDpAsState(
-        targetValue = if (isRailExpanded) 200.dp else 72.dp,
+        targetValue = if (isRailExpanded) SizeConstants.TwoHundredSize else SizeConstants.SeventyTwoSize,
         animationSpec = tween(durationMillis = 300)
     )
     val textEntryAnimation: EnterTransition =

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/components/AnimatedMorphingShapeContainer.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/components/AnimatedMorphingShapeContainer.kt
@@ -11,7 +11,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.unit.dp
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
@@ -22,7 +21,7 @@ fun AnimatedMorphingShapeContainer(imageVector: ImageVector) {
         contentAlignment = Alignment.Center
     ) {
         LoadingIndicator(
-            modifier = Modifier.size(256.dp)
+            modifier = Modifier.size(SizeConstants.TwoHundredFiftySixSize)
         )
 
         Box(
@@ -32,7 +31,7 @@ fun AnimatedMorphingShapeContainer(imageVector: ImageVector) {
             Icon(
                 imageVector = imageVector,
                 contentDescription = null,
-                modifier = Modifier.size(80.dp),
+                modifier = Modifier.size(SizeConstants.EightySize),
                 tint = MaterialTheme.colorScheme.onSecondary
             )
         }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsScreen.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsScreen.kt
@@ -37,7 +37,6 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
-import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import coil3.compose.AsyncImage
 import com.d4rk.android.libs.apptoolkit.R
@@ -192,7 +191,7 @@ fun SettingsDetailPlaceholder(paddingValues: PaddingValues) {
                         model = R.drawable.il_settings,
                         contentDescription = null,
                         modifier = Modifier
-                            .size(size = 258.dp)
+                            .size(size = SizeConstants.TwoHundredFiftyEightSize)
                             .fillMaxWidth(),
                     )
                     LargeVerticalSpacer()
@@ -283,4 +282,3 @@ fun SettingsList(
         }
     }
 }
-

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/theme/ui/ThemeSettingsList.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/theme/ui/ThemeSettingsList.kt
@@ -169,7 +169,7 @@ fun ThemeSettingsList(paddingValues: PaddingValues) {
                     contentDescription = null,
                     modifier = Modifier
                         .fillMaxWidth()
-                        .height(220.dp)
+                        .height(SizeConstants.TwoHundredTwentySize)
                         .clip(
                             RoundedCornerShape(
                                 size = SizeConstants.LargeSize + SizeConstants.SmallSize

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/theme/ui/components/WallpaperColorOptionCard.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/theme/ui/components/WallpaperColorOptionCard.kt
@@ -16,7 +16,6 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import com.d4rk.android.libs.apptoolkit.app.theme.domain.model.WallpaperSwatchColors
 import com.d4rk.android.libs.apptoolkit.core.ui.components.modifiers.bounceClick
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
@@ -27,8 +26,8 @@ fun WallpaperColorOptionCard(
     selected: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
-    cardSize: Dp = 72.dp,
-    swatchSize: Dp = 44.dp,
+    cardSize: Dp = SizeConstants.SeventyTwoSize,
+    swatchSize: Dp = SizeConstants.FortyFourSize,
     shape: RoundedCornerShape = RoundedCornerShape(SizeConstants.LargeSize),
 ) {
     val borderColor = animateColorAsState(

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/components/layouts/LoadingScreen.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/components/layouts/LoadingScreen.kt
@@ -16,9 +16,9 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.MediumVerticalSpacer
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 
 /**
  * Fullscreen wrapper that displays an animated [LoadingIndicator].
@@ -36,8 +36,8 @@ import com.d4rk.android.libs.apptoolkit.core.ui.components.spacers.MediumVertica
 @Composable
 fun LoadingScreen(
     modifier: Modifier = Modifier,
-    paddingValues: PaddingValues = PaddingValues(0.dp),
-    indicatorSize: Dp = 96.dp,
+    paddingValues: PaddingValues = PaddingValues(SizeConstants.ZeroSize),
+    indicatorSize: Dp = SizeConstants.NinetySixSize,
     showText: Boolean = true
 ) {
     Column(

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/components/layouts/NoDataScreen.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/components/layouts/NoDataScreen.kt
@@ -76,7 +76,7 @@ fun NoDataScreen(
             contentAlignment = Alignment.Center
         ) {
             LoadingIndicator(
-                modifier = Modifier.size(size = 144.dp),
+                modifier = Modifier.size(size = SizeConstants.OneFortyFourSize),
                 color = if (isError) MaterialTheme.colorScheme.errorContainer else LoadingIndicatorDefaults.indicatorColor
             )
 

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/components/modifiers/ShimmerAnimation.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/components/modifiers/ShimmerAnimation.kt
@@ -31,7 +31,7 @@ import androidx.compose.ui.graphics.Brush
  * ```
  * Box(
  *     modifier = Modifier
- *         .size(100.dp)
+ *         .size(SizeConstants.OneHundredSize)
  *         .shimmerEffect()
  * )
  * ```

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/utils/constants/ui/SizeConstants.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/utils/constants/ui/SizeConstants.kt
@@ -19,6 +19,20 @@ object SizeConstants {
     val SmallSize: Dp = 8.dp
     val ExtraSmallSize: Dp = 4.dp
     val ExtraTinySize: Dp = 2.dp
+    val ZeroSize: Dp = 0.dp
+    val TwentyFourSize: Dp = LargeSize + SmallSize
+    val FortyFourSize: Dp = ExtraLargeSize + LargeSize
+    val SeventyTwoSize: Dp = ExtraExtraLargeSize + LargeIncreasedSize + ExtraSmallSize
+    val EightySize: Dp = ExtraExtraLargeSize + ExtraLargeIncreasedSize
+    val NinetySixSize: Dp = ExtraExtraLargeSize * 2
+    val OneHundredSize: Dp = ExtraLargeIncreasedSize * 3 + ExtraSmallSize
+    val OneFortyFourSize: Dp = ExtraExtraLargeSize * 3
+    val OneEightySize: Dp = OneFortyFourSize + LargeIncreasedSize + LargeSize
+    val TwoHundredSize: Dp = ExtraExtraLargeSize * 4 + SmallSize
+    val TwoHundredTwentySize: Dp = ExtraExtraLargeSize * 4 + ExtraLargeSize
+    val TwoHundredFortySize: Dp = ExtraExtraLargeSize * 5
+    val TwoHundredFiftySixSize: Dp = TwoHundredFortySize + LargeSize
+    val TwoHundredFiftyEightSize: Dp = TwoHundredFortySize + MediumSize + ExtraSmallSize + ExtraTinySize
     val ButtonIconSize: Dp = ButtonDefaults.IconSize
     val SwitchIconSize: Dp = SwitchDefaults.IconSize
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/utils/helpers/WindowItemFit.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/utils/helpers/WindowItemFit.kt
@@ -5,14 +5,14 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.platform.LocalWindowInfo
 import androidx.compose.ui.unit.Dp
-import androidx.compose.ui.unit.dp
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 
 object WindowItemFit {
     @Composable
     fun count(
         itemHeight: Dp,
-        itemSpacing: Dp = 0.dp,
-        paddingValues: PaddingValues = PaddingValues(all = 0.dp)
+        itemSpacing: Dp = SizeConstants.ZeroSize,
+        paddingValues: PaddingValues = PaddingValues(all = SizeConstants.ZeroSize)
     ): Int {
         val windowInfo = LocalWindowInfo.current
         val density = LocalDensity.current


### PR DESCRIPTION
## Summary
- add shared size definitions for common dimensions and remove hardcoded dp values across UI components and tests
- replace literal measurements with SizeConstants usage, including zero spacing defaults
- update documentation sample to reference centralized sizes

## Testing
- ./gradlew test *(fails: Android SDK location not available in CI environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69478b899ae8832db664baeb4b8f63dd)