### PR TITLE
Add Mutex-protected state helpers and generalJob to BaseViewModel

### DIFF
--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsViewModel.kt
@@ -104,29 +104,33 @@ class FavoriteAppsViewModel(
                         action = "observe",
                         throwable = error,
                     )
-                    screenState.updateState(ScreenState.Error())
-                    showErrorSnackbar(
-                        UiTextHelper.StringResource(R.string.error_failed_to_load_apps)
-                    )
+                    updateStateThreadSafe {
+                        screenState.updateState(ScreenState.Error())
+                        showErrorSnackbar(
+                            UiTextHelper.StringResource(R.string.error_failed_to_load_apps)
+                        )
+                    }
                 }
                 .collect { result ->
-                    result
-                        .onSuccess { apps ->
-                            val immutableApps = apps.toImmutableList()
-                            if (immutableApps.isEmpty()) {
-                                screenState.updateData(ScreenState.NoData()) {
-                                    it.copy(apps = immutableApps)
-                                }
-                            } else {
-                                screenState.updateData(ScreenState.Success()) {
-                                    it.copy(apps = immutableApps)
+                    updateStateThreadSafe {
+                        result
+                            .onSuccess { apps ->
+                                val immutableApps = apps.toImmutableList()
+                                if (immutableApps.isEmpty()) {
+                                    screenState.updateData(ScreenState.NoData()) {
+                                        it.copy(apps = immutableApps)
+                                    }
+                                } else {
+                                    screenState.updateData(ScreenState.Success()) {
+                                        it.copy(apps = immutableApps)
+                                    }
                                 }
                             }
-                        }
-                        .onFailure { error ->
-                            screenState.updateState(ScreenState.Error())
-                            showErrorSnackbar(error.toErrorMessage())
-                        }
+                            .onFailure { error ->
+                                screenState.updateState(ScreenState.Error())
+                                showErrorSnackbar(error.toErrorMessage())
+                            }
+                    }
                 }
         }
     }
@@ -138,8 +142,10 @@ class FavoriteAppsViewModel(
                 withContext(dispatchers.io) { toggleFavoriteUseCase(packageName) }
             } catch (t: Throwable) {
                 if (t is CancellationException) throw t
-                screenState.updateState(ScreenState.Error())
-                showErrorSnackbar(UiTextHelper.StringResource(R.string.error_failed_to_update_favorite))
+                updateStateThreadSafe {
+                    screenState.updateState(ScreenState.Error())
+                    showErrorSnackbar(UiTextHelper.StringResource(R.string.error_failed_to_update_favorite))
+                }
             }
         }
     }

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListViewModel.kt
@@ -115,26 +115,28 @@ class AppsListViewModel(
                         action = "observeFetch",
                         throwable = throwable,
                     )
