### PR TITLE
Restrict seasonal theme visibility

### DIFF
--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/theme/ui/SeasonalPaletteFilter.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/theme/ui/SeasonalPaletteFilter.kt
@@ -1,0 +1,22 @@
+package com.d4rk.android.libs.apptoolkit.app.theme.ui
+
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.colorscheme.StaticPaletteIds
+
+/**
+ * Filters seasonal palette options so they are available only during their seasonal windows or
+ * when the user currently has them selected.
+ */
+internal fun filterSeasonalStaticPalettes(
+    baseOptions: List<String>,
+    isChristmasSeason: Boolean,
+    isHalloweenSeason: Boolean,
+    selectedPaletteId: String
+): List<String> {
+    return baseOptions.filter { id ->
+        when (id) {
+            StaticPaletteIds.CHRISTMAS -> isChristmasSeason || selectedPaletteId == StaticPaletteIds.CHRISTMAS
+            StaticPaletteIds.HALLOWEEN -> isHalloweenSeason || selectedPaletteId == StaticPaletteIds.HALLOWEEN
+            else -> true
+        }
+    }
+}

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/theme/ui/ThemeSettingsList.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/theme/ui/ThemeSettingsList.kt
@@ -123,13 +123,24 @@ fun ThemeSettingsList(paddingValues: PaddingValues) {
         }
     }
 
-    val staticOptions: List<String> = remember { StaticPaletteIds.withDefault }
-
     val isChristmasSeason: Boolean = remember {
         LocalDate.now(ZoneId.systemDefault()).isChristmasSeason
     }
     val isHalloweenSeason: Boolean = remember {
         LocalDate.now(ZoneId.systemDefault()).isHalloweenSeason
+    }
+
+    val staticOptions: List<String> = remember(
+        isChristmasSeason,
+        isHalloweenSeason,
+        staticPaletteId
+    ) {
+        filterSeasonalStaticPalettes(
+            baseOptions = StaticPaletteIds.withDefault,
+            isChristmasSeason = isChristmasSeason,
+            isHalloweenSeason = isHalloweenSeason,
+            selectedPaletteId = staticPaletteId
+        )
     }
 
     val staticSwatches: List<WallpaperSwatchColors> =

--- a/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/app/theme/ui/SeasonalPaletteFilterTest.kt
+++ b/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/app/theme/ui/SeasonalPaletteFilterTest.kt
@@ -1,0 +1,54 @@
+package com.d4rk.android.libs.apptoolkit.app.theme.ui
+
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.colorscheme.StaticPaletteIds
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Test
+
+class SeasonalPaletteFilterTest {
+
+    private val baseOptions: List<String> = StaticPaletteIds.withDefault
+
+    @Test
+    fun `seasonal palettes should be hidden when not in season and not selected`() {
+        val filtered = filterSeasonalStaticPalettes(
+            baseOptions = baseOptions,
+            isChristmasSeason = false,
+            isHalloweenSeason = false,
+            selectedPaletteId = StaticPaletteIds.DEFAULT
+        )
+
+        val expected = baseOptions.filterNot {
+            it == StaticPaletteIds.CHRISTMAS || it == StaticPaletteIds.HALLOWEEN
+        }
+
+        assertEquals(expected, filtered)
+    }
+
+    @Test
+    fun `selected halloween palette remains available outside of season`() {
+        val filtered = filterSeasonalStaticPalettes(
+            baseOptions = baseOptions,
+            isChristmasSeason = false,
+            isHalloweenSeason = false,
+            selectedPaletteId = StaticPaletteIds.HALLOWEEN
+        )
+
+        val expected = baseOptions.filterNot { it == StaticPaletteIds.CHRISTMAS }
+
+        assertEquals(expected, filtered)
+    }
+
+    @Test
+    fun `christmas palette stays visible during the christmas season`() {
+        val filtered = filterSeasonalStaticPalettes(
+            baseOptions = baseOptions,
+            isChristmasSeason = true,
+            isHalloweenSeason = false,
+            selectedPaletteId = StaticPaletteIds.DEFAULT
+        )
+
+        val expected = baseOptions.filterNot { it == StaticPaletteIds.HALLOWEEN }
+
+        assertEquals(expected, filtered)
+    }
+}


### PR DESCRIPTION
## Summary
- hide seasonal static palettes outside their seasonal windows unless the user currently has them selected
- reuse the seasonal filtering in the theme settings list to avoid showing Halloween/Christmas when it is not their season
- add unit coverage for seasonal palette availability rules

## Testing
- ./gradlew apptoolkit:test *(fails: Android SDK not configured in the environment)*

## Change Rationale
- Seasonal themes were appearing outside their intended windows; filtering options by season or current selection keeps seasonal themes hidden until their season returns while allowing users to keep their existing choice.


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958e9d9e6e4832d9c74414954b1fbaa)