### PR TITLE
Add seasonal palette windows for holidays

### DIFF
--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/AppToolkit.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/AppToolkit.kt
@@ -15,6 +15,7 @@ import com.d4rk.android.libs.apptoolkit.app.theme.ui.style.colors.ColorPalette
 import com.d4rk.android.libs.apptoolkit.app.theme.ui.style.colors.ThemePaletteProvider
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.colorscheme.StaticPaletteIds
 import com.d4rk.android.libs.apptoolkit.core.utils.extensions.date.isChristmasSeason
+import com.d4rk.android.libs.apptoolkit.core.utils.extensions.date.isHalloweenSeason
 import com.d4rk.android.libs.apptoolkit.data.core.BaseCoreManager
 import com.d4rk.android.libs.apptoolkit.data.core.ads.AdsCoreManager
 import com.d4rk.android.libs.apptoolkit.data.local.datastore.CommonDataStore
@@ -65,12 +66,15 @@ class AppToolkit : BaseCoreManager(), DefaultLifecycleObserver {
 
         if (!hasInteractedWithSettings) {
             val staticPaletteId: String = runBlocking { dataStore.staticPaletteId.first() }
-            val shouldUseSeasonalPalette: Boolean =
-                staticPaletteId == StaticPaletteIds.DEFAULT &&
-                        LocalDate.now(ZoneId.systemDefault()).isChristmasSeason
+            val today: LocalDate = LocalDate.now(ZoneId.systemDefault())
+            val shouldUseSeasonalPalette: Boolean = staticPaletteId == StaticPaletteIds.DEFAULT
 
             if (shouldUseSeasonalPalette) {
-                return ThemePaletteProvider.paletteById(StaticPaletteIds.CHRISTMAS)
+                return when {
+                    today.isHalloweenSeason -> ThemePaletteProvider.paletteById(StaticPaletteIds.HALLOWEEN)
+                    today.isChristmasSeason -> ThemePaletteProvider.paletteById(StaticPaletteIds.CHRISTMAS)
+                    else -> getKoin().get()
+                }
             }
         }
 

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/theme/ui/ThemeSettingsList.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/theme/ui/ThemeSettingsList.kt
@@ -54,6 +54,7 @@ import com.d4rk.android.libs.apptoolkit.core.utils.extensions.colorscheme.applyD
 import com.d4rk.android.libs.apptoolkit.core.utils.extensions.context.openDisplaySettings
 import com.d4rk.android.libs.apptoolkit.core.utils.extensions.datastore.rememberThemePreferencesState
 import com.d4rk.android.libs.apptoolkit.core.utils.extensions.date.isChristmasSeason
+import com.d4rk.android.libs.apptoolkit.core.utils.extensions.date.isHalloweenSeason
 import com.d4rk.android.libs.apptoolkit.data.local.datastore.rememberCommonDataStore
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -126,6 +127,9 @@ fun ThemeSettingsList(paddingValues: PaddingValues) {
 
     val isChristmasSeason: Boolean = remember {
         LocalDate.now(ZoneId.systemDefault()).isChristmasSeason
+    }
+    val isHalloweenSeason: Boolean = remember {
+        LocalDate.now(ZoneId.systemDefault()).isHalloweenSeason
     }
 
     val staticSwatches: List<WallpaperSwatchColors> =
@@ -242,7 +246,8 @@ fun ThemeSettingsList(paddingValues: PaddingValues) {
                                         WallpaperColorOptionCard(
                                             colors = staticSwatches[index],
                                             selected = !isDynamicColors && id == staticPaletteId,
-                                            showSeasonalBadge = isChristmasSeason && id == StaticPaletteIds.CHRISTMAS,
+                                            showSeasonalBadge = (isChristmasSeason && id == StaticPaletteIds.CHRISTMAS) ||
+                                                    (isHalloweenSeason && id == StaticPaletteIds.HALLOWEEN),
                                             onClick = {
                                                 coroutineScope.launch {
                                                     dataStore.saveDynamicColors(false)
@@ -272,7 +277,8 @@ fun ThemeSettingsList(paddingValues: PaddingValues) {
                             WallpaperColorOptionCard(
                                 colors = staticSwatches[index],
                                 selected = id == staticPaletteId,
-                                showSeasonalBadge = isChristmasSeason && id == StaticPaletteIds.CHRISTMAS,
+                                showSeasonalBadge = (isChristmasSeason && id == StaticPaletteIds.CHRISTMAS) ||
+                                        (isHalloweenSeason && id == StaticPaletteIds.HALLOWEEN),
                                 onClick = {
                                     coroutineScope.launch {
                                         dataStore.saveDynamicColors(false)

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/theme/ui/style/colors/PaletteProvider.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/theme/ui/style/colors/PaletteProvider.kt
@@ -8,6 +8,7 @@ import com.d4rk.android.libs.apptoolkit.app.theme.ui.style.colors.google.yellow.
 import com.d4rk.android.libs.apptoolkit.app.theme.ui.style.colors.monochrome.monochromePalette
 import com.d4rk.android.libs.apptoolkit.app.theme.ui.style.colors.rose.rosePalette
 import com.d4rk.android.libs.apptoolkit.app.theme.ui.style.colors.special.christmas.christmasPalette
+import com.d4rk.android.libs.apptoolkit.app.theme.ui.style.colors.special.halloween.halloweenPalette
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.colorscheme.StaticPaletteIds
 
 object ThemePaletteProvider {
@@ -22,6 +23,7 @@ object ThemePaletteProvider {
         StaticPaletteIds.YELLOW -> yellowPalette
         StaticPaletteIds.ROSE -> rosePalette
         StaticPaletteIds.CHRISTMAS -> christmasPalette
+        StaticPaletteIds.HALLOWEEN -> halloweenPalette
         StaticPaletteIds.DEFAULT -> defaultPalette
         else -> defaultPalette
     }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/utils/constants/colorscheme/PaletteConstants.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/utils/constants/colorscheme/PaletteConstants.kt
@@ -24,6 +24,7 @@ object StaticPaletteIds {
 
     const val ROSE = "rose"
     const val CHRISTMAS = "christmas"
+    const val HALLOWEEN = "halloween"
 
     const val DEFAULT = "default"
 
@@ -36,6 +37,7 @@ object StaticPaletteIds {
         YELLOW,
         ROSE,
         CHRISTMAS,
+        HALLOWEEN,
     )
 
     val withDefault: List<String> = listOf(DEFAULT) + supportedOrder

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/utils/extensions/date/LocalDateExtensions.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/utils/extensions/date/LocalDateExtensions.kt
@@ -2,6 +2,38 @@ package com.d4rk.android.libs.apptoolkit.core.utils.extensions.date
 
 import java.time.LocalDate
 import java.time.Month
+import java.time.MonthDay
 
+/**
+ * Returns whether the current date falls within the Christmas season.
+ *
+ * The season starts on December 24th and continues through January 7th to
+ * accommodate regions that celebrate Christmas later (e.g., Georgian Christmas
+ * on January 7th).
+ */
 val LocalDate.isChristmasSeason: Boolean
-    get() = month == Month.DECEMBER || (month == Month.JANUARY && dayOfMonth <= 6)
+    get() = isWithinSeason(
+        start = MonthDay.of(Month.DECEMBER, 24),
+        end = MonthDay.of(Month.JANUARY, 7),
+    )
+
+/**
+ * Returns whether the current date falls within the Halloween season.
+ *
+ * The season covers October 31st through November 2nd.
+ */
+val LocalDate.isHalloweenSeason: Boolean
+    get() = isWithinSeason(
+        start = MonthDay.of(Month.OCTOBER, 31),
+        end = MonthDay.of(Month.NOVEMBER, 2),
+    )
+
+private fun LocalDate.isWithinSeason(start: MonthDay, end: MonthDay): Boolean {
+    val today: MonthDay = MonthDay.from(this)
+    val seasonWrapsYear = end.isBefore(start)
+    return if (seasonWrapsYear) {
+        today >= start || today <= end
+    } else {
+        today >= start && today <= end
+    }
+}

--- a/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/core/utils/extensions/date/LocalDateExtensionsTest.kt
+++ b/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/core/utils/extensions/date/LocalDateExtensionsTest.kt
@@ -1,0 +1,64 @@
+package com.d4rk.android.libs.apptoolkit.core.utils.extensions.date
+
+import java.time.LocalDate
+import org.junit.jupiter.api.Assertions.assertFalse
+import org.junit.jupiter.api.Assertions.assertTrue
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.ValueSource
+
+class LocalDateExtensionsTest {
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = [
+            "2024-12-24",
+            "2024-12-25",
+            "2024-12-26",
+            "2024-12-31",
+            "2025-01-01",
+            "2025-01-05",
+            "2025-01-07",
+        ]
+    )
+    fun `christmas season should include December 24th through January 7th`(date: String) {
+        assertTrue(LocalDate.parse(date).isChristmasSeason)
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = [
+            "2024-12-23",
+            "2025-01-08",
+            "2024-11-15",
+            "2025-02-01",
+        ]
+    )
+    fun `christmas season should exclude dates outside the window`(date: String) {
+        assertFalse(LocalDate.parse(date).isChristmasSeason)
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = [
+            "2024-10-31",
+            "2024-11-01",
+            "2024-11-02",
+        ]
+    )
+    fun `halloween season should include October 31st through November 2nd`(date: String) {
+        assertTrue(LocalDate.parse(date).isHalloweenSeason)
+    }
+
+    @ParameterizedTest
+    @ValueSource(
+        strings = [
+            "2024-10-30",
+            "2024-11-03",
+            "2024-09-15",
+            "2024-12-24",
+        ]
+    )
+    fun `halloween season should exclude dates outside the window`(date: String) {
+        assertFalse(LocalDate.parse(date).isHalloweenSeason)
+    }
+}


### PR DESCRIPTION
## Summary
- refine seasonal date checks to cover Dec 24–Jan 7 for Christmas and Oct 31–Nov 2 for Halloween with shared helper logic and unit tests
- surface the Halloween palette alongside Christmas, showing seasonal badges only during each festival window
- apply the appropriate seasonal palette by default when users have not customized colors and a seasonal window is active

## Testing
- `./gradlew :apptoolkit:test` *(fails: Android SDK not configured in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958e7efb078832d84968a8b0eb43601)