### PR TITLE
Refactor buttons: add ButtonFeedback and introduce `General*` button variants

### DIFF
--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/AppDetailsBottomSheet.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/AppDetailsBottomSheet.kt
@@ -44,7 +44,7 @@ import com.d4rk.android.apps.apptoolkit.R
 import com.d4rk.android.apps.apptoolkit.app.apps.list.domain.model.AppInfo
 import com.d4rk.android.libs.apptoolkit.core.ui.model.ads.AdsConfig
 import com.d4rk.android.libs.apptoolkit.core.ui.views.ads.AppDetailsNativeAd
-import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.OutlinedIconButtonWithText
+import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.GeneralOutlinedButton
 import com.d4rk.android.libs.apptoolkit.core.ui.views.modifiers.bounceClick
 import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.ExtraSmallVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.LargeVerticalSpacer
@@ -111,7 +111,7 @@ fun AppDetailsBottomSheet(
         ) {
             when (isAppInstalled) {
                 true -> {
-                    OutlinedIconButtonWithText(
+                    GeneralOutlinedButton(
                         onClick = onOpenAppClick,
                         icon = Icons.AutoMirrored.Outlined.OpenInNew,
                         label = stringResource(id = R.string.app_details_open_app)
@@ -216,12 +216,12 @@ fun AppDetailsBottomSheet(
             ),
             verticalAlignment = Alignment.CenterVertically
         ) {
-            OutlinedIconButtonWithText(
+            GeneralOutlinedButton(
                 onClick = onShareClick,
                 icon = Icons.Outlined.Share,
                 label = stringResource(id = R.string.app_details_share_content_description)
             )
-            OutlinedIconButtonWithText(
+            GeneralOutlinedButton(
                 onClick = onFavoriteClick,
                 icon = if (isFavorite) Icons.Filled.Star else Icons.Outlined.StarOutline,
                 label = stringResource(id = R.string.favorite_apps)

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/IssueReporterScreen.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/IssueReporterScreen.kt
@@ -64,7 +64,7 @@ import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.github.Gi
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.ui.contract.IssueReporterEvent
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.ui.state.IssueReporterUiState
 import com.d4rk.android.libs.apptoolkit.core.ui.state.UiStateScreen
-import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.OutlinedIconButtonWithText
+import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.GeneralOutlinedButton
 import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.fab.AnimatedExtendedFloatingActionButton
 import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.fab.SmallFloatingActionButton
 import com.d4rk.android.libs.apptoolkit.core.ui.views.layouts.LoadingScreen
@@ -228,7 +228,7 @@ fun IssueReporterScreenContent(
                             verticalAlignment = Alignment.CenterVertically,
                             horizontalArrangement = Arrangement.End
                         ) {
-                            OutlinedIconButtonWithText(
+                            GeneralOutlinedButton(
                                 onClick = { data.issueUrl.let(uriHandler::openUri) },
                                 icon = Icons.AutoMirrored.Outlined.OpenInNew,
                                 iconContentDescription = stringResource(R.string.open_issue_in_browser),

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/main/ui/views/navigation/MainTopAppBar.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/main/ui/views/navigation/MainTopAppBar.kt
@@ -19,6 +19,7 @@ import androidx.compose.ui.res.stringResource
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.support.ui.SupportActivity
 import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.AnimatedIconButtonDirection
+import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.ButtonFeedback
 import com.d4rk.android.libs.apptoolkit.core.ui.views.dropdown.CommonDropdownMenuItem
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.core.utils.extensions.context.openActivity
@@ -51,7 +52,7 @@ fun MainTopAppBar(
                 icon = navigationIcon,
                 contentDescription = stringResource(id = R.string.go_back),
                 onClick = onNavigationIconClick,
-                vibrate = false
+                feedback = ButtonFeedback(hapticFeedbackType = null)
             )
         },
         actions = {

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingScreen.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingScreen.kt
@@ -34,7 +34,7 @@ import com.d4rk.android.libs.apptoolkit.app.onboarding.ui.state.OnboardingUiStat
 import com.d4rk.android.libs.apptoolkit.app.onboarding.ui.views.OnboardingBottomNavigation
 import com.d4rk.android.libs.apptoolkit.app.onboarding.ui.views.pages.OnboardingDefaultPageLayout
 import com.d4rk.android.libs.apptoolkit.app.onboarding.utils.interfaces.providers.OnboardingProvider
-import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.OutlinedIconButtonWithText
+import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.GeneralOutlinedButton
 import com.d4rk.android.libs.apptoolkit.core.ui.views.modifiers.hapticPagerSwipe
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
@@ -82,7 +82,7 @@ fun OnboardingScreen() {
                         enter = slideInHorizontally(initialOffsetX = { fullWidth -> fullWidth }) + fadeIn(),
                         exit = slideOutHorizontally(targetOffsetX = { fullWidth -> fullWidth }) + fadeOut()
                     ) {
-                        OutlinedIconButtonWithText(
+                        GeneralOutlinedButton(
                             onClick = { onSkipRequested() },
                             icon = Icons.Filled.SkipNext,
                             iconContentDescription = stringResource(id = R.string.skip_button_content_description),

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/views/OnboardingBottomNavigation.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/views/OnboardingBottomNavigation.kt
@@ -26,8 +26,8 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import com.d4rk.android.libs.apptoolkit.R
-import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.IconButtonWithText
-import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.OutlinedIconButtonWithText
+import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.GeneralButton
+import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.GeneralOutlinedButton
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 
 @OptIn(
@@ -66,7 +66,7 @@ fun OnboardingBottomNavigation(
             ) + fadeOut(animationSpec = spring(stiffness = Spring.StiffnessLow))
         ) {
             Box(contentAlignment = Alignment.CenterStart) {
-                OutlinedIconButtonWithText(
+                GeneralOutlinedButton(
                     onClick = onBackClicked,
                     icon = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
                     iconContentDescription = stringResource(id = R.string.back_button_content_description),
@@ -88,7 +88,7 @@ fun OnboardingBottomNavigation(
             contentAlignment = Alignment.CenterEnd
         ) {
             val isLastPage = pagerState.currentPage == pageCount - 1
-            IconButtonWithText(
+            GeneralButton(
                 onClick = onNextClicked,
                 modifier = Modifier.animateContentSize(),
                 icon = if (isLastPage) Icons.Filled.Check else Icons.AutoMirrored.Filled.KeyboardArrowRight,

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/views/pages/CrashlyticsOnboardingPageTab.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/views/pages/CrashlyticsOnboardingPageTab.kt
@@ -63,7 +63,7 @@ import com.d4rk.android.libs.apptoolkit.app.diagnostics.ui.state.UsageAndDiagnos
 import com.d4rk.android.libs.apptoolkit.app.onboarding.ui.OnboardingViewModel
 import com.d4rk.android.libs.apptoolkit.app.onboarding.ui.contract.OnboardingEvent
 import com.d4rk.android.libs.apptoolkit.app.onboarding.ui.state.OnboardingUiState
-import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.OutlinedIconButtonWithText
+import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.GeneralOutlinedButton
 import com.d4rk.android.libs.apptoolkit.core.ui.views.modifiers.bounceClick
 import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.ExtraLargeIncreasedVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.ExtraLargeVerticalSpacer
@@ -140,7 +140,7 @@ fun CrashlyticsOnboardingPageTab() {
 
             LargeVerticalSpacer()
 
-            OutlinedIconButtonWithText(
+            GeneralOutlinedButton(
                 onClick = {
                     onboardingViewModel.onEvent(OnboardingEvent.ShowCrashlyticsDialog)
                 },
@@ -279,7 +279,7 @@ fun LearnMoreSection() {
 
         MediumVerticalSpacer()
 
-        OutlinedIconButtonWithText(
+        GeneralOutlinedButton(
             onClick = {
                 val opened = context.startActivitySafely(
                     intent = Intent(Intent.ACTION_VIEW, AppLinks.PRIVACY_POLICY.toUri()),
@@ -385,7 +385,7 @@ fun CrashlyticsConsentDialog(
             }
         },
         confirmButton = {
-            OutlinedIconButtonWithText(
+            GeneralOutlinedButton(
                 onClick = {
                     val overallConsent: Boolean =
                         state.analyticsConsent && state.adStorageConsent && state.adUserDataConsent && state.adPersonalizationConsent

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsScreen.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsScreen.kt
@@ -49,7 +49,7 @@ import com.d4rk.android.libs.apptoolkit.app.settings.settings.domain.model.Setti
 import com.d4rk.android.libs.apptoolkit.app.settings.settings.ui.contract.SettingsEvent
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.GeneralSettingsContentProvider
 import com.d4rk.android.libs.apptoolkit.core.ui.state.UiStateScreen
-import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.OutlinedIconButtonWithText
+import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.GeneralOutlinedButton
 import com.d4rk.android.libs.apptoolkit.core.ui.views.layouts.LoadingScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.views.layouts.NoDataScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.views.layouts.ScreenStateHandler
@@ -207,7 +207,7 @@ fun SettingsDetailPlaceholder(paddingValues: PaddingValues) {
                         textAlign = TextAlign.Center,
                     )
                 }
-                OutlinedIconButtonWithText(
+                GeneralOutlinedButton(
                     modifier = Modifier
                         .padding(all = SizeConstants.MediumSize * 2)
                         .align(alignment = Alignment.Start),

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportScreen.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportScreen.kt
@@ -36,7 +36,7 @@ import com.d4rk.android.libs.apptoolkit.app.support.utils.extensions.primaryForm
 import com.d4rk.android.libs.apptoolkit.core.ui.model.ads.AdsConfig
 import com.d4rk.android.libs.apptoolkit.core.ui.state.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.views.ads.SupportNativeAdCard
-import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.TonalIconButtonWithText
+import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.GeneralTonalButton
 import com.d4rk.android.libs.apptoolkit.core.ui.views.layouts.LoadingScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.views.layouts.NoDataScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.views.layouts.ScreenStateHandler
@@ -151,7 +151,7 @@ fun SupportScreenContent(
                         horizontalArrangement = Arrangement.SpaceEvenly
                     ) {
                         item {
-                            TonalIconButtonWithText(
+                            GeneralTonalButton(
                                 modifier = Modifier.fillMaxWidth(),
                                 onClick = {
                                     onDonateClick(DonationProductIds.LOW_DONATION)
@@ -161,7 +161,7 @@ fun SupportScreenContent(
                             )
                         }
                         item {
-                            TonalIconButtonWithText(
+                            GeneralTonalButton(
                                 modifier = Modifier.fillMaxWidth(),
                                 onClick = {
                                     onDonateClick(DonationProductIds.NORMAL_DONATION)
@@ -178,7 +178,7 @@ fun SupportScreenContent(
                         horizontalArrangement = Arrangement.SpaceEvenly
                     ) {
                         item {
-                            TonalIconButtonWithText(
+                            GeneralTonalButton(
                                 modifier = Modifier.fillMaxWidth(),
                                 onClick = {
                                     onDonateClick(DonationProductIds.HIGH_DONATION)
@@ -188,7 +188,7 @@ fun SupportScreenContent(
                             )
                         }
                         item {
-                            TonalIconButtonWithText(
+                            GeneralTonalButton(
                                 modifier = Modifier.fillMaxWidth(),
                                 onClick = {
                                     onDonateClick(DonationProductIds.EXTREME_DONATION)
@@ -209,7 +209,7 @@ fun SupportScreenContent(
             )
         }
         item {
-            TonalIconButtonWithText(
+            GeneralTonalButton(
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(all = SizeConstants.LargeSize),

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/buttons/AnimatedIconButtonDirection.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/buttons/AnimatedIconButtonDirection.kt
@@ -1,6 +1,5 @@
 package com.d4rk.android.libs.apptoolkit.core.ui.views.buttons
 
-import android.view.SoundEffectConstants
 import android.view.View
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.core.tween
@@ -20,7 +19,6 @@ import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.hapticfeedback.HapticFeedback
-import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalView
 import com.d4rk.android.libs.apptoolkit.core.ui.views.modifiers.bounceClick
@@ -39,6 +37,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.views.modifiers.bounceClick
  * @param durationMillis The duration of the animation in milliseconds. Defaults to 500ms.
  * @param autoAnimate If true, the button will automatically animate in when `visible` is true.
  *                    If false, the animation will not be triggered automatically and will only occur when the visibility state changes. Defaults to true.
+ * @param feedback The feedback configuration for sound and haptics.
  * @param fromRight If true, the button will slide in from the right and slide out to the right.
  *                  If false, the button will slide in from the left and slide out to the left. Defaults to false.
  *
@@ -59,7 +58,7 @@ fun AnimatedIconButtonDirection(
     onClick: () -> Unit,
     durationMillis: Int = 500,
     autoAnimate: Boolean = true,
-    vibrate: Boolean = true,
+    feedback: ButtonFeedback = ButtonFeedback(),
     fromRight: Boolean = false
 ) {
     val animatedVisibility: MutableState<Boolean> =
@@ -88,10 +87,7 @@ fun AnimatedIconButtonDirection(
         )
     ) {
         IconButton(modifier = modifier.bounceClick(), onClick = {
-            view.playSoundEffect(SoundEffectConstants.CLICK)
-            if (vibrate) {
-                hapticFeedback.performHapticFeedback(hapticFeedbackType = HapticFeedbackType.ContextClick)
-            }
+            feedback.performClick(view = view, hapticFeedback = hapticFeedback)
             onClick()
         }, shapes = IconButtonDefaults.shapes()) {
             Icon(imageVector = icon, contentDescription = contentDescription)

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/buttons/ButtonFeedback.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/buttons/ButtonFeedback.kt
@@ -1,0 +1,25 @@
+package com.d4rk.android.libs.apptoolkit.core.ui.views.buttons
+
+import android.view.SoundEffectConstants
+import android.view.View
+import androidx.compose.ui.hapticfeedback.HapticFeedback
+import androidx.compose.ui.hapticfeedback.HapticFeedbackType
+
+/**
+ * Configures feedback behavior for button interactions.
+ *
+ * @param soundEffect The Android sound effect to play, or `null` to disable sound.
+ * @param hapticFeedbackType The haptic feedback type to perform, or `null` to disable haptics.
+ */
+data class ButtonFeedback(
+    val soundEffect: Int? = SoundEffectConstants.CLICK,
+    val hapticFeedbackType: HapticFeedbackType? = HapticFeedbackType.ContextClick,
+) {
+    /**
+     * Performs the configured feedback using the provided [View] and [HapticFeedback].
+     */
+    fun performClick(view: View, hapticFeedback: HapticFeedback) {
+        soundEffect?.let(view::playSoundEffect)
+        hapticFeedbackType?.let(hapticFeedback::performHapticFeedback)
+    }
+}

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/buttons/fab/AnimatedExtendedFloatingActionButton.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/buttons/fab/AnimatedExtendedFloatingActionButton.kt
@@ -1,6 +1,5 @@
 package com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.fab
 
-import android.view.SoundEffectConstants
 import android.view.View
 import androidx.compose.animation.core.FastOutSlowInEasing
 import androidx.compose.animation.core.animateFloatAsState
@@ -14,9 +13,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.TransformOrigin
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.hapticfeedback.HapticFeedback
-import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalView
+import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.ButtonFeedback
 import com.d4rk.android.libs.apptoolkit.core.ui.views.modifiers.bounceClick
 
 /**
@@ -28,6 +27,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.views.modifiers.bounceClick
  * @param text Optional text to display alongside the icon in the button.
  * @param expanded Determines whether the button is in its expanded state (with text) or collapsed (icon only).
  * @param modifier Modifier to apply to the button.
+ * @param feedback The feedback configuration for sound and haptics.
  */
 @Composable
 fun AnimatedExtendedFloatingActionButton(
@@ -37,7 +37,8 @@ fun AnimatedExtendedFloatingActionButton(
     icon: @Composable () -> Unit,
     text: (@Composable () -> Unit)? = null,
     expanded: Boolean = true,
-    containerColor: Color = FloatingActionButtonDefaults.containerColor
+    containerColor: Color = FloatingActionButtonDefaults.containerColor,
+    feedback: ButtonFeedback = ButtonFeedback(),
 ) {
     val animatedScale: Float by animateFloatAsState(
         targetValue = if (visible) 1f else 0f,
@@ -51,8 +52,7 @@ fun AnimatedExtendedFloatingActionButton(
     if (animatedScale > 0f) {
         ExtendedFloatingActionButton(
             onClick = {
-                view.playSoundEffect(SoundEffectConstants.CLICK)
-                hapticFeedback.performHapticFeedback(hapticFeedbackType = HapticFeedbackType.ContextClick)
+                feedback.performClick(view = view, hapticFeedback = hapticFeedback)
                 onClick()
             }, icon = icon, text = text ?: {}, expanded = expanded, modifier = modifier
                 .bounceClick()

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/buttons/fab/AnimatedFloatingActionButton.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/buttons/fab/AnimatedFloatingActionButton.kt
@@ -1,6 +1,5 @@
 package com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.fab
 
-import android.view.SoundEffectConstants
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -15,9 +14,9 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
-import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalView
+import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.ButtonFeedback
 import com.d4rk.android.libs.apptoolkit.core.ui.views.modifiers.bounceClick
 
 /**
@@ -30,6 +29,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.views.modifiers.bounceClick
  * @param icon The [ImageVector] to be displayed inside the FAB.
  * @param contentDescription Text used by accessibility services to describe what the icon represents.
  * @param onClick A lambda function to be invoked when the button is clicked.
+ * @param feedback The feedback configuration for sound and haptics.
  */
 @OptIn(ExperimentalMaterial3Api::class, ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -38,7 +38,8 @@ fun AnimatedFloatingActionButton(
     isVisible: Boolean,
     icon: ImageVector,
     contentDescription: String? = null,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    feedback: ButtonFeedback = ButtonFeedback(),
 ) {
     val haptics = LocalHapticFeedback.current
     val view = LocalView.current
@@ -52,8 +53,7 @@ fun AnimatedFloatingActionButton(
         ToggleFloatingActionButton(
             checked = checkedState.value,
             onCheckedChange = { newChecked ->
-                view.playSoundEffect(SoundEffectConstants.CLICK)
-                haptics.performHapticFeedback(HapticFeedbackType.ContextClick)
+                feedback.performClick(view = view, hapticFeedback = haptics)
                 checkedState.value = newChecked
                 onClick()
             },

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/buttons/fab/SmallFloatingActionButton.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/buttons/fab/SmallFloatingActionButton.kt
@@ -1,6 +1,5 @@
 package com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.fab
 
-import android.view.SoundEffectConstants
 import android.view.View
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.scaleIn
@@ -11,9 +10,9 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.hapticfeedback.HapticFeedback
-import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalView
+import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.ButtonFeedback
 import com.d4rk.android.libs.apptoolkit.core.ui.views.modifiers.bounceClick
 
 /**
@@ -28,6 +27,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.views.modifiers.bounceClick
  * @param icon The icon to be displayed inside the button.
  * @param contentDescription Optional description of the icon for accessibility.
  * @param onClick The action to be performed when the button is clicked.
+ * @param feedback The feedback configuration for sound and haptics.
  */
 @Composable
 fun SmallFloatingActionButton(
@@ -36,7 +36,8 @@ fun SmallFloatingActionButton(
     isExtended: Boolean,
     icon: ImageVector,
     contentDescription: String? = null,
-    onClick: () -> Unit
+    onClick: () -> Unit,
+    feedback: ButtonFeedback = ButtonFeedback(),
 ) {
     val hapticFeedback: HapticFeedback = LocalHapticFeedback.current
     val view: View = LocalView.current
@@ -47,8 +48,7 @@ fun SmallFloatingActionButton(
         exit = scaleOut(),
     ) {
         SmallFloatingActionButton(onClick = {
-            view.playSoundEffect(SoundEffectConstants.CLICK)
-            hapticFeedback.performHapticFeedback(hapticFeedbackType = HapticFeedbackType.ContextClick)
+            feedback.performClick(view = view, hapticFeedback = hapticFeedback)
             onClick()
         }, modifier = modifier.bounceClick()) {
             Icon(imageVector = icon, contentDescription = contentDescription)

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/layouts/NoDataScreen.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/layouts/NoDataScreen.kt
@@ -27,7 +27,7 @@ import androidx.compose.ui.text.style.TextAlign
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.core.ui.model.ads.AdsConfig
 import com.d4rk.android.libs.apptoolkit.core.ui.views.ads.NoDataNativeAdCard
-import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.IconButtonWithText
+import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.GeneralButton
 import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.LargeVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import org.koin.compose.koinInject
@@ -96,7 +96,7 @@ fun NoDataScreen(
         )
         if (showRetry) {
             LargeVerticalSpacer()
-            IconButtonWithText(
+            GeneralButton(
                 onClick = onRetry,
                 icon = Icons.Filled.Refresh,
                 label = stringResource(id = text)


### PR DESCRIPTION
### Motivation
- Previously button helpers were named and constrained around icon+text (`Icon*WithText`) and duplicated feedback logic, which made usage confusing and inflexible; the change rationalizes the API to express general-purpose buttons and centralizes feedback configuration.
- The goal is to support 3 rendering modes (text-only, icon+text, icon-only) while delegating to Material 3 base components and making sound/haptic behavior configurable per control.

### Description
- Add a new `ButtonFeedback` data class (`core/ui/views/buttons/ButtonFeedback.kt`) to centralize sound and haptic configuration and provide a `performClick` helper for all buttons and FABs.
- Replace the previous icon+text helpers with generalized variants: `GeneralButton`, `GeneralTonalButton`, `GeneralOutlinedButton`, and `GeneralTextButton` in `IconButton.kt`, each requiring a label and/or icon and falling back to the icon-only Material components when only an icon is provided.
- Wire `ButtonFeedback` into existing interactive components by replacing direct `playSoundEffect`/`performHapticFeedback` calls with `feedback.performClick(...)` in `AnimatedIconButtonDirection.kt` and FAB implementations under `buttons/fab/` and update call sites to use the new `General*` composables (examples: `SupportScreen`, `OnboardingBottomNavigation`, `SettingsScreen`, `IssueReporterScreen`, `NoDataScreen`).
- Add simple runtime guards with `require(hasIcon || hasLabel)` and keep usage of Material 3 components (`Button`, `FilledTonalButton`, `OutlinedButton`, `TextButton`, and icon-only variants) to preserve native behaviors like ripples.

### Testing
- No automated tests were executed as part of this change (no unit or instrumented tests run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696fa173e108832d99e4a5a4688fa7c6)