-                    showLoadAppsError()
+                    updateStateThreadSafe { showLoadAppsError() }
                 }
                 .collect { result ->
-                    result
-                        .onSuccess { apps ->
-                            val data = apps.toImmutableList()
-                            if (data.isEmpty()) {
-                                screenState.update { current ->
-                                    current.copy(
-                                        screenState = ScreenState.NoData(),
-                                        data = AppListUiState(apps = persistentListOf())
-                                    )
-                                }
-                            } else {
-                                screenState.updateData(newState = ScreenState.Success()) { current ->
-                                    current.copy(apps = data)
+                    updateStateThreadSafe {
+                        result
+                            .onSuccess { apps ->
+                                val data = apps.toImmutableList()
+                                if (data.isEmpty()) {
+                                    screenState.update { current ->
+                                        current.copy(
+                                            screenState = ScreenState.NoData(),
+                                            data = AppListUiState(apps = persistentListOf())
+                                        )
+                                    }
+                                } else {
+                                    screenState.updateData(newState = ScreenState.Success()) { current ->
+                                        current.copy(apps = data)
+                                    }
                                 }
                             }
-                        }
-                        .onFailure(::showLoadAppsError)
+                            .onFailure { showLoadAppsError(it) }
+                    }
                 }
         }
     }

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainViewModel.kt
@@ -22,7 +22,6 @@ import com.d4rk.android.libs.apptoolkit.core.ui.state.successData
 import com.d4rk.android.libs.apptoolkit.core.utils.extensions.errors.toError
 import com.d4rk.android.libs.apptoolkit.core.utils.platform.UiTextHelper
 import kotlinx.collections.immutable.toImmutableList
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
@@ -42,8 +41,6 @@ class MainViewModel(
 ) : ScreenViewModel<MainUiState, MainEvent, MainAction>(
     initialState = UiStateScreen(data = MainUiState())
 ) {
-
-    private var consentJob: Job? = null
 
     init {
         onEvent(MainEvent.LoadNavigation)
@@ -109,8 +106,8 @@ class MainViewModel(
     }
 
     private fun requestConsent(host: ConsentHost) {
-        consentJob?.cancel()
-        consentJob = requestConsentUseCase(host = host)
+        generalJob?.cancel()
+        generalJob = requestConsentUseCase(host = host)
             .flowOn(dispatchers.main)
             .catch { throwable ->
                 if (throwable is CancellationException) throw throwable

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/advanced/ui/AdvancedSettingsViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/advanced/ui/AdvancedSettingsViewModel.kt
@@ -19,7 +19,6 @@ import com.d4rk.android.libs.apptoolkit.core.ui.state.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.state.copyData
 import com.d4rk.android.libs.apptoolkit.core.ui.state.setLoading
 import com.d4rk.android.libs.apptoolkit.core.ui.state.updateState
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
@@ -50,8 +49,6 @@ class AdvancedSettingsViewModel(
     ),
 ) {
 
-    private var clearCacheJob: Job? = null
-
     override fun onEvent(event: AdvancedSettingsEvent) {
         when (event) {
             AdvancedSettingsEvent.ClearCache -> clearCache()
@@ -68,9 +65,9 @@ class AdvancedSettingsViewModel(
      * to the user. It also handles potential exceptions during the flow execution.
      */
     private fun clearCache() {
-        clearCacheJob?.cancel()
+        generalJob?.cancel()
 
-        clearCacheJob = repository.clearCache()
+        generalJob = repository.clearCache()
             .flowOn(dispatchers.io)
             .map<Result<Unit>, DataState<Unit, Errors.Database>> { result ->
                 when (result) {

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/GeneralSettingsViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/GeneralSettingsViewModel.kt
@@ -24,7 +24,6 @@ import com.d4rk.android.libs.apptoolkit.core.utils.extensions.errors.asUiText
 import com.d4rk.android.libs.apptoolkit.core.utils.extensions.errors.toError
 import com.d4rk.android.libs.apptoolkit.core.utils.platform.UiTextHelper
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
@@ -41,8 +40,6 @@ class GeneralSettingsViewModel(
     initialState = UiStateScreen(data = GeneralSettingsUiState())
 ) {
 
-    private var loadJob: Job? = null
-
     override fun onEvent(event: GeneralSettingsEvent) {
         when (event) {
             is GeneralSettingsEvent.Load -> loadContent(contentKey = event.contentKey)
@@ -50,8 +47,8 @@ class GeneralSettingsViewModel(
     }
 
     private fun loadContent(contentKey: String?) {
-        loadJob?.cancel()
-        loadJob = viewModelScope.launch {
+        generalJob?.cancel()
+        generalJob = viewModelScope.launch {
             repository.getContentKey(contentKey)
                 .flowOn(dispatchers.default)
                 .map<String, DataState<String, Errors>> { key ->

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupViewModel.kt
@@ -15,7 +15,6 @@ import com.d4rk.android.libs.apptoolkit.core.ui.state.ScreenState
 import com.d4rk.android.libs.apptoolkit.core.ui.state.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.state.updateData
 import kotlinx.coroutines.CancellationException
-import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
@@ -29,8 +28,6 @@ class StartupViewModel(
     initialState = UiStateScreen(data = StartupUiState())
 ) {
 
-    private var consentJob: Job? = null
-
     override fun onEvent(event: StartupEvent) {
         when (event) {
             is StartupEvent.RequestConsent -> requestConsent(event.host)
@@ -43,8 +40,8 @@ class StartupViewModel(
     }
 
     private fun requestConsent(host: ConsentHost) {
-        consentJob?.cancel()
-        consentJob = requestConsentUseCase(host = host)
+        generalJob?.cancel()
+        generalJob = requestConsentUseCase(host = host)
             .flowOn(dispatchers.main)
             .catch { throwable ->
                 if (throwable is CancellationException) throw throwable

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportViewModel.kt
@@ -317,8 +317,10 @@ class SupportViewModel(
             billingTimeoutJob = null
         }
 
-        screenState.copyData {
-            copy(isBillingInProgress = inProgress)
+        viewModelScope.launch {
+            updateSuccessState(screenState) {
+                it.copy(isBillingInProgress = inProgress)
+            }
         }
     }
 


### PR DESCRIPTION
### Motivation
- Prevent race conditions when multiple flows update `UiStateScreen` concurrently by providing mutex-protected helpers. 
- Reduce per-ViewModel boilerplate for single cancellable operations by introducing a shared `generalJob` slot. 
- Make success-only updates more explicit and easier to reason about for screen state transitions.

### Description
- Added `private val stateMutex = Mutex()`, `protected suspend fun updateStateThreadSafe(...)`, `protected suspend fun <T> updateSuccessState(...)`, and `protected fun <T> getSuccessData(...)` to `BaseViewModel`, and introduced `protected var generalJob: Job? = null` to centralize single-operation job management. 
- Replaced several per-ViewModel single-job usages with `generalJob` (notably in `StartupViewModel`, `GeneralSettingsViewModel`, `HelpViewModel`, `AdvancedSettingsViewModel`, `IssueReporterViewModel`, `MainViewModel`). 
- Serialized state updates using `updateStateThreadSafe` in `AppsListViewModel` and `FavoriteAppsViewModel`, and used `updateSuccessState` in `SupportViewModel` for billing progress toggles. 
- Minor import and cleanup changes (removed some unused `Job` properties and imports where `generalJob` is used instead).

### Testing
- No automated tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ce263d7b0832d8f82d50bc6976648)