### PR TITLE
Improve error mapping for apps list and support billing flows

### DIFF
--- a/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/data/repository/DeveloperAppsRepositoryImplTest.kt
+++ b/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/data/repository/DeveloperAppsRepositoryImplTest.kt
@@ -8,6 +8,7 @@ import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppCategory
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
 import com.d4rk.android.apps.apptoolkit.core.domain.model.network.AppErrors
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Errors
 import io.ktor.client.HttpClient
 import io.ktor.client.engine.mock.MockEngine
 import io.ktor.client.engine.mock.respond
@@ -120,7 +121,7 @@ class DeveloperAppsRepositoryImplTest {
 
         val result = repository.fetchDeveloperApps().first()
         val error = result as DataState.Error
-        assertEquals(AppErrors.Network.REQUEST_TIMEOUT, error.error)
+        assertEquals(AppErrors.Common(Errors.Network.REQUEST_TIMEOUT), error.error)
     }
 
     @Test
@@ -192,6 +193,6 @@ class DeveloperAppsRepositoryImplTest {
 
         val result = repository.fetchDeveloperApps().first()
         val error = result as DataState.Error
-        assertEquals(AppErrors.UseCase.FAILED_TO_LOAD_APPS, error.error)
+        assertEquals(AppErrors.Common(Errors.Network.HTTP_CLIENT_ERROR), error.error)
     }
 }

--- a/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/usecases/FetchDeveloperAppsUseCaseTest.kt
+++ b/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/usecases/FetchDeveloperAppsUseCaseTest.kt
@@ -4,6 +4,7 @@ import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.repository.DeveloperAppsRepository
 import com.d4rk.android.apps.apptoolkit.core.domain.model.network.AppErrors
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Errors
 import io.mockk.every
 import io.mockk.mockk
 import io.mockk.verify
@@ -31,7 +32,9 @@ class FetchDeveloperAppsUseCaseTest {
         )
         val repositoryEmissions = listOf(
             DataState.Success(apps),
-            DataState.Error<List<AppInfo>, AppErrors>(error = AppErrors.Network.REQUEST_TIMEOUT),
+            DataState.Error<List<AppInfo>, AppErrors>(
+                error = AppErrors.Common(Errors.Network.REQUEST_TIMEOUT)
+            ),
         )
         val repository = mockk<DeveloperAppsRepository> {
             every { fetchDeveloperApps() } returns repositoryEmissions.asFlow()


### PR DESCRIPTION
## Summary
- map developer apps repository HTTP status and exceptions to shared network error taxonomy and refresh unit expectations
- align support billing query DataState with shared Errors and simplify snackbar/error state updates

## Testing
- ⚠️ `./gradlew :app:testDebugUnitTest --tests "com.d4rk.android.apps.apptoolkit.app.apps.list.data.repository.DeveloperAppsRepositoryImplTest" --tests "com.d4rk.android.apps.apptoolkit.app.apps.list.domain.usecases.FetchDeveloperAppsUseCaseTest"` *(fails: Android SDK not configured in environment)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958efd4224c832da3c9d0b3c206b85d)