### PR TITLE
Place wallpaper color strings in library locales

### DIFF
--- a/apptoolkit/src/main/res/values-ar-rEG/strings.xml
+++ b/apptoolkit/src/main/res/values-ar-rEG/strings.xml
@@ -88,6 +88,8 @@
     <string name="will_turn_on_automatically_by_system">سيتم تشغيله تلقائيًا بواسطة النظام</string>
     <string name="will_never_turn_on_automatically">لن يتم تشغيله تلقائيًا أبدًا</string>
     <string name="amoled_mode">وضع AMOLED</string>
+    <string name="wallpaper_colors">ألوان خلفية الشاشة</string>
+    <string name="other_colors">ألوان أخرى</string>
     <string name="follow_system">اتباع وضع النظام</string>
     <string name="light_mode">الوضع الفاتح</string>
     <string name="dark_mode">الوضع الداكن</string>

--- a/apptoolkit/src/main/res/values-bg-rBG/strings.xml
+++ b/apptoolkit/src/main/res/values-bg-rBG/strings.xml
@@ -88,6 +88,8 @@
     <string name="will_turn_on_automatically_by_system">Ще се включи автоматично от системата</string>
     <string name="will_never_turn_on_automatically">Никога няма да се включи автоматично</string>
     <string name="amoled_mode">AMOLED режим</string>
+    <string name="wallpaper_colors">Цветове на тапета</string>
+    <string name="other_colors">Други цветове</string>
     <string name="follow_system">Следвай системния режим</string>
     <string name="light_mode">Светъл режим</string>
     <string name="dark_mode">Тъмен режим</string>

--- a/apptoolkit/src/main/res/values-bn-rBD/strings.xml
+++ b/apptoolkit/src/main/res/values-bn-rBD/strings.xml
@@ -88,6 +88,8 @@
     <string name="will_turn_on_automatically_by_system">সিস্টেম দ্বারা স্বয়ংক্রিয়ভাবে চালু হবে</string>
     <string name="will_never_turn_on_automatically">কখনো স্বয়ংক্রিয়ভাবে চালু হবে না</string>
     <string name="amoled_mode">AMOLED মোড</string>
+    <string name="wallpaper_colors">ওয়ালপেপারের রং</string>
+    <string name="other_colors">অন্যান্য রং</string>
     <string name="follow_system">সিস্টেম মোড অনুসরণ করুন</string>
     <string name="light_mode">লাইট মোড</string>
     <string name="dark_mode">ডার্ক মোড</string>

--- a/apptoolkit/src/main/res/values-de-rDE/strings.xml
+++ b/apptoolkit/src/main/res/values-de-rDE/strings.xml
@@ -88,6 +88,8 @@
     <string name="will_turn_on_automatically_by_system">Wird automatisch vom System aktiviert</string>
     <string name="will_never_turn_on_automatically">Wird niemals automatisch aktiviert</string>
     <string name="amoled_mode">AMOLED-Modus</string>
+    <string name="wallpaper_colors">Hintergrundfarben</string>
+    <string name="other_colors">Andere Farben</string>
     <string name="follow_system">Systemmodus folgen</string>
     <string name="light_mode">Helles thema</string>
     <string name="dark_mode">Dunkles thema</string>

--- a/apptoolkit/src/main/res/values-es-rGQ/strings.xml
+++ b/apptoolkit/src/main/res/values-es-rGQ/strings.xml
@@ -88,6 +88,8 @@
     <string name="will_turn_on_automatically_by_system">Se activará automáticamente por el sistema</string>
     <string name="will_never_turn_on_automatically">Nunca se activará automáticamente</string>
     <string name="amoled_mode">Modo AMOLED</string>
+    <string name="wallpaper_colors">Colores del fondo de pantalla</string>
+    <string name="other_colors">Otros colores</string>
     <string name="follow_system">Seguir modo del sistema</string>
     <string name="light_mode">Modo claro</string>
     <string name="dark_mode">Modo oscuro</string>

