### PR TITLE
Refactor app install checks into extensions

### DIFF
--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/AppActions.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/AppActions.kt
@@ -11,6 +11,7 @@ import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import com.d4rk.android.libs.apptoolkit.core.utils.extensions.context.openPlayStoreForApp
 import com.d4rk.android.libs.apptoolkit.core.utils.extensions.context.shareApp
+import com.d4rk.android.libs.apptoolkit.core.utils.extensions.pm.isAppInstalled
 import com.d4rk.android.libs.apptoolkit.core.utils.platform.AppInfoHelper
 import kotlinx.coroutines.launch
 import org.koin.compose.koinInject
@@ -28,7 +29,7 @@ fun buildOnAppClick(
             coroutineScope.launch {
                 val ctx = currentContext
                 if (appInfo.packageName.isNotEmpty()) {
-                    if (appInfoHelper.isAppInstalled(ctx, appInfo.packageName)) {
+                    if (ctx.isAppInstalled(appInfo.packageName)) {
                         if (!appInfoHelper.openApp(ctx, appInfo.packageName)) {
                             ctx.openPlayStoreForApp(appInfo.packageName)
                         }

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsScreen.kt
@@ -39,6 +39,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.views.ads.rememberAdsEnabled
 import com.d4rk.android.libs.apptoolkit.core.ui.views.layouts.NoDataScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.views.layouts.ScreenStateHandler
 import com.d4rk.android.libs.apptoolkit.core.utils.extensions.context.openPlayStoreForApp
+import com.d4rk.android.libs.apptoolkit.core.utils.extensions.pm.isAppInstalled
 import com.d4rk.android.libs.apptoolkit.core.utils.platform.AppInfoHelper
 import com.d4rk.android.libs.apptoolkit.core.utils.window.AppWindowWidthSizeClass
 import kotlinx.collections.immutable.ImmutableSet
@@ -110,10 +111,11 @@ fun FavoriteAppsRoute(
 
     LaunchedEffect(selectedApp?.packageName) {
         isSelectedAppInstalled = selectedApp?.let { app ->
-            if (app.packageName.isNotEmpty()) appInfoHelper.isAppInstalled(
-                context,
-                app.packageName
-            ) else false
+            if (app.packageName.isNotEmpty()) {
+                context.isAppInstalled(app.packageName)
+            } else {
+                false
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListScreen.kt
@@ -32,6 +32,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.views.ads.rememberAdsEnabled
 import com.d4rk.android.libs.apptoolkit.core.ui.views.layouts.NoDataScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.views.layouts.ScreenStateHandler
 import com.d4rk.android.libs.apptoolkit.core.utils.extensions.context.openPlayStoreForApp
+import com.d4rk.android.libs.apptoolkit.core.utils.extensions.pm.isAppInstalled
 import com.d4rk.android.libs.apptoolkit.core.utils.platform.AppInfoHelper
 import com.d4rk.android.libs.apptoolkit.core.utils.window.AppWindowWidthSizeClass
 import kotlinx.collections.immutable.toImmutableSet
@@ -107,10 +108,11 @@ fun AppsListRoute(
 
     LaunchedEffect(selectedApp?.packageName) {
         isSelectedAppInstalled = selectedApp?.let { app ->
-            if (app.packageName.isNotEmpty()) appInfoHelper.isAppInstalled(
-                context,
-                app.packageName
-            ) else false
+            if (app.packageName.isNotEmpty()) {
+                context.isAppInstalled(app.packageName)
+            } else {
+                false
+            }
         }
     }
 

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/utils/extensions/packagemanager/PackageManagerExtensions.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/utils/extensions/packagemanager/PackageManagerExtensions.kt
@@ -1,5 +1,6 @@
 package com.d4rk.android.libs.apptoolkit.core.utils.extensions.pm
 
+import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.os.Build
@@ -14,6 +15,23 @@ import com.d4rk.android.libs.apptoolkit.core.ui.model.AppVersionInfo
 @CheckResult
 fun PackageManager.hasPackageVisible(packageName: String): Boolean =
     runCatching { getPackageInfoCompat(packageName) }.isSuccess
+
+/**
+ * Returns `true` when [packageName] is installed.
+ *
+ * The visibility rules documented in [hasPackageVisible] apply here as well on Android 11+
+ * devices.
+ */
+@CheckResult
+fun PackageManager.isAppInstalled(packageName: String): Boolean =
+    hasPackageVisible(packageName)
+
+/**
+ * Returns `true` when [packageName] is installed on this [Context]'s device.
+ */
+@CheckResult
+fun Context.isAppInstalled(packageName: String): Boolean =
+    packageManager.isAppInstalled(packageName)
 
 /**
  * Returns version metadata for [packageName], or `null` when unavailable (not installed, not visible, or error).

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/utils/platform/AppInfoHelper.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/utils/platform/AppInfoHelper.kt
@@ -12,15 +12,6 @@ open class AppInfoHelper(
 ) {
 
     /**
-     * Checks if a specific app is installed on the device.
-     * @return True if the app is installed, false otherwise.
-     */
-    suspend fun isAppInstalled(context: Context, packageName: String): Boolean =
-        withContext(dispatchers.io) {
-            runCatching { context.packageManager.getApplicationInfo(packageName, 0) }.isSuccess
-        }
-
-    /**
      * Opens a specific app if installed.
      *
      * Returns `true` if the app was successfully launched and `false` otherwise.

--- a/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/core/utils/platform/TestAppInfoHelper.kt
+++ b/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/core/utils/platform/TestAppInfoHelper.kt
@@ -4,10 +4,11 @@ import android.app.Activity
 import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
-import android.content.pm.ApplicationInfo
+import android.content.pm.PackageInfo
 import android.content.pm.PackageManager
 import android.widget.Toast
 import com.d4rk.android.libs.apptoolkit.core.di.TestDispatchers
+import com.d4rk.android.libs.apptoolkit.core.utils.extensions.pm.isAppInstalled
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
@@ -79,15 +80,13 @@ class TestAppInfoHelper {
 
     @Test
     fun `isAppInstalled returns true when app exists`() = runTest {
-        val dispatcher = UnconfinedTestDispatcher(testScheduler)
         println("🚀 [TEST] isAppInstalled returns true when app exists")
         val context = mockk<Context>()
         val pm = mockk<PackageManager>()
-        val appInfo = mockk<ApplicationInfo>()
         every { context.packageManager } returns pm
-        every { pm.getApplicationInfo("pkg", 0) } returns appInfo
+        every { pm.getPackageInfo("pkg", 0) } returns PackageInfo()
 
-        val result = AppInfoHelper(TestDispatchers(dispatcher)).isAppInstalled(context, "pkg")
+        val result = context.isAppInstalled("pkg")
 
         assertEquals(true, result)
         println("🏁 [TEST DONE] isAppInstalled returns true when app exists")
@@ -95,14 +94,13 @@ class TestAppInfoHelper {
 
     @Test
     fun `isAppInstalled returns false when app missing`() = runTest {
-        val dispatcher = UnconfinedTestDispatcher(testScheduler)
         println("🚀 [TEST] isAppInstalled returns false when app missing")
         val context = mockk<Context>()
         val pm = mockk<PackageManager>()
         every { context.packageManager } returns pm
-        every { pm.getApplicationInfo("pkg", 0) } throws PackageManager.NameNotFoundException()
+        every { pm.getPackageInfo("pkg", 0) } throws PackageManager.NameNotFoundException()
 
-        val result = AppInfoHelper(TestDispatchers(dispatcher)).isAppInstalled(context, "pkg")
+        val result = context.isAppInstalled("pkg")
 
         assertEquals(false, result)
         println("🏁 [TEST DONE] isAppInstalled returns false when app missing")


### PR DESCRIPTION
## Summary
- add reusable PackageManager/Context isAppInstalled extensions alongside existing package utilities
- update app actions and bottom sheet flows to use the new extension and remove duplicate helper logic
- adjust unit tests to exercise the extension-based install check

## Testing
- `./gradlew :apptoolkit:testDebugUnitTest --tests com.d4rk.android.libs.apptoolkit.core.utils.platform.TestAppInfoHelper` *(fails: Android SDK not configured in environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a3bb30318832dbd31dec48b6be82c)