### PR TITLE
Separate DI modules per feature

### DIFF
--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/KoinModule.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/KoinModule.kt
@@ -5,28 +5,27 @@ import com.d4rk.android.apps.apptoolkit.core.di.modules.app.adsModule
 import com.d4rk.android.apps.apptoolkit.core.di.modules.app.appModule
 import com.d4rk.android.apps.apptoolkit.core.di.modules.app.onboardingModule
 import com.d4rk.android.apps.apptoolkit.core.di.modules.app.startupModule
-import com.d4rk.android.apps.apptoolkit.core.di.modules.apptoolkit.appToolkitModule
+import com.d4rk.android.apps.apptoolkit.core.di.modules.apptoolkit.appToolkitModules
 import com.d4rk.android.apps.apptoolkit.core.di.modules.dispatchersModule
-import com.d4rk.android.apps.apptoolkit.core.di.modules.settings.settingsModule
+import com.d4rk.android.apps.apptoolkit.core.di.modules.settings.settingsModules
 import com.d4rk.android.apps.apptoolkit.core.di.modules.settings.themeModule
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.context.startKoin
 
-// TODO: Separate all modules better (per-feature some of them)
 fun initializeKoin(context: Context) {
     startKoin {
         androidContext(androidContext = context)
         modules(
-            modules = listOf(
-                appModule,
-                settingsModule,
-                adsModule,
-                appToolkitModule,
-                themeModule,
-                dispatchersModule,
-                onboardingModule,
-                startupModule,
-            )
+            modules = buildList {
+                add(appModule)
+                addAll(settingsModules)
+                add(adsModule)
+                addAll(appToolkitModules)
+                add(themeModule)
+                add(dispatchersModule)
+                add(onboardingModule)
+                add(startupModule)
+            }
         )
     }
 }

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/apptoolkit/AppToolkitCoreModule.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/apptoolkit/AppToolkitCoreModule.kt
@@ -1,0 +1,22 @@
+package com.d4rk.android.apps.apptoolkit.core.di.modules.apptoolkit
+
+import com.d4rk.android.apps.apptoolkit.BuildConfig
+import com.d4rk.android.apps.apptoolkit.app.startup.utils.interfaces.providers.AppStartupProvider
+import com.d4rk.android.libs.apptoolkit.app.startup.ui.StartupViewModel
+import com.d4rk.android.libs.apptoolkit.app.startup.utils.interfaces.providers.StartupProvider
+import com.d4rk.android.libs.apptoolkit.core.ui.model.AppVersionInfo
+import org.koin.core.module.Module
+import org.koin.core.module.dsl.viewModel
+import org.koin.dsl.module
+
+val appToolkitCoreModule: Module = module {
+    single<StartupProvider> { AppStartupProvider() }
+    viewModel { StartupViewModel() }
+
+    single<AppVersionInfo> {
+        AppVersionInfo(
+            BuildConfig.VERSION_NAME,
+            BuildConfig.VERSION_CODE.toLong()
+        )
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/apptoolkit/AppToolkitModules.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/apptoolkit/AppToolkitModules.kt
@@ -1,0 +1,8 @@
+package com.d4rk.android.apps.apptoolkit.core.di.modules.apptoolkit
+
+val appToolkitModules = listOf(
+    appToolkitCoreModule,
+    supportModule,
+    helpModule,
+    issueReporterModule
+)

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/apptoolkit/HelpModule.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/apptoolkit/HelpModule.kt
@@ -1,0 +1,32 @@
+package com.d4rk.android.apps.apptoolkit.core.di.modules.apptoolkit
+
+import com.d4rk.android.apps.apptoolkit.BuildConfig
+import com.d4rk.android.apps.apptoolkit.core.utils.constants.HelpConstants
+import com.d4rk.android.libs.apptoolkit.app.help.data.local.HelpLocalDataSource
+import com.d4rk.android.libs.apptoolkit.app.help.data.remote.HelpRemoteDataSource
+import com.d4rk.android.libs.apptoolkit.app.help.data.repository.FaqRepositoryImpl
+import com.d4rk.android.libs.apptoolkit.app.help.domain.repository.FaqRepository
+import com.d4rk.android.libs.apptoolkit.app.help.domain.usecases.GetFaqUseCase
+import com.d4rk.android.libs.apptoolkit.app.help.ui.HelpViewModel
+import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
+import com.d4rk.android.libs.apptoolkit.core.utils.extensions.string.faqCatalogUrl
+import org.koin.core.module.Module
+import org.koin.core.module.dsl.viewModel
+import org.koin.dsl.module
+
+val helpModule: Module = module {
+    single { HelpLocalDataSource(context = get()) }
+    single { HelpRemoteDataSource(client = get()) }
+    single<FaqRepository> {
+        FaqRepositoryImpl(
+            localDataSource = get(),
+            remoteDataSource = get(),
+            catalogUrl = com.d4rk.android.libs.apptoolkit.core.utils.constants.help.HelpConstants.FAQ_BASE_URL.faqCatalogUrl(
+                isDebugBuild = BuildConfig.DEBUG
+            ),
+            productId = HelpConstants.FAQ_PRODUCT_ID,
+        )
+    }
+    single { GetFaqUseCase(repository = get()) }
+    viewModel { HelpViewModel(getFaqUseCase = get(), dispatchers = get<DispatcherProvider>()) }
+}

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/apptoolkit/IssueReporterModule.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/apptoolkit/IssueReporterModule.kt
@@ -1,0 +1,51 @@
+package com.d4rk.android.apps.apptoolkit.core.di.modules.apptoolkit
+
+import com.d4rk.android.apps.apptoolkit.BuildConfig
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.data.local.DeviceInfoLocalDataSource
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.data.remote.IssueReporterRemoteDataSource
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.data.repository.IssueReporterRepositoryImpl
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.github.GithubTarget
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.providers.DeviceInfoProvider
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.repository.IssueReporterRepository
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.usecases.SendIssueReportUseCase
+import com.d4rk.android.libs.apptoolkit.app.issuereporter.ui.IssueReporterViewModel
+import com.d4rk.android.libs.apptoolkit.core.di.GithubToken
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.github.GithubConstants
+import com.d4rk.android.libs.apptoolkit.core.utils.extensions.string.toToken
+import org.koin.core.module.Module
+import org.koin.core.module.dsl.viewModel
+import org.koin.core.qualifier.named
+import org.koin.core.qualifier.qualifier
+import org.koin.dsl.module
+
+private val githubTokenQualifier = qualifier<GithubToken>()
+
+val issueReporterModule: Module = module {
+    single { IssueReporterRemoteDataSource(client = get()) }
+    single<DeviceInfoProvider> { DeviceInfoLocalDataSource(get(), get()) }
+    single<IssueReporterRepository> { IssueReporterRepositoryImpl(get(), get()) }
+    single { SendIssueReportUseCase(get(), get()) }
+
+    single(qualifier = named(name = "github_repository")) { "App-Toolkit-for-Android" }
+    single<GithubTarget> {
+        GithubTarget(
+            username = GithubConstants.GITHUB_USER,
+            repository = get(qualifier = named("github_repository")),
+        )
+    }
+
+    single(qualifier = named("github_changelog")) {
+        GithubConstants.githubChangelog(get<String>(named("github_repository")))
+    }
+
+    single(githubTokenQualifier) { BuildConfig.GITHUB_TOKEN.toToken() }
+
+    viewModel {
+        IssueReporterViewModel(
+            sendIssueReport = get(),
+            githubTarget = get(),
+            githubToken = get(githubTokenQualifier),
+            deviceInfoProvider = get()
+        )
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/apptoolkit/SupportModule.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/apptoolkit/SupportModule.kt
@@ -1,0 +1,25 @@
+package com.d4rk.android.apps.apptoolkit.core.di.modules.apptoolkit
+
+import com.d4rk.android.libs.apptoolkit.app.support.billing.BillingRepository
+import com.d4rk.android.libs.apptoolkit.app.support.ui.SupportViewModel
+import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import org.koin.core.module.Module
+import org.koin.core.module.dsl.viewModel
+import org.koin.dsl.module
+
+val supportModule: Module = module {
+    single(createdAtStart = true) {
+        val dispatchers = get<DispatcherProvider>()
+        BillingRepository.getInstance(
+            context = get(),
+            dispatchers = dispatchers,
+            externalScope = CoroutineScope(SupervisorJob() + dispatchers.io)
+        )
+    }
+
+    viewModel {
+        SupportViewModel(billingRepository = get())
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/settings/AboutModule.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/settings/AboutModule.kt
@@ -1,0 +1,36 @@
+package com.d4rk.android.apps.apptoolkit.core.di.modules.settings
+
+import com.d4rk.android.apps.apptoolkit.app.settings.settings.utils.providers.AppAboutSettingsProvider
+import com.d4rk.android.apps.apptoolkit.app.settings.settings.utils.providers.AppBuildInfoProvider
+import com.d4rk.android.libs.apptoolkit.app.about.data.repository.AboutRepositoryImpl
+import com.d4rk.android.libs.apptoolkit.app.about.domain.repository.AboutRepository
+import com.d4rk.android.libs.apptoolkit.app.about.domain.usecases.CopyDeviceInfoUseCase
+import com.d4rk.android.libs.apptoolkit.app.about.domain.usecases.GetAboutInfoUseCase
+import com.d4rk.android.libs.apptoolkit.app.about.ui.AboutViewModel
+import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.AboutSettingsProvider
+import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoProvider
+import org.koin.core.module.Module
+import org.koin.core.module.dsl.viewModel
+import org.koin.dsl.module
+
+val aboutModule: Module = module {
+    single<AboutSettingsProvider> { AppAboutSettingsProvider(context = get()) }
+    single<BuildInfoProvider> { AppBuildInfoProvider() }
+    single<AboutRepository> {
+        AboutRepositoryImpl(
+            deviceProvider = get(),
+            buildInfoProvider = get(),
+            context = get(),
+        )
+    }
+    single { GetAboutInfoUseCase(repository = get()) }
+    single { CopyDeviceInfoUseCase(repository = get()) }
+
+    viewModel {
+        AboutViewModel(
+            getAboutInfo = get(),
+            copyDeviceInfo = get(),
+            dispatchers = get(),
+        )
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/settings/AdvancedSettingsModule.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/settings/AdvancedSettingsModule.kt
@@ -1,0 +1,17 @@
+package com.d4rk.android.apps.apptoolkit.core.di.modules.settings
+
+import com.d4rk.android.apps.apptoolkit.app.settings.settings.utils.providers.AppAdvancedSettingsProvider
+import com.d4rk.android.libs.apptoolkit.app.advanced.data.repository.CacheRepositoryImpl
+import com.d4rk.android.libs.apptoolkit.app.advanced.domain.repository.CacheRepository
+import com.d4rk.android.libs.apptoolkit.app.advanced.ui.AdvancedSettingsViewModel
+import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.AdvancedSettingsProvider
+import org.koin.core.module.Module
+import org.koin.core.module.dsl.viewModel
+import org.koin.dsl.module
+
+val advancedSettingsModule: Module = module {
+    single<AdvancedSettingsProvider> { AppAdvancedSettingsProvider(context = get()) }
+    single<CacheRepository> { CacheRepositoryImpl(context = get()) }
+
+    viewModel { AdvancedSettingsViewModel(repository = get(), dispatchers = get()) }
+}

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/settings/GeneralSettingsModule.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/settings/GeneralSettingsModule.kt
@@ -1,0 +1,24 @@
+package com.d4rk.android.apps.apptoolkit.core.di.modules.settings
+
+import com.d4rk.android.apps.apptoolkit.app.settings.settings.utils.providers.AppDisplaySettingsProvider
+import com.d4rk.android.apps.apptoolkit.app.settings.settings.utils.providers.AppPrivacySettingsProvider
+import com.d4rk.android.libs.apptoolkit.app.settings.general.data.repository.GeneralSettingsRepositoryImpl
+import com.d4rk.android.libs.apptoolkit.app.settings.general.domain.repository.GeneralSettingsRepository
+import com.d4rk.android.libs.apptoolkit.app.settings.general.ui.GeneralSettingsViewModel
+import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.DisplaySettingsProvider
+import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.GeneralSettingsContentProvider
+import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.PrivacySettingsProvider
+import org.koin.core.module.Module
+import org.koin.core.module.dsl.viewModel
+import org.koin.dsl.module
+
+val generalSettingsModule: Module = module {
+    single<DisplaySettingsProvider> { AppDisplaySettingsProvider(context = get()) }
+    single<PrivacySettingsProvider> { AppPrivacySettingsProvider(context = get()) }
+    single<GeneralSettingsContentProvider> { GeneralSettingsContentProvider() }
+    single<GeneralSettingsRepository> { GeneralSettingsRepositoryImpl() }
+
+    viewModel {
+        GeneralSettingsViewModel(repository = get(), dispatchers = get())
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/settings/PermissionsModule.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/settings/PermissionsModule.kt
@@ -1,0 +1,22 @@
+package com.d4rk.android.apps.apptoolkit.core.di.modules.settings
+
+import com.d4rk.android.libs.apptoolkit.app.permissions.data.repository.PermissionsRepositoryImpl
+import com.d4rk.android.libs.apptoolkit.app.permissions.domain.repository.PermissionsRepository
+import com.d4rk.android.libs.apptoolkit.app.permissions.ui.PermissionsViewModel
+import org.koin.core.module.Module
+import org.koin.core.module.dsl.viewModel
+import org.koin.dsl.module
+
+val permissionsModule: Module = module {
+    single<PermissionsRepository> {
+        PermissionsRepositoryImpl(
+            context = get(),
+            dispatchers = get()
+        )
+    }
+    viewModel {
+        PermissionsViewModel(
+            permissionsRepository = get(),
+        )
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/settings/SettingsModule.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/settings/SettingsModule.kt
@@ -44,8 +44,9 @@ val settingsModule = module {
             dispatchers = get(),
         )
     }
+}
 
-    // TODO: Make about module
+val aboutModule = module {
     single<AboutSettingsProvider> { AppAboutSettingsProvider(context = get()) }
     single<AdvancedSettingsProvider> { AppAdvancedSettingsProvider(context = get()) }
     single<DisplaySettingsProvider> { AppDisplaySettingsProvider(context = get()) }
@@ -67,7 +68,18 @@ val settingsModule = module {
         GeneralSettingsViewModel(repository = get(), dispatchers = get())
     }
 
-    // TODO MAke permissions module
+    viewModel { AdvancedSettingsViewModel(repository = get(), dispatchers = get()) }
+
+    viewModel {
+        AboutViewModel(
+            getAboutInfo = get(),
+            copyDeviceInfo = get(),
+            dispatchers = get(),
+        )
+    }
+}
+
+val permissionsModule = module {
     single<PermissionsRepository> {
         PermissionsRepositoryImpl(
             context = get(),
@@ -79,19 +91,9 @@ val settingsModule = module {
             permissionsRepository = get(),
         )
     }
+}
 
-    viewModel { AdvancedSettingsViewModel(repository = get(), dispatchers = get()) }
-
-    single<GetAboutInfoUseCase> { GetAboutInfoUseCase(repository = get()) }
-    viewModel {
-        AboutViewModel(
-            getAboutInfo = get(),
-            copyDeviceInfo = get(),
-            dispatchers = get(),
-        )
-    }
-
-    // TODO Make usage and diagnostics module
+val usageAndDiagnosticsModule = module {
     single<UsageAndDiagnosticsRepository> {
         UsageAndDiagnosticsRepositoryImpl(
             dataSource = get<CommonDataStore>(),
@@ -104,3 +106,10 @@ val settingsModule = module {
         UsageAndDiagnosticsViewModel(repository = get())
     }
 }
+
+val settingsModules = listOf(
+    settingsModule,
+    aboutModule,
+    permissionsModule,
+    usageAndDiagnosticsModule
+)

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/settings/SettingsModules.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/settings/SettingsModules.kt
@@ -1,0 +1,10 @@
+package com.d4rk.android.apps.apptoolkit.core.di.modules.settings
+
+val settingsModules = listOf(
+    settingsRootModule,
+    aboutModule,
+    advancedSettingsModule,
+    generalSettingsModule,
+    permissionsModule,
+    usageAndDiagnosticsModule
+)

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/settings/SettingsRootModule.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/settings/SettingsRootModule.kt
@@ -1,0 +1,19 @@
+package com.d4rk.android.apps.apptoolkit.core.di.modules.settings
+
+import com.d4rk.android.apps.apptoolkit.app.settings.settings.utils.providers.AppSettingsProvider
+import com.d4rk.android.libs.apptoolkit.app.settings.settings.ui.SettingsViewModel
+import com.d4rk.android.libs.apptoolkit.app.settings.utils.interfaces.SettingsProvider
+import org.koin.core.module.Module
+import org.koin.core.module.dsl.viewModel
+import org.koin.dsl.module
+
+val settingsRootModule: Module = module {
+    single<SettingsProvider> { AppSettingsProvider() }
+
+    viewModel {
+        SettingsViewModel(
+            settingsProvider = get(),
+            dispatchers = get(),
+        )
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/settings/UsageAndDiagnosticsModule.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/settings/UsageAndDiagnosticsModule.kt
@@ -1,0 +1,23 @@
+package com.d4rk.android.apps.apptoolkit.core.di.modules.settings
+
+import com.d4rk.android.libs.apptoolkit.app.diagnostics.data.repository.UsageAndDiagnosticsRepositoryImpl
+import com.d4rk.android.libs.apptoolkit.app.diagnostics.domain.repository.UsageAndDiagnosticsRepository
+import com.d4rk.android.libs.apptoolkit.app.diagnostics.ui.UsageAndDiagnosticsViewModel
+import com.d4rk.android.libs.apptoolkit.data.local.datastore.CommonDataStore
+import org.koin.core.module.Module
+import org.koin.core.module.dsl.viewModel
+import org.koin.dsl.module
+
+val usageAndDiagnosticsModule: Module = module {
+    single<UsageAndDiagnosticsRepository> {
+        UsageAndDiagnosticsRepositoryImpl(
+            dataSource = get<CommonDataStore>(),
+            configProvider = get(),
+            dispatchers = get(),
+        )
+    }
+
+    viewModel {
+        UsageAndDiagnosticsViewModel(repository = get())
+    }
+}


### PR DESCRIPTION
## Summary
- split app toolkit DI into individual modules per screen (startup/app version, support, help, issue reporter) and expose a grouped list
- separate settings DI into per-screen modules (root, about, advanced, general, permissions, diagnostics) with a shared aggregator
- wire Koin initialization to the new module collections for clearer feature boundaries

## Rationale
- addresses TODOs by isolating bindings per feature/screen, improving maintainability and feature-first organization

## Testing
- :app:compileDebugKotlin *(fails: Android SDK not available in environment)*


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6958f4f08ff0832da35569ab99131dcc)