--- a/apptoolkit/src/main/res/values-es-rMX/strings.xml
+++ b/apptoolkit/src/main/res/values-es-rMX/strings.xml
@@ -88,6 +88,8 @@
     <string name="will_turn_on_automatically_by_system">Se activará automáticamente por el sistema</string>
     <string name="will_never_turn_on_automatically">Nunca se activará automáticamente</string>
     <string name="amoled_mode">Modo AMOLED</string>
+    <string name="wallpaper_colors">Colores del fondo de pantalla</string>
+    <string name="other_colors">Otros colores</string>
     <string name="follow_system">Seguir modo del sistema</string>
     <string name="light_mode">Modo claro</string>
     <string name="dark_mode">Modo oscuro</string>

--- a/apptoolkit/src/main/res/values-fil-rPH/strings.xml
+++ b/apptoolkit/src/main/res/values-fil-rPH/strings.xml
@@ -88,6 +88,8 @@
     <string name="will_turn_on_automatically_by_system">Awtomatikong mag-o-on sa pamamagitan ng system</string>
     <string name="will_never_turn_on_automatically">Hindi kailanman awtomatikong mag-o-on</string>
     <string name="amoled_mode">AMOLED mode</string>
+    <string name="wallpaper_colors">Mga kulay ng wallpaper</string>
+    <string name="other_colors">Ibang mga kulay</string>
     <string name="follow_system">Sundin ang system mode</string>
     <string name="light_mode">Light mode</string>
     <string name="dark_mode">Dark mode</string>

--- a/apptoolkit/src/main/res/values-fr-rFR/strings.xml
+++ b/apptoolkit/src/main/res/values-fr-rFR/strings.xml
@@ -88,6 +88,8 @@
     <string name="will_turn_on_automatically_by_system">Sera activé automatiquement par le système</string>
     <string name="will_never_turn_on_automatically">Ne sera jamais activé automatiquement</string>
     <string name="amoled_mode">Mode AMOLED</string>
+    <string name="wallpaper_colors">Couleurs du fond d'écran</string>
+    <string name="other_colors">Autres couleurs</string>
     <string name="follow_system">Suivre le mode système</string>
     <string name="light_mode">Mode clair</string>
     <string name="dark_mode">Mode sombre</string>

--- a/apptoolkit/src/main/res/values-hi-rIN/strings.xml
+++ b/apptoolkit/src/main/res/values-hi-rIN/strings.xml
@@ -88,6 +88,8 @@
     <string name="will_turn_on_automatically_by_system">सिस्टम द्वारा स्वचालित रूप से चालू हो जाएगी</string>
     <string name="will_never_turn_on_automatically">स्वचालित रूप से कभी चालू नहीं होगी</string>
     <string name="amoled_mode">AMOLED मोड</string>
+    <string name="wallpaper_colors">वॉलपेपर के रंग</string>
+    <string name="other_colors">अन्य रंग</string>
     <string name="follow_system">सिस्टम मोड का अनुसरण करें</string>
     <string name="light_mode">लाइट मोड</string>
     <string name="dark_mode">डार्क मोड</string>

--- a/apptoolkit/src/main/res/values-hu-rHU/strings.xml
+++ b/apptoolkit/src/main/res/values-hu-rHU/strings.xml
@@ -88,6 +88,8 @@
     <string name="will_turn_on_automatically_by_system">Automatikusan bekapcsol a rendszer által</string>
     <string name="will_never_turn_on_automatically">Soha nem kapcsol be automatikusan</string>
     <string name="amoled_mode">AMOLED mód</string>
+    <string name="wallpaper_colors">Háttérkép színei</string>
+    <string name="other_colors">Egyéb színek</string>
     <string name="follow_system">Rendszerbeállítás követése</string>
     <string name="light_mode">Világos mód</string>
     <string name="dark_mode">Sötét mód</string>

