### PR TITLE
Use rememberUpdatedState for random handler registration in AppsListRoute

### DIFF
--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListScreen.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
@@ -158,8 +159,10 @@ fun AppsListRoute(
     val randomAppHandler: RandomAppHandler =
         remember(viewModel) { { viewModel.onEvent(HomeEvent.OpenRandomApp) } }
 
+    val registerHandler by rememberUpdatedState(onRegisterRandomAppHandler)
+
     LaunchedEffect(canOpenRandomApp) {
-        onRegisterRandomAppHandler(if (canOpenRandomApp) randomAppHandler else null)
+        registerHandler(if (canOpenRandomApp) randomAppHandler else null)
     }
 
     LaunchedEffect(viewModel) {


### PR DESCRIPTION
### Motivation

- Keep `AppsListRoute` consistent with `FavoriteAppsRoute` by mirroring the handler-registration pattern.
- Prevent potential stale-callback issues when the parent recomposes and passes a new `onRegisterRandomAppHandler` lambda.

### Description

- Added an import for `rememberUpdatedState` and created `val registerHandler by rememberUpdatedState(onRegisterRandomAppHandler)` in `AppsListRoute`.
- Updated the `LaunchedEffect(canOpenRandomApp)` to call `registerHandler(if (canOpenRandomApp) randomAppHandler else null)` instead of invoking `onRegisterRandomAppHandler` directly.
- This change keeps the latest registration callback without restarting the effect when the parent lambda changes.

### Testing

- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960d3969c4c832d881dde0ea49eaf70)