### PR TITLE
Inject DispatcherProvider into MainViewModel and run navigation flow on IO dispatcher

### DIFF
--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainViewModel.kt
@@ -10,6 +10,7 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Errors
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.onFailure
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.onSuccess
+import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
 import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
 import com.d4rk.android.libs.apptoolkit.core.ui.base.ScreenViewModel
 import com.d4rk.android.libs.apptoolkit.core.ui.model.navigation.NavigationDrawerItem
@@ -20,15 +21,20 @@ import com.d4rk.android.libs.apptoolkit.core.utils.extensions.errors.toError
 import com.d4rk.android.libs.apptoolkit.core.utils.platform.UiTextHelper
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.flow.catch
+import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlin.coroutines.cancellation.CancellationException
 
 
+/**
+ * ViewModel for the main screen that loads navigation drawer content.
+ */
 class MainViewModel(
     private val navigationRepository: NavigationRepository,
     private val firebaseController: FirebaseController,
+    private val dispatchers: DispatcherProvider,
 ) : ScreenViewModel<MainUiState, MainEvent, MainAction>(
     initialState = UiStateScreen(data = MainUiState())
 ) {
@@ -46,6 +52,7 @@ class MainViewModel(
     private fun loadNavigationItems() {
         viewModelScope.launch {
             navigationRepository.getNavigationDrawerItems()
+                .flowOn(dispatchers.io)
                 .map<List<NavigationDrawerItem>, DataState<List<NavigationDrawerItem>, Errors>> { items ->
                     if (items.isEmpty()) {
                         DataState.Error(error = Errors.UseCase.NO_DATA)

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/app/modules/AppModule.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/app/modules/AppModule.kt
@@ -14,7 +14,13 @@ import org.koin.dsl.module
 
 val appModule: Module = module {
     single<NavigationRepository> { MainRepositoryImpl(dispatchers = get()) }
-    viewModel { MainViewModel(navigationRepository = get(), firebaseController = get()) }
+    viewModel {
+        MainViewModel(
+            navigationRepository = get(),
+            firebaseController = get(),
+            dispatchers = get(),
+        )
+    }
 
     single<String>(qualifier = named(name = "developer_apps_api_url")) {
         val environment = BuildConfig.DEBUG.toApiEnvironment()

--- a/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainViewModelTest.kt
+++ b/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainViewModelTest.kt
@@ -2,8 +2,10 @@ package com.d4rk.android.apps.apptoolkit.app.main.ui
 
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.d4rk.android.apps.apptoolkit.app.core.utils.dispatchers.StandardDispatcherExtension
+import com.d4rk.android.apps.apptoolkit.app.core.utils.dispatchers.TestDispatchers
 import com.d4rk.android.apps.apptoolkit.app.main.ui.states.MainUiState
 import com.d4rk.android.libs.apptoolkit.app.main.domain.repository.NavigationRepository
+import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
 import com.d4rk.android.libs.apptoolkit.core.ui.model.navigation.NavigationDrawerItem
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.core.utils.platform.UiTextHelper
@@ -38,8 +40,13 @@ class MainViewModelTest {
     @Test
     fun `initialization triggers navigation load`() = runTest(dispatcherExtension.testDispatcher) {
         val repo = FakeNavigationRepository(flowOf(emptyList()))
+        val dispatchers = TestDispatchers(dispatcherExtension.testDispatcher)
 
-        MainViewModel(repo)
+        MainViewModel(
+            navigationRepository = repo,
+            firebaseController = FakeFirebaseController(),
+            dispatchers = dispatchers,
+        )
 
         runCurrent()
         advanceUntilIdle()
@@ -59,8 +66,13 @@ class MainViewModelTest {
                 )
             )
             val repo = FakeNavigationRepository(flowOf(expectedItems))
+            val dispatchers = TestDispatchers(dispatcherExtension.testDispatcher)
 
-            val viewModel = MainViewModel(repo)
+            val viewModel = MainViewModel(
+                navigationRepository = repo,
+                firebaseController = FakeFirebaseController(),
+                dispatchers = dispatchers,
+            )
 
             runCurrent()
             advanceUntilIdle()
@@ -79,8 +91,13 @@ class MainViewModelTest {
         val repo = FakeNavigationRepository(
             flow { throw error }
         )
+        val dispatchers = TestDispatchers(dispatcherExtension.testDispatcher)
 
-        val viewModel = MainViewModel(repo)
+        val viewModel = MainViewModel(
+            navigationRepository = repo,
+            firebaseController = FakeFirebaseController(),
+            dispatchers = dispatchers,
+        )
 
         runCurrent()
         advanceUntilIdle()
@@ -105,6 +122,28 @@ class MainViewModelTest {
             callCount++
             return upstream
         }
+    }
+
+    private class FakeFirebaseController : FirebaseController {
+        override fun updateConsent(
+            analyticsGranted: Boolean,
+            adStorageGranted: Boolean,
+            adUserDataGranted: Boolean,
+            adPersonalizationGranted: Boolean,
+        ) = Unit
+
+        override fun setAnalyticsEnabled(enabled: Boolean) = Unit
+
+        override fun setCrashlyticsEnabled(enabled: Boolean) = Unit
+
+        override fun setPerformanceEnabled(enabled: Boolean) = Unit
+
+        override fun reportViewModelError(
+            viewModelName: String,
+            action: String,
+            throwable: Throwable,
+            extraKeys: Map<String, String>,
+        ) = Unit
     }
 
     private fun createIcon(): ImageVector =


### PR DESCRIPTION
### Motivation
- Ensure the ViewModel owns dispatcher decisions as required by the architecture rules.
- Move upstream IO-bound work off the main thread by running the navigation flow on an IO dispatcher.
- Provide dispatchers via DI so production code uses `StandardDispatchers` and tests can supply `TestDispatchers`.

### Description
- Added a `DispatcherProvider` parameter to `MainViewModel` and applied `.flowOn(dispatchers.io)` before the `map` in `loadNavigationItems()`.
- Updated the app Koin module (`AppModule.kt`) to pass `dispatchers = get()` when creating `MainViewModel`.
- Updated `MainViewModelTest` to construct `MainViewModel` with `TestDispatchers` and a `FakeFirebaseController` to avoid touching real Firebase during tests.
- Added a short KDoc comment to `MainViewModel` describing its responsibility.

### Testing
- No automated test suite was executed during this rollout.
- Unit tests in `app/src/test/kotlin/.../MainViewModelTest.kt` were updated to work with the injected `DispatcherProvider` and the fake `FirebaseController` but were not run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6960d456303c832dbbfadefd72dd90c0)