### PR TITLE
Fix static palette validation for rose theme

### DIFF
--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/theme/ui/ThemeSettingsList.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/theme/ui/ThemeSettingsList.kt
@@ -126,17 +126,7 @@ fun ThemeSettingsList(paddingValues: PaddingValues) {
         }
     }
 
-    val staticOptions: List<String> = remember {
-        listOf(
-            StaticPaletteIds.DEFAULT,
-            StaticPaletteIds.MONOCHROME,
-            StaticPaletteIds.BLUE,
-            StaticPaletteIds.GREEN,
-            StaticPaletteIds.RED,
-            StaticPaletteIds.YELLOW,
-            StaticPaletteIds.ROSE,
-        )
-    }
+    val staticOptions: List<String> = remember { StaticPaletteIds.withDefault }
 
     val staticSwatches: List<WallpaperSwatchColors> =
         remember(staticOptions, isSystemInDarkThemeNow) {

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/utils/extensions/ColorSchemeExtensions.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/utils/extensions/ColorSchemeExtensions.kt
@@ -33,6 +33,23 @@ object StaticPaletteIds {
     const val ROSE = "rose"
 
     const val DEFAULT = "default"
+
+    private val supportedOrder = listOf(
+        MONOCHROME,
+        BLUE,
+        GREEN,
+        RED,
+        YELLOW,
+        ROSE,
+    )
+
+    val withDefault: List<String> = listOf(DEFAULT) + supportedOrder
+
+    fun sanitize(id: String): String = when (id) {
+        DEFAULT -> DEFAULT
+        in supportedOrder -> id
+        else -> DEFAULT
+    }
 }
 
 fun ColorScheme.applyDynamicVariant(variant: Int): ColorScheme =

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/data/datastore/CommonDataStore.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/data/datastore/CommonDataStore.kt
@@ -175,19 +175,13 @@ open class CommonDataStore(
         stringPreferencesKey(name = DataStoreNamesConstants.DATA_STORE_STATIC_PALETTE_ID)
 
     val staticPaletteId: Flow<String> = dataStore.data
-        .map { preferences -> preferences[staticPaletteIdKey] ?: StaticPaletteIds.DEFAULT }
+        .map { preferences ->
+            StaticPaletteIds.sanitize(preferences[staticPaletteIdKey] ?: StaticPaletteIds.DEFAULT)
+        }
         .distinctUntilChanged()
 
     suspend fun saveStaticPaletteId(id: String) {
-        val safe = when (id) {
-            StaticPaletteIds.MONOCHROME,
-            StaticPaletteIds.BLUE,
-            StaticPaletteIds.GREEN,
-            StaticPaletteIds.RED,
-            StaticPaletteIds.YELLOW -> id
-
-            else -> StaticPaletteIds.DEFAULT
-        }
+        val safe = StaticPaletteIds.sanitize(id)
 
         dataStore.edit { preferences ->
             preferences[staticPaletteIdKey] = safe


### PR DESCRIPTION
## Summary
- allow the rose color palette to be persisted by sanitizing static palette ids through a shared helper
- share the centralized palette id list with the theme settings UI to reduce duplication when adding new palettes
- continue using the sanitized palette id when reading from DataStore so invalid values fall back safely

## Testing
- ./gradlew test *(fails: Android SDK not available in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69479745764c832d9a6ff5aca562525e)