### PR TITLE
Move AppWindowWidthSizeClass into core UI window package

### DIFF
--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/screens/AppsList.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/screens/AppsList.kt
@@ -27,7 +27,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.views.ads.AppsListNativeAdCard
 import com.d4rk.android.libs.apptoolkit.core.ui.views.modifiers.animateVisibility
 import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.LargeVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
-import com.d4rk.android.libs.apptoolkit.core.utils.window.AppWindowWidthSizeClass
+import com.d4rk.android.libs.apptoolkit.core.ui.window.AppWindowWidthSizeClass
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableSet
 import org.koin.compose.koinInject

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/screens/loading/HomeLoadingScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/screens/loading/HomeLoadingScreen.kt
@@ -12,7 +12,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.core.utils.platform.WindowItemFit
-import com.d4rk.android.libs.apptoolkit.core.utils.window.AppWindowWidthSizeClass
+import com.d4rk.android.libs.apptoolkit.core.ui.window.AppWindowWidthSizeClass
 
 @Composable
 fun HomeLoadingScreen(

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsScreen.kt
@@ -40,7 +40,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.views.layouts.NoDataScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.views.layouts.ScreenStateHandler
 import com.d4rk.android.libs.apptoolkit.core.utils.extensions.context.openPlayStoreForApp
 import com.d4rk.android.libs.apptoolkit.core.utils.platform.AppInfoHelper
-import com.d4rk.android.libs.apptoolkit.core.utils.window.AppWindowWidthSizeClass
+import com.d4rk.android.libs.apptoolkit.core.ui.window.AppWindowWidthSizeClass
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.toImmutableSet
 import kotlinx.coroutines.flow.collectLatest

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListScreen.kt
@@ -33,7 +33,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.views.layouts.NoDataScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.views.layouts.ScreenStateHandler
 import com.d4rk.android.libs.apptoolkit.core.utils.extensions.context.openPlayStoreForApp
 import com.d4rk.android.libs.apptoolkit.core.utils.platform.AppInfoHelper
-import com.d4rk.android.libs.apptoolkit.core.utils.window.AppWindowWidthSizeClass
+import com.d4rk.android.libs.apptoolkit.core.ui.window.AppWindowWidthSizeClass
 import kotlinx.collections.immutable.toImmutableSet
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainScreen.kt
@@ -66,8 +66,8 @@ import com.d4rk.android.libs.apptoolkit.core.ui.navigation.rememberNavigationSta
 import com.d4rk.android.libs.apptoolkit.core.ui.state.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.views.ads.BottomAppBarNativeAdBanner
 import com.d4rk.android.libs.apptoolkit.core.ui.views.snackbar.DefaultSnackbarHost
-import com.d4rk.android.libs.apptoolkit.core.utils.window.AppWindowWidthSizeClass
-import com.d4rk.android.libs.apptoolkit.core.utils.window.rememberWindowWidthSizeClass
+import com.d4rk.android.libs.apptoolkit.core.ui.window.AppWindowWidthSizeClass
+import com.d4rk.android.libs.apptoolkit.core.ui.window.rememberWindowWidthSizeClass
 import com.d4rk.android.libs.apptoolkit.data.local.datastore.startupDestinationFlow
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.CoroutineScope

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/views/navigation/AppNavigationGraph.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/views/navigation/AppNavigationGraph.kt
@@ -6,7 +6,7 @@ import com.d4rk.android.apps.apptoolkit.app.apps.favorites.ui.navigation.favorit
 import com.d4rk.android.apps.apptoolkit.app.apps.list.ui.navigation.appsListEntryBuilder
 import com.d4rk.android.apps.apptoolkit.app.main.utils.constants.AppNavKey
 import com.d4rk.android.libs.apptoolkit.core.ui.navigation.NavigationEntryBuilder
-import com.d4rk.android.libs.apptoolkit.core.utils.window.AppWindowWidthSizeClass
+import com.d4rk.android.libs.apptoolkit.core.ui.window.AppWindowWidthSizeClass
 
 /**
  * Context shared by all navigation entry builders in the app module.

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/views/navigation/AppNavigationHost.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/views/navigation/AppNavigationHost.kt
@@ -13,7 +13,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.navigation.NavigationState
 import com.d4rk.android.libs.apptoolkit.core.ui.navigation.Navigator
 import com.d4rk.android.libs.apptoolkit.core.ui.navigation.entryProviderFor
 import com.d4rk.android.libs.apptoolkit.core.ui.navigation.rememberNavigationEntryDecorators
-import com.d4rk.android.libs.apptoolkit.core.utils.window.AppWindowWidthSizeClass
+import com.d4rk.android.libs.apptoolkit.core.ui.window.AppWindowWidthSizeClass
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/views/navigation/NavigationDrawer.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/views/navigation/NavigationDrawer.kt
@@ -24,7 +24,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.navigation.NavigationState
 import com.d4rk.android.libs.apptoolkit.core.ui.navigation.Navigator
 import com.d4rk.android.libs.apptoolkit.core.ui.views.modifiers.hapticDrawerSwipe
 import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.LargeVerticalSpacer
-import com.d4rk.android.libs.apptoolkit.core.utils.window.AppWindowWidthSizeClass
+import com.d4rk.android.libs.apptoolkit.core.ui.window.AppWindowWidthSizeClass
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.CoroutineScope
 import org.koin.compose.koinInject

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsScreen.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsScreen.kt
@@ -60,8 +60,8 @@ import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.LargeVerticalSpace
 import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.SmallVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.core.utils.extensions.context.openActivity
-import com.d4rk.android.libs.apptoolkit.core.utils.window.AppWindowWidthSizeClass
-import com.d4rk.android.libs.apptoolkit.core.utils.window.rememberWindowWidthSizeClass
+import com.d4rk.android.libs.apptoolkit.core.ui.window.AppWindowWidthSizeClass
+import com.d4rk.android.libs.apptoolkit.core.ui.window.rememberWindowWidthSizeClass
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/window/WindowSizeClassUtils.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/window/WindowSizeClassUtils.kt
@@ -1,4 +1,4 @@
-package com.d4rk.android.libs.apptoolkit.core.utils.window
+package com.d4rk.android.libs.apptoolkit.core.ui.window
 
 import androidx.compose.material3.adaptive.WindowAdaptiveInfo
 import androidx.compose.material3.adaptive.currentWindowAdaptiveInfo

--- a/docs/general/app-toolkit-library.md
+++ b/docs/general/app-toolkit-library.md
@@ -19,7 +19,7 @@ The `core` package provides foundational helpers and models:
 
 - Material 3 window size classes are exported as API dependencies so apps using the toolkit inherit
   responsive layout tooling by default.
-- Use `rememberWindowWidthSizeClass()` from `core.utils.window` to query the current width class in
+- Use `rememberWindowWidthSizeClass()` from `core.ui.window` to query the current width class in
   composables and toggle between phone and tablet experiences without relying on orientation
   heuristics.
 


### PR DESCRIPTION
## Summary
- move `AppWindowWidthSizeClass` utilities into the core UI window package so sizing constants live alongside shared UI helpers
- update all call sites and documentation references to the new UI-layer namespace to keep non-UI modules from depending on sizing classes

## Testing
- ❌ `./gradlew :apptoolkit:compileDebugKotlin` *(fails: Android SDK is not configured in this environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a3bbabc84832dac1f29ab2b484636)