### PR TITLE
Move app install checks to IO dispatcher in list and favorites routes

### DIFF
--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsScreen.kt
@@ -45,6 +45,7 @@ import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.toImmutableSet
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.qualifier.named
@@ -113,7 +114,9 @@ fun FavoriteAppsRoute(
     LaunchedEffect(selectedApp?.packageName) {
         isSelectedAppInstalled = selectedApp?.let { app ->
             if (app.packageName.isNotEmpty()) {
-                context.isAppInstalled(app.packageName)
+                withContext(dispatchers.io) {
+                    context.isAppInstalled(app.packageName)
+                }
             } else {
                 false
             }

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListScreen.kt
@@ -38,6 +38,7 @@ import com.d4rk.android.libs.apptoolkit.core.utils.extensions.packagemanager.isA
 import kotlinx.collections.immutable.toImmutableSet
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.qualifier.named
@@ -114,7 +115,9 @@ fun AppsListRoute(
     LaunchedEffect(selectedApp?.packageName) {
         isSelectedAppInstalled = selectedApp?.let { app ->
             if (app.packageName.isNotEmpty()) {
-                context.isAppInstalled(app.packageName)
+                withContext(dispatchers.io) {
+                    context.isAppInstalled(app.packageName)
+                }
             } else {
                 false
             }


### PR DESCRIPTION
### Motivation
- Run package manager queries off the main thread to avoid UI jank when an app is selected for details.
- Keep the existing cancellation/restart semantics by keeping the `LaunchedEffect` keyed to `selectedApp?.packageName`.
- Preserve the nullable state handling for `isSelectedAppInstalled` so downstream UI logic is unchanged.
- Change rationale: previously the install check executed on the main dispatcher inside the `LaunchedEffect`, and now it runs on `dispatchers.io` to move IO-bound work off the UI thread.

### Description
- Added `withContext(dispatchers.io) { context.isAppInstalled(app.packageName) }` inside the existing `LaunchedEffect` in `AppsListScreen.kt` and `FavoriteAppsScreen.kt` to perform the check on the IO dispatcher.
- Imported `kotlinx.coroutines.withContext` in both files and left the `LaunchedEffect` key as `selectedApp?.packageName` so the suspend work is cancelled and restarted when the package changes.
- Only the execution context for `isAppInstalled` was changed; nullable state handling and selection logic remain intact.
- No public API surface or behavioral changes beyond shifting the package check to the IO dispatcher.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960d38ea8ec832dbca9aefba68de003)