### PR TITLE
Center onboarding indicator dots

### DIFF
--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/views/OnboardingBottomNavigation.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/views/OnboardingBottomNavigation.kt
@@ -47,25 +47,27 @@ fun OnboardingBottomNavigation(
         ),
         horizontalArrangement = Arrangement.SpaceBetween
     ) {
-        AnimatedVisibility(
-            visible = pagerState.currentPage > 0,
+        Box(
             modifier = Modifier
                 .weight(1f)
                 .fillMaxWidth(),
-            enter = slideInHorizontally(
-                initialOffsetX = { -it }, animationSpec = spring(
-                    dampingRatio = Spring.DampingRatioMediumBouncy,
-                    stiffness = Spring.StiffnessLow
-                )
-            ) + fadeIn(animationSpec = spring(stiffness = Spring.StiffnessLow)),
-            exit = slideOutHorizontally(
-                targetOffsetX = { -it }, animationSpec = spring(
-                    dampingRatio = Spring.DampingRatioMediumBouncy,
-                    stiffness = Spring.StiffnessLow
-                )
-            ) + fadeOut(animationSpec = spring(stiffness = Spring.StiffnessLow))
+            contentAlignment = Alignment.CenterStart
         ) {
-            Box(contentAlignment = Alignment.CenterStart) {
+            AnimatedVisibility(
+                visible = pagerState.currentPage > 0,
+                enter = slideInHorizontally(
+                    initialOffsetX = { -it }, animationSpec = spring(
+                        dampingRatio = Spring.DampingRatioMediumBouncy,
+                        stiffness = Spring.StiffnessLow
+                    )
+                ) + fadeIn(animationSpec = spring(stiffness = Spring.StiffnessLow)),
+                exit = slideOutHorizontally(
+                    targetOffsetX = { -it }, animationSpec = spring(
+                        dampingRatio = Spring.DampingRatioMediumBouncy,
+                        stiffness = Spring.StiffnessLow
+                    )
+                ) + fadeOut(animationSpec = spring(stiffness = Spring.StiffnessLow))
+            ) {
                 GeneralOutlinedButton(
                     onClick = onBackClicked,
                     icon = Icons.AutoMirrored.Filled.KeyboardArrowLeft,
@@ -75,11 +77,15 @@ fun OnboardingBottomNavigation(
             }
         }
 
-        PageIndicatorDots(
-            pagerState = pagerState,
-            pageCount = pageCount,
-            modifier = Modifier.weight(1f)
-        )
+        Box(
+            modifier = Modifier.weight(1f),
+            contentAlignment = Alignment.Center
+        ) {
+            PageIndicatorDots(
+                pagerState = pagerState,
+                pageCount = pageCount
+            )
+        }
 
         Box(
             modifier = Modifier


### PR DESCRIPTION
### Motivation
- Fix a layout glitch where the onboarding indicator dots shift to the left on the first page because the back button `AnimatedVisibility` collapses its slot during its enter animation. 
- Change rationale: before the left slot collapsed and the dots occupied that space which caused a jarring alignment jump; reserving the back-button slot preserves spatial stability and reduces visual jitter in the onboarding bottom bar.

### Description
- Update `OnboardingBottomNavigation.kt` to wrap the left/back area, the indicator area, and the next button area in three `Box` containers each using `Modifier.weight(1f)` so the center slot stays stable. 
- Move `AnimatedVisibility` inside the left `Box` and center the `PageIndicatorDots` inside its own centered `Box` so the dots remain centered while the back button animates. 
- This is a pure layout adjustment (no public API changes) implemented using `Box`, `AnimatedVisibility`, `PageIndicatorDots`, and `FlexibleBottomAppBar`.

### Testing
- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69706972d5c4832d90e9306ef4c599a5)