### PR TITLE
Fix back handling for top-level Navigation 3 flows to prevent app exit

### DIFF
--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/views/navigation/AppNavigationHost.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/views/navigation/AppNavigationHost.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.activity.compose.BackHandler
 import androidx.navigation3.runtime.NavEntry
 import androidx.navigation3.ui.NavDisplay
 import com.d4rk.android.apps.apptoolkit.app.main.utils.constants.AppNavKey
@@ -51,6 +52,10 @@ fun AppNavigationHost(
         remember(entryBuilders) {
             entryProviderFor(entryBuilders)
         }
+
+    BackHandler(enabled = navigator.canGoBack()) {
+        navigator.goBack()
+    }
 
     NavDisplay(
         modifier = modifier,

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/navigation/NavigationState.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/navigation/NavigationState.kt
@@ -102,16 +102,36 @@ class Navigator<T : StableNavKey>(val state: NavigationState<T>) {
         }
     }
 
-    fun goBack() {
-        val currentRoute = state.currentBackStack.lastOrNull() ?: return
+    /**
+     * Returns true when the current back stack can handle a back action.
+     */
+    fun canGoBack(): Boolean {
+        val currentRoute = state.currentBackStack.lastOrNull() ?: return false
+
+        return if (currentRoute == state.topLevelRoute) {
+            state.topLevelRoute != state.startRoute
+        } else {
+            true
+        }
+    }
+
+    /**
+     * Handles a back action, returning true when navigation consumed the request.
+     */
+    fun goBack(): Boolean {
+        val currentRoute = state.currentBackStack.lastOrNull() ?: return false
 
         if (currentRoute == state.topLevelRoute) {
             if (state.topLevelRoute != state.startRoute) {
                 state.topLevelRoute = state.startRoute
+                return true
             }
         } else {
             state.currentBackStack.removeLastOrNull()
+            return true
         }
+
+        return false
     }
 }
 


### PR DESCRIPTION
### Motivation
- Users reported that after switching tabs, using the system back gesture or system nav bar sometimes closed the app because Navigation 3 did not consume the back action.
- The change aims to ensure top-level/tab navigation consumes back events until the configured start route is reached, matching typical tabbed UX expectations.

### Description
- Add a `BackHandler` in `AppNavigationHost` that consults `navigator.canGoBack()` and invokes `navigator.goBack()` to explicitly consume system back events when navigation can handle them.
- Extend `Navigator` in `NavigationState.kt` with a `canGoBack()` helper and change `goBack()` to return a `Boolean` indicating whether the back action was consumed, and to route to the `startRoute` instead of falling through to the activity.
- Include concise KDoc-style comments explaining the new `canGoBack()`/`goBack()` semantics and the intended behavior change as a rationale for the modification.

### Testing
- No automated tests were run on these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69751ced7e84832da5b9809dd7c0b11b)