### PR TITLE
Align copy feedback with ViewModel patterns

### DIFF
--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/about/data/repository/AboutRepositoryImpl.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/about/data/repository/AboutRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.d4rk.android.libs.apptoolkit.app.about.data.repository
 
 import android.content.Context
 import com.d4rk.android.libs.apptoolkit.app.about.domain.model.AboutInfo
+import com.d4rk.android.libs.apptoolkit.app.about.domain.model.CopyDeviceInfoResult
 import com.d4rk.android.libs.apptoolkit.app.about.domain.repository.AboutRepository
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.AboutSettingsProvider
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoProvider
@@ -20,6 +21,16 @@ class AboutRepositoryImpl(
             deviceInfo = deviceProvider.deviceInfo,
         )
 
-    override fun copyDeviceInfo(label: String, deviceInfo: String): Boolean =
-        context.copyTextToClipboard(label = label, text = deviceInfo)
+    override fun copyDeviceInfo(label: String, deviceInfo: String): CopyDeviceInfoResult {
+        var shouldShowFeedback = false
+        val copied = context.copyTextToClipboard(
+            label = label,
+            text = deviceInfo,
+            onCopyFallback = { shouldShowFeedback = true }
+        )
+        return CopyDeviceInfoResult(
+            copied = copied,
+            shouldShowFeedback = shouldShowFeedback
+        )
+    }
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/about/domain/model/CopyDeviceInfoResult.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/about/domain/model/CopyDeviceInfoResult.kt
@@ -1,0 +1,13 @@
+package com.d4rk.android.libs.apptoolkit.app.about.domain.model
+
+/**
+ * Result of a device info copy attempt.
+ *
+ * @param copied whether the clipboard operation succeeded.
+ * @param shouldShowFeedback true when legacy platforms require in-app confirmation because no system
+ * clipboard preview is available.
+ */
+data class CopyDeviceInfoResult(
+    val copied: Boolean,
+    val shouldShowFeedback: Boolean,
+)

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/about/domain/repository/AboutRepository.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/about/domain/repository/AboutRepository.kt
@@ -1,8 +1,9 @@
 package com.d4rk.android.libs.apptoolkit.app.about.domain.repository
 
 import com.d4rk.android.libs.apptoolkit.app.about.domain.model.AboutInfo
+import com.d4rk.android.libs.apptoolkit.app.about.domain.model.CopyDeviceInfoResult
 
 interface AboutRepository {
     suspend fun getAboutInfo(): AboutInfo
-    fun copyDeviceInfo(label: String, deviceInfo: String): Boolean
+    fun copyDeviceInfo(label: String, deviceInfo: String): CopyDeviceInfoResult
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/about/domain/usecases/CopyDeviceInfoUseCase.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/about/domain/usecases/CopyDeviceInfoUseCase.kt
@@ -1,5 +1,6 @@
 package com.d4rk.android.libs.apptoolkit.app.about.domain.usecases
 
+import com.d4rk.android.libs.apptoolkit.app.about.domain.model.CopyDeviceInfoResult
 import com.d4rk.android.libs.apptoolkit.app.about.domain.repository.AboutRepository
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Errors
@@ -8,9 +9,15 @@ import kotlinx.coroutines.flow.flow
 
 class CopyDeviceInfoUseCase(private val repository: AboutRepository) {
 
-    operator fun invoke(label: String, deviceInfo: String): Flow<DataState<Boolean, Errors>> =
+    operator fun invoke(
+        label: String,
+        deviceInfo: String,
+    ): Flow<DataState<CopyDeviceInfoResult, Errors>> =
         flow {
-            val copied = repository.copyDeviceInfo(label = label, deviceInfo = deviceInfo)
-            emit(DataState.Success(copied))
+            val result = repository.copyDeviceInfo(
+                label = label,
+                deviceInfo = deviceInfo
+            )
+            emit(DataState.Success(result))
         }
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/about/ui/AboutViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/about/ui/AboutViewModel.kt
@@ -125,26 +125,31 @@ open class AboutViewModel(
         }
 
         copyJob?.cancel()
-        copyJob = copyDeviceInfo(label = label, deviceInfo = deviceInfo)
+        copyJob = copyDeviceInfo(
+            label = label,
+            deviceInfo = deviceInfo,
+        )
             .flowOn(dispatchers.io)
             .onEach { result ->
                 result
-                    .onSuccess { copied ->
-                        val messageRes = if (copied) {
+                    .onSuccess { copyResult ->
+                        val messageRes = if (copyResult.copied) {
                             R.string.snack_device_info_copied
                         } else {
                             R.string.snack_device_info_failed
                         }
-                        screenState.showSnackbar(
-                            UiSnackbar(
-                                message = UiTextHelper.StringResource(
-                                    messageRes
-                                ),
-                                isError = !copied,
-                                timeStamp = System.nanoTime(),
-                                type = ScreenMessageType.SNACKBAR
+                        if (!copyResult.copied || copyResult.shouldShowFeedback) {
+                            screenState.showSnackbar(
+                                UiSnackbar(
+                                    message = UiTextHelper.StringResource(
+                                        messageRes
+                                    ),
+                                    isError = !copyResult.copied,
+                                    timeStamp = System.nanoTime(),
+                                    type = ScreenMessageType.SNACKBAR
+                                )
                             )
-                        )
+                        }
                     }
                     .onFailure { error ->
                         screenState.showSnackbar(


### PR DESCRIPTION
### Motivation

- Avoid duplicate success snackbars on modern Android by surfacing in-app feedback only when system previews are unavailable. 
- Make the copy flow consistent with other view models by returning structured results and using `onSuccess`/`onFailure` handlers. 
- Keep error handling in the ViewModel flows and avoid additional `try/catch` logic inside the ViewModel. 

### Description

- Add `CopyDeviceInfoResult` domain model to represent copy outcome and whether legacy in-app feedback is required. 
- Update `AboutRepository` and `AboutRepositoryImpl` to return `CopyDeviceInfoResult` and capture the `onCopyFallback` callback internally. 
- Change `CopyDeviceInfoUseCase` to emit `DataState<CopyDeviceInfoResult, Errors>` and update `AboutViewModel` to use `onSuccess`/`onFailure` and only show success snackbars when `shouldShowFeedback` is true or the copy failed. 
- Adjust unit tests `TestAboutRepositoryImpl` and `TestAboutViewModel` to cover both fallback and non-fallback copy flows. 

### Testing

- Updated unit tests `TestAboutRepositoryImpl` and `TestAboutViewModel` to assert `CopyDeviceInfoResult` behavior and the snackbar visibility logic. 
- Attempted to run `./gradlew :apptoolkit:testDebugUnitTest --tests com.d4rk.android.libs.apptoolkit.app.about.ui.TestAboutViewModel`, but the task failed because the Android SDK path is not configured in this environment. 
- No other automated test runs were executed due to the CI environment SDK constraint.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695a740d96b4832db980d44dc2821db9)