### PR TITLE
Unify activities on BaseActivity for shared Compose setup

### DIFF
--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainActivity.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainActivity.kt
@@ -1,19 +1,17 @@
 package com.d4rk.android.apps.apptoolkit.app.main.ui
 
 import android.os.Bundle
-import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.IntentSenderRequest
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.runtime.Composable
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.lifecycle.lifecycleScope
 import com.d4rk.android.apps.apptoolkit.core.data.local.DataStore
 import com.d4rk.android.libs.apptoolkit.app.main.utils.InAppUpdateHelper
 import com.d4rk.android.libs.apptoolkit.app.startup.ui.StartupActivity
-import com.d4rk.android.libs.apptoolkit.app.theme.ui.style.AppTheme
 import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
+import com.d4rk.android.libs.apptoolkit.core.ui.base.BaseActivity
 import com.d4rk.android.libs.apptoolkit.core.utils.extensions.context.openActivity
 import com.d4rk.android.libs.apptoolkit.core.utils.platform.ConsentFormHelper
 import com.d4rk.android.libs.apptoolkit.core.utils.platform.ConsentManagerHelper
@@ -31,7 +29,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.koin.android.ext.android.inject
 
-class MainActivity : AppCompatActivity() {
+class MainActivity : BaseActivity() {
 
     private val dataStore: DataStore by inject()
     private val dispatchers: DispatcherProvider by inject()
@@ -39,11 +37,12 @@ class MainActivity : AppCompatActivity() {
         registerForActivityResult(contract = ActivityResultContracts.StartIntentSenderForResult()) {}
     private var keepSplashVisible: Boolean = true
 
+    override fun shouldSetContentOnCreate(): Boolean = false
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         val splashScreen = installSplashScreen()
         splashScreen.setKeepOnScreenCondition { keepSplashVisible }
-        enableEdgeToEdge()
         initializeDependencies()
         handleStartup()
         checkInAppReview()
@@ -88,11 +87,12 @@ class MainActivity : AppCompatActivity() {
     }
 
     private fun setMainActivityContent() {
-        setContent {
-            AppTheme {
-                MainScreen()
-            }
-        }
+        setComposeContent()
+    }
+
+    @Composable
+    override fun ScreenContent() {
+        MainScreen()
     }
 
     private fun checkUserConsent() {

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/ads/ui/AdsSettingsActivity.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/ads/ui/AdsSettingsActivity.kt
@@ -1,10 +1,7 @@
 package com.d4rk.android.libs.apptoolkit.app.ads.ui
 
-import android.os.Bundle
-import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
-import com.d4rk.android.libs.apptoolkit.app.theme.ui.style.AppTheme
+import androidx.compose.runtime.Composable
+import com.d4rk.android.libs.apptoolkit.core.ui.base.BaseActivity
 
 /**
  * An activity that displays advertisement-related settings to the user.
@@ -12,15 +9,10 @@ import com.d4rk.android.libs.apptoolkit.app.theme.ui.style.AppTheme
  * This activity hosts the [AdsSettingsScreen] composable, which provides the user interface
  * for managing ad preferences, such as consenting to personalized ads or disabling them.
  */
-class AdsSettingsActivity : AppCompatActivity() {
+class AdsSettingsActivity : BaseActivity() {
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
-        setContent {
-            AppTheme {
-                AdsSettingsScreen()
-            }
-        }
+    @Composable
+    override fun ScreenContent() {
+        AdsSettingsScreen()
     }
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpActivity.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpActivity.kt
@@ -1,23 +1,15 @@
 package com.d4rk.android.libs.apptoolkit.app.help.ui
 
-import android.os.Bundle
-import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
-import com.d4rk.android.libs.apptoolkit.app.theme.ui.style.AppTheme
+import androidx.compose.runtime.Composable
+import com.d4rk.android.libs.apptoolkit.core.ui.base.BaseActivity
 import com.d4rk.android.libs.apptoolkit.core.ui.model.AppVersionInfo
 import org.koin.android.ext.android.inject
 
-class HelpActivity : AppCompatActivity() {
+class HelpActivity : BaseActivity() {
     private val config: AppVersionInfo by inject()
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
-        setContent {
-            AppTheme {
-                HelpScreen(config = config)
-            }
-        }
+    @Composable
+    override fun ScreenContent() {
+        HelpScreen(config = config)
     }
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/IssueReporterActivity.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/IssueReporterActivity.kt
@@ -1,24 +1,16 @@
 package com.d4rk.android.libs.apptoolkit.app.issuereporter.ui
 
-import android.os.Bundle
-import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
-import com.d4rk.android.libs.apptoolkit.app.theme.ui.style.AppTheme
+import androidx.compose.runtime.Composable
+import com.d4rk.android.libs.apptoolkit.core.ui.base.BaseActivity
 
-class IssueReporterActivity : AppCompatActivity() {
+class IssueReporterActivity : BaseActivity() {
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
-        setContent {
-            AppTheme {
-                IssueReporterScreen(
-                    onBackClicked = {
-                        this.finish()
-                    }
-                )
+    @Composable
+    override fun ScreenContent() {
+        IssueReporterScreen(
+            onBackClicked = {
+                this.finish()
             }
-        }
+        )
     }
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/licenses/ui/LicensesActivity.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/licenses/ui/LicensesActivity.kt
@@ -1,23 +1,15 @@
 package com.d4rk.android.libs.apptoolkit.app.licenses.ui
 
-import android.os.Bundle
-import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
-import com.d4rk.android.libs.apptoolkit.app.theme.ui.style.AppTheme
+import androidx.compose.runtime.Composable
+import com.d4rk.android.libs.apptoolkit.core.ui.base.BaseActivity
 
-class LicensesActivity : AppCompatActivity() {
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
-        setContent {
-            AppTheme {
-                LicensesScreen(
-                    onBackClicked = {
-                        this.finish()
-                    }
-                )
+class LicensesActivity : BaseActivity() {
+    @Composable
+    override fun ScreenContent() {
+        LicensesScreen(
+            onBackClicked = {
+                this.finish()
             }
-        }
+        )
     }
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/permissions/ui/PermissionsActivity.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/permissions/ui/PermissionsActivity.kt
@@ -1,23 +1,13 @@
 package com.d4rk.android.libs.apptoolkit.app.permissions.ui
 
-import android.os.Bundle
-import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
-import com.d4rk.android.libs.apptoolkit.app.theme.ui.style.AppTheme
+import androidx.compose.runtime.Composable
+import com.d4rk.android.libs.apptoolkit.core.ui.base.BaseActivity
 
 /** Hosts the permissions screen. */
-class PermissionsActivity : AppCompatActivity() {
+class PermissionsActivity : BaseActivity() {
 
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
-
-        setContent {
-            AppTheme {
-                PermissionsScreen()
-            }
-        }
+    @Composable
+    override fun ScreenContent() {
+        PermissionsScreen()
     }
 }
-

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/GeneralSettingsActivity.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/GeneralSettingsActivity.kt
@@ -4,17 +4,18 @@ import android.content.Context
 import android.content.Intent
 import android.os.Bundle
 import android.util.Log
-import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
+import androidx.compose.runtime.Composable
 import androidx.lifecycle.lifecycleScope
-import com.d4rk.android.libs.apptoolkit.app.theme.ui.style.AppTheme
+import com.d4rk.android.libs.apptoolkit.core.ui.base.BaseActivity
 import com.d4rk.android.libs.apptoolkit.core.logging.GENERAL_SETTINGS_LOG_TAG
 import com.d4rk.android.libs.apptoolkit.core.utils.extensions.context.startActivitySafely
 import com.d4rk.android.libs.apptoolkit.data.local.datastore.CommonDataStore
 import kotlinx.coroutines.launch
 
-class GeneralSettingsActivity : AppCompatActivity() {
+class GeneralSettingsActivity : BaseActivity() {
+
+    private var title: String = ""
+    private var contentKey: String? = null
 
     companion object {
         private const val EXTRA_TITLE: String = "extra_title"
@@ -43,21 +44,23 @@ class GeneralSettingsActivity : AppCompatActivity() {
         }
     }
 
+    override fun shouldSetContentOnCreate(): Boolean = false
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
         lifecycleScope.launch {
             CommonDataStore.getInstance(applicationContext).markSettingsInteracted()
         }
 
-        val title: String = intent.getStringExtra(EXTRA_TITLE)
+        title = intent.getStringExtra(EXTRA_TITLE)
             ?: getString(com.d4rk.android.libs.apptoolkit.R.string.settings)
-        val contentKey: String? = intent.getStringExtra(EXTRA_CONTENT)
+        contentKey = intent.getStringExtra(EXTRA_CONTENT)
 
-        setContent {
-            AppTheme {
-                GeneralSettingsScreen(title = title, contentKey = contentKey) { finish() }
-            }
-        }
+        setComposeContent()
+    }
+
+    @Composable
+    override fun ScreenContent() {
+        GeneralSettingsScreen(title = title, contentKey = contentKey) { finish() }
     }
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsActivity.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsActivity.kt
@@ -1,20 +1,11 @@
 package com.d4rk.android.libs.apptoolkit.app.settings.settings.ui
 
-import android.os.Bundle
-import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
-import com.d4rk.android.libs.apptoolkit.app.theme.ui.style.AppTheme
+import androidx.compose.runtime.Composable
+import com.d4rk.android.libs.apptoolkit.core.ui.base.BaseActivity
 
-class SettingsActivity : AppCompatActivity() {
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
-
-        setContent {
-            AppTheme {
-                SettingsScreen()
-            }
-        }
+class SettingsActivity : BaseActivity() {
+    @Composable
+    override fun ScreenContent() {
+        SettingsScreen()
     }
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupActivity.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupActivity.kt
@@ -2,12 +2,10 @@ package com.d4rk.android.libs.apptoolkit.app.startup.ui
 
 import android.os.Bundle
 import android.util.Log
-import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
-import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.Composable
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
@@ -15,8 +13,8 @@ import androidx.lifecycle.repeatOnLifecycle
 import com.d4rk.android.libs.apptoolkit.app.startup.ui.contract.StartupAction
 import com.d4rk.android.libs.apptoolkit.app.startup.ui.contract.StartupEvent
 import com.d4rk.android.libs.apptoolkit.app.startup.utils.interfaces.providers.StartupProvider
-import com.d4rk.android.libs.apptoolkit.app.theme.ui.style.AppTheme
 import com.d4rk.android.libs.apptoolkit.core.logging.STARTUP_LOG_TAG
+import com.d4rk.android.libs.apptoolkit.core.ui.base.BaseActivity
 import com.d4rk.android.libs.apptoolkit.core.utils.extensions.context.openActivity
 import com.d4rk.android.libs.apptoolkit.core.utils.platform.ConsentFormHelper
 import com.google.android.ump.ConsentInformation
@@ -27,7 +25,7 @@ import kotlinx.coroutines.launch
 import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
-class StartupActivity : AppCompatActivity() {
+class StartupActivity : BaseActivity() {
     private val provider: StartupProvider by inject()
     private val viewModel: StartupViewModel by viewModel()
     private val permissionLauncher: ActivityResultLauncher<Array<String>> =
@@ -35,7 +33,6 @@ class StartupActivity : AppCompatActivity() {
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
 
         lifecycleScope.launch {
             repeatOnLifecycle(Lifecycle.State.STARTED) {
@@ -65,16 +62,15 @@ class StartupActivity : AppCompatActivity() {
                 checkUserConsent()
             }
         }
+    }
 
-        setContent {
-            AppTheme {
-                val screenState by viewModel.uiState.collectAsStateWithLifecycle()
-                StartupScreen(
-                    screenState = screenState,
-                    onContinueClick = { viewModel.onEvent(StartupEvent.Continue) }
-                )
-            }
-        }
+    @Composable
+    override fun ScreenContent() {
+        val screenState by viewModel.uiState.collectAsStateWithLifecycle()
+        StartupScreen(
+            screenState = screenState,
+            onContinueClick = { viewModel.onEvent(StartupEvent.Continue) }
+        )
     }
 
     private fun navigateToNext() {

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportActivity.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportActivity.kt
@@ -1,19 +1,11 @@
 package com.d4rk.android.libs.apptoolkit.app.support.ui
 
-import android.os.Bundle
-import androidx.activity.compose.setContent
-import androidx.activity.enableEdgeToEdge
-import androidx.appcompat.app.AppCompatActivity
-import com.d4rk.android.libs.apptoolkit.app.theme.ui.style.AppTheme
+import androidx.compose.runtime.Composable
+import com.d4rk.android.libs.apptoolkit.core.ui.base.BaseActivity
 
-class SupportActivity : AppCompatActivity() {
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        enableEdgeToEdge()
-        setContent {
-            AppTheme {
-                SupportComposable()
-            }
-        }
+class SupportActivity : BaseActivity() {
+    @Composable
+    override fun ScreenContent() {
+        SupportComposable()
     }
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/base/BaseActivity.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/base/BaseActivity.kt
@@ -8,10 +8,9 @@ import androidx.compose.runtime.Composable
 import com.d4rk.android.libs.apptoolkit.app.theme.ui.style.AppTheme
 
 /**
- * Activity that provides common Compose setup for cleanup screens.
+ * Activity that provides shared Compose setup for screens.
  */
-abstract class BaseActivity :
-    AppCompatActivity() { // TODO: Make the other screens rely on this activity
+abstract class BaseActivity : AppCompatActivity() {
 
     /**
      * Compose content to be rendered by this activity.
@@ -19,13 +18,27 @@ abstract class BaseActivity :
     @Composable
     protected abstract fun ScreenContent()
 
+    /**
+     * Controls whether this activity should set its Compose content during [onCreate].
+     */
+    protected open fun shouldSetContentOnCreate(): Boolean = true
+
+    /**
+     * Sets the activity content using the shared [AppTheme] wrapper.
+     */
+    protected fun setComposeContent(content: @Composable () -> Unit = { ScreenContent() }) {
+        setContent {
+            AppTheme {
+                content()
+            }
+        }
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         enableEdgeToEdge()
-        setContent {
-            AppTheme {
-                ScreenContent()
-            }
+        if (shouldSetContentOnCreate()) {
+            setComposeContent()
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Reduce boilerplate and ensure consistent edge-to-edge + Material 3 theming by centralizing Compose setup into a single base activity. 
- Provide a mechanism to defer setting Compose content for activities that need pre-content initialization (splash, intent parsing). 
- Change rationale: previously each Activity called `enableEdgeToEdge()` and `setContent { AppTheme { ... } }` individually which duplicated imports and setup and risked inconsistencies; centralizing this in `BaseActivity` reduces duplication and enforces uniform behavior.

### Description
- Expanded `BaseActivity` to call `enableEdgeToEdge()`, wrap content with `AppTheme`, and expose `shouldSetContentOnCreate()` and `setComposeContent()` to allow opt-out or deferred content rendering. 
- Migrated multiple activities to extend `BaseActivity` and implement the `@Composable fun ScreenContent()` contract (including `MainActivity`, `StartupActivity`, `GeneralSettingsActivity`, `SettingsActivity`, `PermissionsActivity`, `SupportActivity`, `LicensesActivity`, `IssueReporterActivity`, `HelpActivity`, `AdsSettingsActivity`). 
- Implemented opt-out/deferred flows: `MainActivity` overrides `shouldSetContentOnCreate()` to delay content until splash startup logic finishes and calls `setComposeContent()` when ready, and `GeneralSettingsActivity` defers content until intent extras are read and state is prepared. 
- Removed duplicated `enableEdgeToEdge()` / `setContent { AppTheme { ... } }` occurrences from the migrated activities and reduced redundant imports.

### Testing
- No automated tests were executed as part of this change.
- Basic local edits were compiled in the working workspace (no full CI/build run reported).
- Recommend running a full project build (`./gradlew assemble`) and unit/instrumented tests after merging to validate integration across modules.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696f9da0a938832d97eeb3e28dee5df6)