### PR TITLE
Improve intent handling and ads use case wiring

### DIFF
--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/settings/settings/utils/providers/AppSettingsProvider.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/settings/settings/utils/providers/AppSettingsProvider.kt
@@ -29,7 +29,16 @@ class AppSettingsProvider : SettingsProvider {
                             icon = Icons.Outlined.Notifications,
                             title = context.getString(R.string.notifications),
                             summary = context.getString(R.string.summary_preference_settings_notifications),
-                            action = { context.openAppNotificationSettings() },
+                            action = {
+                                val opened = context.openAppNotificationSettings()
+                                if (!opened) {
+                                    GeneralSettingsActivity.start(
+                                        context = context,
+                                        title = context.getString(R.string.security_and_privacy),
+                                        contentKey = SettingsContent.SECURITY_AND_PRIVACY,
+                                    )
+                                }
+                            },
                         ),
                         SettingsPreference(
                             key = SettingsContent.DISPLAY,

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/app/AdsModule.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/app/AdsModule.kt
@@ -3,6 +3,8 @@ package com.d4rk.android.apps.apptoolkit.core.di.modules.app
 import com.d4rk.android.apps.apptoolkit.core.utils.constants.ads.AdsConstants
 import com.d4rk.android.libs.apptoolkit.app.ads.data.repository.AdsSettingsRepositoryImpl
 import com.d4rk.android.libs.apptoolkit.app.ads.domain.repository.AdsSettingsRepository
+import com.d4rk.android.libs.apptoolkit.app.ads.domain.usecases.ObserveAdsEnabledUseCase
+import com.d4rk.android.libs.apptoolkit.app.ads.domain.usecases.SetAdsEnabledUseCase
 import com.d4rk.android.libs.apptoolkit.app.ads.ui.AdsSettingsViewModel
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoProvider
 import com.d4rk.android.libs.apptoolkit.core.ui.model.ads.AdsConfig
@@ -20,6 +22,9 @@ val adsModule: Module = module {
             buildInfoProvider = get<BuildInfoProvider>(),
         )
     }