--- a/apptoolkit/src/main/res/values-in-rID/strings.xml
+++ b/apptoolkit/src/main/res/values-in-rID/strings.xml
@@ -88,6 +88,8 @@
     <string name="will_turn_on_automatically_by_system">Akan diaktifkan secara otomatis oleh sistem</string>
     <string name="will_never_turn_on_automatically">Tidak akan pernah diaktifkan secara otomatis</string>
     <string name="amoled_mode">Mode AMOLED</string>
+    <string name="wallpaper_colors">Warna wallpaper</string>
+    <string name="other_colors">Warna lainnya</string>
     <string name="follow_system">Ikuti mode sistem</string>
     <string name="light_mode">Mode terang</string>
     <string name="dark_mode">Mode gelap</string>

--- a/apptoolkit/src/main/res/values-it-rIT/strings.xml
+++ b/apptoolkit/src/main/res/values-it-rIT/strings.xml
@@ -88,6 +88,8 @@
     <string name="will_turn_on_automatically_by_system">Si attiverà automaticamente dal sistema</string>
     <string name="will_never_turn_on_automatically">Non si attiverà mai automaticamente</string>
     <string name="amoled_mode">Modalità AMOLED</string>
+    <string name="wallpaper_colors">Colori dello sfondo</string>
+    <string name="other_colors">Altri colori</string>
     <string name="follow_system">Segui modalità sistema</string>
     <string name="light_mode">Modalità chiara</string>
     <string name="dark_mode">Modalità scura</string>

--- a/apptoolkit/src/main/res/values-ja-rJP/strings.xml
+++ b/apptoolkit/src/main/res/values-ja-rJP/strings.xml
@@ -88,6 +88,8 @@
     <string name="will_turn_on_automatically_by_system">システムによって自動的にオンになります</string>
     <string name="will_never_turn_on_automatically">自動的にオンにはなりません</string>
     <string name="amoled_mode">AMOLEDモード</string>
+    <string name="wallpaper_colors">壁紙の色</string>
+    <string name="other_colors">その他の色</string>
     <string name="follow_system">システムモードに従う</string>
     <string name="light_mode">ライトモード</string>
     <string name="dark_mode">ダークモード</string>

--- a/apptoolkit/src/main/res/values-ko-rKR/strings.xml
+++ b/apptoolkit/src/main/res/values-ko-rKR/strings.xml
@@ -88,6 +88,8 @@
     <string name="will_turn_on_automatically_by_system">시스템에 의해 자동으로 켜집니다.</string>
     <string name="will_never_turn_on_automatically">자동으로 켜지지 않습니다.</string>
     <string name="amoled_mode">AMOLED 모드</string>
+    <string name="wallpaper_colors">배경화면 색상</string>
+    <string name="other_colors">기타 색상</string>
     <string name="follow_system">시스템 모드 따르기</string>
     <string name="light_mode">라이트 모드</string>
     <string name="dark_mode">다크 모드</string>

--- a/apptoolkit/src/main/res/values-pl-rPL/strings.xml
+++ b/apptoolkit/src/main/res/values-pl-rPL/strings.xml
@@ -88,6 +88,8 @@
     <string name="will_turn_on_automatically_by_system">Zostanie automatycznie włączony przez system</string>
     <string name="will_never_turn_on_automatically">Nigdy nie włączy się automatycznie</string>
     <string name="amoled_mode">Tryb AMOLED</string>
+    <string name="wallpaper_colors">Kolory tapety</string>
+    <string name="other_colors">Inne kolory</string>
     <string name="follow_system">Podążaj za ustawieniami systemu</string>
     <string name="light_mode">Tryb jasny</string>
     <string name="dark_mode">Tryb ciemny</string>

