### PR TITLE
Fix ads settings tests for updated contracts

### DIFF
--- a/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/core/utils/platform/ConsentManagerHelperTest.kt
+++ b/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/core/utils/platform/ConsentManagerHelperTest.kt
@@ -93,10 +93,10 @@ class ConsentManagerHelperTest {
 
             ConsentManagerHelper.applyInitialConsent(dataStore)
 
-            verify(exactly = 1) { dataStore.analyticsConsent(defaultValue) } // FIXME: Flow is constructed but not used
-            verify(exactly = 1) { dataStore.adStorageConsent(defaultValue) }// FIXME: Flow is constructed but not used
-            verify(exactly = 1) { dataStore.adUserDataConsent(defaultValue) }// FIXME: Flow is constructed but not used
-            verify(exactly = 1) { dataStore.adPersonalizationConsent(defaultValue) }// FIXME: Flow is constructed but not used
+            verify(exactly = 1) { dataStore.analyticsConsent(defaultValue) }
+            verify(exactly = 1) { dataStore.adStorageConsent(defaultValue) }
+            verify(exactly = 1) { dataStore.adUserDataConsent(defaultValue) }
+            verify(exactly = 1) { dataStore.adPersonalizationConsent(defaultValue) }
 
             verify(exactly = 1) {
                 ConsentManagerHelper.updateConsent(


### PR DESCRIPTION
## Summary
- update AdsSettingsViewModel unit coverage to use the new use cases and repository contract
- refresh consent helper verifications now that the flows are consumed in production code

## Testing
- ⚠️ `./gradlew :apptoolkit:testDebugUnitTest` *(fails: Android SDK not configured in the environment)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a468d6950832d9f4adf0667027c36)