+
+    single { ObserveAdsEnabledUseCase(repo = get()) }
+    single { SetAdsEnabledUseCase(repo = get()) }
 
     viewModel {
         AdsSettingsViewModel(

--- a/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/settings/settings/utils/providers/AppSettingsProviderTest.kt
+++ b/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/settings/settings/utils/providers/AppSettingsProviderTest.kt
@@ -97,7 +97,7 @@ class AppSettingsProviderTest {
         assertEquals(defaultStrings[R.string.summary_preference_settings_about], about.summary)
 
         notifications.action.invoke()
-        verify(exactly = 1) { context.openAppNotificationSettings() } // FIXME: The result of `openAppNotificationSettings` is not used
+        verify(exactly = 1) { context.openAppNotificationSettings() }
 
         display.action.invoke()
         verify(exactly = 1) {
@@ -132,6 +132,32 @@ class AppSettingsProviderTest {
                 context,
                 defaultStrings[R.string.about]!!,
                 SettingsContent.ABOUT
+            )
+        }
+
+        assertNull(config.categories[0].title)
+        assertEquals(defaultStrings[R.string.settings], config.title)
+    }
+
+    @Test
+    fun `notifications preference falls back to privacy screen when system settings cannot open`() {
+        val context = createContext(defaultStrings)
+        mockkStatic("com.d4rk.android.libs.apptoolkit.core.utils.extensions.context.IntentActionsExtensionsKt")
+        mockkObject(GeneralSettingsActivity.Companion)
+        every { context.openAppNotificationSettings() } returns false
+        every { GeneralSettingsActivity.start(any(), any(), any()) } just Runs
+
+        val config = provider.provideSettingsConfig(context)
+        val notifications = config.categories.first().preferences.first()
+
+        assertDoesNotThrow { notifications.action.invoke() }
+
+        verify(exactly = 1) { context.openAppNotificationSettings() }
+        verify(exactly = 1) {
+            GeneralSettingsActivity.start(
+                context,
+                defaultStrings[R.string.security_and_privacy]!!,
+                SettingsContent.SECURITY_AND_PRIVACY
             )
         }
     }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/ads/domain/usecases/ObserveAdsEnabledUseCase.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/ads/domain/usecases/ObserveAdsEnabledUseCase.kt
@@ -3,7 +3,9 @@ package com.d4rk.android.libs.apptoolkit.app.ads.domain.usecases
 import com.d4rk.android.libs.apptoolkit.app.ads.domain.repository.AdsSettingsRepository
 import kotlinx.coroutines.flow.Flow
 
-// TODO && FIXME: May be miss from DI Koin
+/**
+ * Exposes a stream of the ads-enabled flag from the repository.
+ */
 class ObserveAdsEnabledUseCase(
     private val repo: AdsSettingsRepository,
 ) {

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/utils/extensions/context/ContextIntentExtensions.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/utils/extensions/context/ContextIntentExtensions.kt
@@ -27,20 +27,12 @@ fun Context.startActivitySafely(
 ): Boolean {
     val launchIntent = if (addNewTaskFlag) intent.requireNewTask(this) else intent
 
-    return try { // TODO: Make try catch to be runCatching
-        startActivity(launchIntent)
-        true
-    } catch (t: ActivityNotFoundException) {
-        onFailure(t)
-        false
-    } catch (t: SecurityException) {
-        onFailure(t)
-        false
-    } catch (t: RuntimeException) {
-        // Covers OEM/background launch restrictions, bad flags, etc.
-        onFailure(t)
-        false
-    }
+    return runCatching { startActivity(launchIntent) }
+        .onFailure(onFailure)
+        .fold(
+            onSuccess = { true },
+            onFailure = { false }
+        )
 }
 
 @CheckResult
@@ -94,7 +86,14 @@ fun Context.openAppNotificationSettings(): Boolean {
             putExtra(Settings.EXTRA_CHANNEL_ID, 0)
         }
     }
-    return startActivitySafely(intent)
+    if (startActivitySafely(intent)) return true
+
+    val appDetails = Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+        data = Uri.fromParts("package", pkg, null)
+    }
+    if (startActivitySafely(appDetails)) return true
+
+    return startActivitySafely(Intent(Settings.ACTION_SETTINGS))
 }
 
 /**

--- a/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/app/about/data/repository/TestAboutRepositoryImpl.kt
+++ b/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/app/about/data/repository/TestAboutRepositoryImpl.kt
@@ -62,12 +62,14 @@ class TestAboutRepositoryImpl {
             "com.d4rk.android.libs.apptoolkit.core.utils.extensions.context.ContextExtensionsKt"
         mockkStatic(extFile)
 
-        try { // TODO: Make try catch to be runCatching
-            every { ctx.copyTextToClipboard(any(), any(), any()) } returns true
+        try {
+            val copied = runCatching {
+                every { ctx.copyTextToClipboard(any(), any(), any()) } returns true
+                repo.copyDeviceInfo("label", "info")
+            }.getOrThrow()
 
-            val copied = repo.copyDeviceInfo("label", "info")
             verify {
-                ctx.copyTextToClipboard( // FIXME: The result of `copyTextToClipboard` is not used
+                ctx.copyTextToClipboard(
                     "label",
                     "info",
                     any()

--- a/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/core/utils/platform/TestAppInfoHelper.kt
+++ b/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/core/utils/platform/TestAppInfoHelper.kt
@@ -34,11 +34,7 @@ class TestAppInfoHelper {
         crossinline block: suspend () -> T,
         crossinline finallyBlock: () -> Unit
     ): T {
-        val result: Result<T> = try { // TODO: Make try catch to be runCatching
-            Result.success(block())
-        } catch (t: Throwable) {
-            Result.failure(t)
-        }
+        val result: Result<T> = runCatching { block() }
 
         val cleanupError: Throwable? = runCatching { finallyBlock() }.exceptionOrNull()
 


### PR DESCRIPTION
## Summary
- wire ads settings use cases into the DI graph and document the ads flag observer
- harden activity intent helpers with runCatching and add notification settings fallbacks
- add notification fallback navigation and strengthen related unit tests

## Testing
- ⚠️ `./gradlew app:testDebugUnitTest --tests "com.d4rk.android.apps.apptoolkit.app.settings.settings.utils.providers.AppSettingsProviderTest"` *(fails: Android SDK not configured in CI sandbox)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958f152a118832db1dcca99aedba25f)