--- a/apptoolkit/src/main/res/values-pt-rBR/strings.xml
+++ b/apptoolkit/src/main/res/values-pt-rBR/strings.xml
@@ -88,6 +88,8 @@
     <string name="will_turn_on_automatically_by_system">Será ativado automaticamente pelo sistema</string>
     <string name="will_never_turn_on_automatically">Nunca será ativado automaticamente</string>
     <string name="amoled_mode">Modo AMOLED</string>
+    <string name="wallpaper_colors">Cores do papel de parede</string>
+    <string name="other_colors">Outras cores</string>
     <string name="follow_system">Seguir o sistema</string>
     <string name="light_mode">Modo claro</string>
     <string name="dark_mode">Modo escuro</string>

--- a/apptoolkit/src/main/res/values-ro-rRO/strings.xml
+++ b/apptoolkit/src/main/res/values-ro-rRO/strings.xml
@@ -88,6 +88,8 @@
     <string name="will_turn_on_automatically_by_system">Se va activa automat prin setările sistemului</string>
     <string name="will_never_turn_on_automatically">Nu se va activa niciodată automat</string>
     <string name="amoled_mode">Mod AMOLED</string>
+    <string name="wallpaper_colors">Culorile fundalului</string>
+    <string name="other_colors">Alte culori</string>
     <string name="follow_system">Urmărește setările sistemului</string>
     <string name="light_mode">Mod luminos</string>
     <string name="dark_mode">Mod întunecat</string>

--- a/apptoolkit/src/main/res/values-ru-rRU/strings.xml
+++ b/apptoolkit/src/main/res/values-ru-rRU/strings.xml
@@ -88,6 +88,8 @@
     <string name="will_turn_on_automatically_by_system">Будет включено автоматически системой</string>
     <string name="will_never_turn_on_automatically">Никогда не будет включено автоматически</string>
     <string name="amoled_mode">AMOLED-режим</string>
+    <string name="wallpaper_colors">Цвета обоев</string>
+    <string name="other_colors">Другие цвета</string>
     <string name="follow_system">Следовать за системой</string>
     <string name="light_mode">Светлый режим</string>
     <string name="dark_mode">Тёмный режим</string>

--- a/apptoolkit/src/main/res/values-sv-rSE/strings.xml
+++ b/apptoolkit/src/main/res/values-sv-rSE/strings.xml
@@ -88,6 +88,8 @@
     <string name="will_turn_on_automatically_by_system">Kommer att aktiveras automatiskt av systemet</string>
     <string name="will_never_turn_on_automatically">Kommer aldrig att aktiveras automatiskt</string>
     <string name="amoled_mode">AMOLED-läge</string>
+    <string name="wallpaper_colors">Bakgrundsfärger</string>
+    <string name="other_colors">Andra färger</string>
     <string name="follow_system">Följ systeminställningar</string>
     <string name="light_mode">Ljust läge</string>
     <string name="dark_mode">Mörkt läge</string>

--- a/apptoolkit/src/main/res/values-th-rTH/strings.xml
+++ b/apptoolkit/src/main/res/values-th-rTH/strings.xml
@@ -88,6 +88,8 @@
     <string name="will_turn_on_automatically_by_system">ระบบจะเปิดใช้งานโดยอัตโนมัติ</string>
     <string name="will_never_turn_on_automatically">จะไม่มีการเปิดใช้งานอัตโนมัติ</string>
     <string name="amoled_mode">โหมด AMOLED</string>
+    <string name="wallpaper_colors">สีของวอลเปเปอร์</string>
+    <string name="other_colors">สีอื่นๆ</string>
     <string name="follow_system">ตามการตั้งค่าระบบ</string>
     <string name="light_mode">โหมดสว่าง</string>
     <string name="dark_mode">โหมดมืด</string>

--- a/apptoolkit/src/main/res/values-tr-rTR/strings.xml
+++ b/apptoolkit/src/main/res/values-tr-rTR/strings.xml
@@ -88,6 +88,8 @@
     <string name="will_turn_on_automatically_by_system">Sistem tarafından otomatik olarak açılacak</string>
     <string name="will_never_turn_on_automatically">Hiçbir zaman otomatik olarak açılmayacak</string>
     <string name="amoled_mode">AMOLED modu</string>
