### PR TITLE
Inject SDK provider into AboutRepositoryImpl to avoid static Build.VERSION mocking

### DIFF
--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/about/data/repository/AboutRepositoryImpl.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/about/data/repository/AboutRepositoryImpl.kt
@@ -11,10 +11,16 @@ import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoPr
 import com.d4rk.android.libs.apptoolkit.core.logging.CLIPBOARD_HELPER_LOG_TAG
 import com.d4rk.android.libs.apptoolkit.core.utils.extensions.context.copyTextToClipboard
 
+/**
+ * Provides About-related data and handles clipboard interactions for device info.
+ *
+ * @param sdkIntProvider Supplies the current SDK version for clipboard feedback decisions.
+ */
 class AboutRepositoryImpl(
     private val deviceProvider: AboutSettingsProvider,
     private val buildInfoProvider: BuildInfoProvider,
     private val context: Context,
+    private val sdkIntProvider: () -> Int = { Build.VERSION.SDK_INT },
 ) : AboutRepository {
 
     override suspend fun getAboutInfo(): AboutInfo =
@@ -25,7 +31,7 @@ class AboutRepositoryImpl(
         )
 
     override fun copyDeviceInfo(label: String, deviceInfo: String): CopyDeviceInfoResult {
-        val allowFeedback = Build.VERSION.SDK_INT <= Build.VERSION_CODES.S_V2
+        val allowFeedback = sdkIntProvider() <= Build.VERSION_CODES.S_V2
         var shouldShowFeedback = false
         val copied = runCatching {
             context.copyTextToClipboard(


### PR DESCRIPTION
### Motivation

- Fix a failing/flaky unit test that attempted to mock `Build.VERSION.SDK_INT` and caused MockK issues.  
- Make clipboard feedback logic in `AboutRepositoryImpl` testable without static mocking.  
- Improve test reliability and allow deterministic behavior in unit tests that depend on Android SDK level.  

### Description

- Add an injectable `sdkIntProvider: () -> Int` parameter to `AboutRepositoryImpl` with a default of `{ Build.VERSION.SDK_INT }`.  
- Replace direct `Build.VERSION.SDK_INT` usage with the injected `sdkIntProvider()` when computing `allowFeedback`.  
- Update the `TestAboutRepositoryImpl` unit test to supply a deterministic `sdkIntProvider` value and remove static `Build.VERSION` mocking.  
- Change rationale: previously the code used static `Build.VERSION` checks which required static mocking in tests and caused MockK failures, so injecting the provider preserves runtime behavior while avoiding brittle static mocks and improving test determinism.  

### Testing

- An attempt was made to run the specific unit test via Gradle (`:apptoolkit:testDebugUnitTest --tests "...TestAboutRepositoryImpl.copyDeviceInfo delegates to copyTextToClipboard"`), but the run failed because the Android SDK location was not configured in the environment (Gradle error about `local.properties`/`ANDROID_HOME`).  
- No automated unit tests were executed successfully in this environment after the change due to the missing SDK, so test pass/fail status could not be verified here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69612197c6d4832d9019433cec75c208)