### PR TITLE
Fix AboutRepositoryImpl unit test by mocking `Log.w` and ensuring static mock cleanup

### DIFF
--- a/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/app/about/data/repository/TestAboutRepositoryImpl.kt
+++ b/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/app/about/data/repository/TestAboutRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.d4rk.android.libs.apptoolkit.app.about.data.repository
 
 import android.content.ClipboardManager
 import android.content.Context
+import android.content.ClipData
 import android.os.Build
 import android.util.Log
 import com.d4rk.android.libs.apptoolkit.app.about.domain.model.AboutInfo
@@ -65,6 +66,9 @@ class TestAboutRepositoryImpl {
     fun `copyDeviceInfo delegates to copyTextToClipboard`() {
         mockkStatic(Log::class)
         every { Log.w(any(), any(), any()) } returns 0
+        mockkStatic(ClipData::class)
+        val clipData = mockk<ClipData>()
+        every { ClipData.newPlainText(any(), any()) } returns clipData
         val context = mockk<Context>()
         val clipboardManager = mockk<ClipboardManager>()
         every { context.getSystemService(ClipboardManager::class.java) } returns clipboardManager
@@ -80,6 +84,7 @@ class TestAboutRepositoryImpl {
                 "info"
             )
         } finally {
+            unmockkStatic(ClipData::class)
             unmockkStatic(Log::class)
         }
 

--- a/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/app/about/data/repository/TestAboutRepositoryImpl.kt
+++ b/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/app/about/data/repository/TestAboutRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.d4rk.android.libs.apptoolkit.app.about.data.repository
 import android.content.ClipboardManager
 import android.content.Context
 import android.os.Build
+import android.util.Log
 import com.d4rk.android.libs.apptoolkit.app.about.domain.model.AboutInfo
 import com.d4rk.android.libs.apptoolkit.app.about.domain.model.CopyDeviceInfoResult
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.AboutSettingsProvider
@@ -12,6 +13,8 @@ import com.google.common.truth.Truth.assertThat
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
+import io.mockk.mockkStatic
+import io.mockk.unmockkStatic
 import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
@@ -58,16 +61,10 @@ class TestAboutRepositoryImpl {
         assertThat(result.deviceInfo).isEqualTo(deviceProvider.deviceInfo)
     }
 
-    /*
-    FIXME:
-    Method w in android.util.Log not mocked. See https://developer.android.com/r/studio-ui/build/not-mocked for details.
-    java.lang.RuntimeException: Method w in android.util.Log not mocked. See https://developer.android.com/r/studio-ui/build/not-mocked for details.
-        at android.util.Log.w(Log.java)
-        at com.d4rk.android.libs.apptoolkit.app.about.data.repository.AboutRepositoryImpl.copyDeviceInfo(AboutRepositoryImpl.kt:47)
-        at com.d4rk.android.libs.apptoolkit.app.about.data.repository.TestAboutRepositoryImpl.copyDeviceInfo delegates to copyTextToClipboard(TestAboutRepositoryImpl.kt:72)
-   */
     @Test
     fun `copyDeviceInfo delegates to copyTextToClipboard`() {
+        mockkStatic(Log::class)
+        every { Log.w(any(), any(), any()) } returns 0
         val context = mockk<Context>()
         val clipboardManager = mockk<ClipboardManager>()
         every { context.getSystemService(ClipboardManager::class.java) } returns clipboardManager
@@ -77,10 +74,14 @@ class TestAboutRepositoryImpl {
             sdkIntProvider = { Build.VERSION_CODES.S_V2 },
         )
 
-        val copyResult = repo.copyDeviceInfo(
-            "label",
-            "info"
-        ) // FIXME: Method w in android.util.Log not mocked. See https://developer.android.com/r/studio-ui/build/not-mocked for details.
+        val copyResult = try {
+            repo.copyDeviceInfo(
+                "label",
+                "info"
+            )
+        } finally {
+            unmockkStatic(Log::class)
+        }
 
         verify { clipboardManager.setPrimaryClip(any()) }
         assertThat(copyResult).isEqualTo(


### PR DESCRIPTION
### Motivation
- The `copyDeviceInfo` unit test crashed on the JVM because `android.util.Log.w` is not available in local unit tests and threw a runtime exception. 
- The test should be able to exercise clipboard behavior and assert `CopyDeviceInfoResult` without Android logging interfering. 
- Keep the fix isolated to test code so production behavior in `AboutRepositoryImpl` remains unchanged.

### Description
- In `TestAboutRepositoryImpl` add `mockkStatic(Log::class)` and stub `Log.w` with `every { Log.w(any(), any(), any()) } returns 0` to prevent the JVM logging exception. 
- Wrap the call to `repo.copyDeviceInfo(...)` in a `try`/`finally` and call `unmockkStatic(Log::class)` in `finally` to ensure static mock cleanup. 
- Removed the in-test `FIXME` condition by addressing the root cause rather than altering production code.

### Testing
- No automated tests were executed as part of this PR. 
- The change is limited to test code and is intended to allow the existing unit test to run on the JVM without crashing due to Android logging.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6961ea00feb4832da924db44485682f3)