### PR TITLE
Clarify loading responsibility in fetch apps use case

### DIFF
--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/usecases/FetchDeveloperAppsUseCase.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/usecases/FetchDeveloperAppsUseCase.kt
@@ -15,8 +15,8 @@ class FetchDeveloperAppsUseCase(
      * Returns developer apps.
      *
      * The repository flow is emitted untouched so upstream errors and cancellations keep their
-     * original semantics. The leading [DataState.Loading] allows screens to render a progress UI
-     * before the repository responds.
+     * original semantics. Loading UI should be driven by the ViewModel using `onStart` to keep
+     * presentation concerns out of the domain layer.
      */
     operator fun invoke(): Flow<DataState<List<AppInfo>, AppErrors>> = flow {
         emitAll(repository.fetchDeveloperApps())


### PR DESCRIPTION
### Motivation
- The KDoc implied the use case should emit a leading `DataState.Loading`, which can cause duplication when ViewModels already set loading via `onStart`.
- Loading is a presentation concern and should be handled by the UI layer, not the domain layer.
- The repository flow must remain unmodified so upstream errors and cancellations keep their original semantics.

### Description
- Updated the KDoc in `app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/usecases/FetchDeveloperAppsUseCase.kt` to remove the suggestion to emit a leading `DataState.Loading`.
- Documented that loading UI should be driven by the ViewModel using `onStart` to keep presentation concerns out of the domain layer.
- The `operator fun invoke()` implementation remains unchanged and continues to forward the repository flow via `emitAll(repository.fetchDeveloperApps())`.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960d2cf10b8832dbbd8f38340ef625a)