+    <string name="wallpaper_colors">Duvar kâğıdı renkleri</string>
+    <string name="other_colors">Diğer renkler</string>
     <string name="follow_system">Sistem modunu takip et</string>
     <string name="light_mode">Aydınlık mod</string>
     <string name="dark_mode">Koyu mod</string>

--- a/apptoolkit/src/main/res/values-uk-rUA/strings.xml
+++ b/apptoolkit/src/main/res/values-uk-rUA/strings.xml
@@ -88,6 +88,8 @@
     <string name="will_turn_on_automatically_by_system">Автоматично увімкнеться системою</string>
     <string name="will_never_turn_on_automatically">Ніколи не буде ввімкнено автоматично</string>
     <string name="amoled_mode">Режим AMOLED</string>
+    <string name="wallpaper_colors">Кольори шпалер</string>
+    <string name="other_colors">Інші кольори</string>
     <string name="follow_system">Дотримуватися системного режиму</string>
     <string name="light_mode">Світла тема</string>
     <string name="dark_mode">Темна тема</string>

--- a/apptoolkit/src/main/res/values-ur-rPK/strings.xml
+++ b/apptoolkit/src/main/res/values-ur-rPK/strings.xml
@@ -88,6 +88,8 @@
     <string name="will_turn_on_automatically_by_system">سسٹم کے ذریعے خود بخود آن ہو جائے گا</string>
     <string name="will_never_turn_on_automatically">کبھی خود بخود آن نہیں ہوگا</string>
     <string name="amoled_mode">AMOLED موڈ</string>
+    <string name="wallpaper_colors">وال پیپر کے رنگ</string>
+    <string name="other_colors">دیگر رنگ</string>
     <string name="follow_system">سسٹم موڈ فالو کریں</string>
     <string name="light_mode">لائٹ موڈ</string>
     <string name="dark_mode">ڈارک موڈ</string>

--- a/apptoolkit/src/main/res/values-vi-rVN/strings.xml
+++ b/apptoolkit/src/main/res/values-vi-rVN/strings.xml
@@ -88,6 +88,8 @@
     <string name="will_turn_on_automatically_by_system">Sẽ tự động bật theo hệ thống</string>
     <string name="will_never_turn_on_automatically">Sẽ không bao giờ tự động bật</string>
     <string name="amoled_mode">Chế độ AMOLED</string>
+    <string name="wallpaper_colors">Màu hình nền</string>
+    <string name="other_colors">Màu khác</string>
     <string name="follow_system">Theo chế độ hệ thống</string>
     <string name="light_mode">Chế độ sáng</string>
     <string name="dark_mode">Chế độ tối</string>

--- a/apptoolkit/src/main/res/values-zh-rTW/strings.xml
+++ b/apptoolkit/src/main/res/values-zh-rTW/strings.xml
@@ -88,6 +88,8 @@
     <string name="will_turn_on_automatically_by_system">將由系統自動啟用</string>
     <string name="will_never_turn_on_automatically">永遠不會自動啟用</string>
     <string name="amoled_mode">AMOLED 模式</string>
+    <string name="wallpaper_colors">桌布顏色</string>
+    <string name="other_colors">其他顏色</string>
     <string name="follow_system">跟隨系統模式</string>
     <string name="light_mode">淺色模式</string>
     <string name="dark_mode">深色模式</string>


### PR DESCRIPTION
## Summary
- move wallpaper color translations into the Apptoolkit module locale resources alongside appearance settings strings
- remove misplaced wallpaper color entries from app module locale files to mirror the base ordering

## Testing
- ./gradlew test *(fails: Android SDK not configured in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69478b85abdc832d8d59b4eda396d2b7)