### PR TITLE
Configure library publishing for Maven and JitPack

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,36 @@ Download App Toolkit from the Google Play Store and explore the internal structu
 apps. It's free, easy to navigate, and the perfect way to discover how reusable design can elevate
 any project.
 
+# Use the library in your project
+
+App Toolkit’s shared components are published as a library that you can consume from Maven
+repositories. Maven Central publishing is being prepared, and JitPack is available right now.
+
+### Gradle (Maven Central-ready)
+
+```kotlin
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation("com.d4rk.android.libs:apptoolkit:1.1.6")
+}
+```
+
+### Gradle (JitPack)
+
+```kotlin
+repositories {
+    mavenCentral()
+    maven(url = "https://jitpack.io")
+}
+
+dependencies {
+    implementation("com.github.MihaiCristianCondrea:apptoolkit:1.1.6")
+}
+```
+
 # Feedback
 
 We are constantly updating and improving App Toolkit to give you the best possible experience. If you

--- a/apptoolkit/build.gradle.kts
+++ b/apptoolkit/build.gradle.kts
@@ -1,5 +1,18 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
+val publishingGroupId = providers.gradleProperty("PUBLISHING_GROUP_ID").orElse("com.d4rk.android.libs")
+val publishingArtifactId = providers.gradleProperty("PUBLISHING_ARTIFACT_ID").orElse("apptoolkit")
+val jitpackGroupId = providers.gradleProperty("JITPACK_GROUP_ID").orElse("com.github.MihaiCristianCondrea")
+val publishingVersion = providers.gradleProperty("PUBLISHING_VERSION").orElse("1.1.6")
+
+val useJitpackCoordinates = providers.gradleProperty("USE_JITPACK_COORDINATES")
+    .map(String::toBoolean)
+    .orElse(true)
+    .get() || providers.environmentVariable("JITPACK").isPresent
+
+group = if (useJitpackCoordinates) jitpackGroupId.get() else publishingGroupId.get()
+version = publishingVersion.get()
+
 plugins {
     alias(notation = libs.plugins.android.library)
     alias(notation = libs.plugins.kotlin.android)
@@ -54,7 +67,10 @@ android {
     }
 
     publishing {
-        singleVariant("release") {}
+        singleVariant("release") {
+            withSourcesJar()
+            withJavadocJar()
+        }
     }
 }
 
@@ -107,12 +123,36 @@ dependencies {
 publishing {
     publications {
         register<MavenPublication>("release") {
-            groupId = "com.github.MihaiCristianCondrea"
-            artifactId = "App-Toolkit-for-Android"
-            version = "1.1.6"
+            groupId = group.toString()
+            artifactId = publishingArtifactId.get()
+            version = publishingVersion.get()
 
             afterEvaluate {
                 from(components["release"])
+            }
+
+            pom {
+                name.set("App Toolkit for Android")
+                description.set("Reusable Compose toolkit with common UI and infrastructure building blocks.")
+                url.set("https://github.com/MihaiCristianCondrea/App-Toolkit-for-Android")
+                licenses {
+                    license {
+                        name.set("GNU General Public License v3.0")
+                        url.set("https://www.gnu.org/licenses/gpl-3.0.html")
+                    }
+                }
+                developers {
+                    developer {
+                        id.set("MihaiCristianCondrea")
+                        name.set("Mihai Cristian Condrea")
+                        url.set("https://github.com/MihaiCristianCondrea")
+                    }
+                }
+                scm {
+                    connection.set("scm:git:git://github.com/MihaiCristianCondrea/App-Toolkit-for-Android.git")
+                    developerConnection.set("scm:git:ssh://git@github.com/MihaiCristianCondrea/App-Toolkit-for-Android.git")
+                    url.set("https://github.com/MihaiCristianCondrea/App-Toolkit-for-Android")
+                }
             }
         }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,3 +22,7 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+PUBLISHING_GROUP_ID=com.d4rk.android.libs
+PUBLISHING_ARTIFACT_ID=apptoolkit
+JITPACK_GROUP_ID=com.github.MihaiCristianCondrea
+PUBLISHING_VERSION=1.1.6


### PR DESCRIPTION
## Summary
- add configurable publishing coordinates and metadata for Maven Central and JitPack builds
- generate source and Javadoc artifacts for the release variant
- document Gradle setup examples for Maven Central-ready and JitPack consumers

## Testing
- `./gradlew test` *(fails: Android SDK is not available in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69490003ab00832d9c1541125766a350)