### PR TITLE
Add Firebase breadcrumbs across app and library flows

### DIFF
--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/data/repository/DeveloperAppsRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/data/repository/DeveloperAppsRepositoryImpl.kt
@@ -7,6 +7,7 @@ import com.d4rk.android.apps.apptoolkit.app.apps.common.domain.repository.Develo
 import com.d4rk.android.apps.apptoolkit.core.domain.model.network.AppErrors
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Errors
+import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
 import com.d4rk.android.libs.apptoolkit.core.utils.extensions.result.runSuspendCatching
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
@@ -28,9 +29,14 @@ import kotlin.coroutines.cancellation.CancellationException
 class DeveloperAppsRepositoryImpl(
     private val client: HttpClient,
     private val baseUrl: String,
+    private val firebaseController: FirebaseController,
 ) : DeveloperAppsRepository {
 
     override fun fetchDeveloperApps(): Flow<DataState<List<AppInfo>, AppErrors>> = flow {
+        firebaseController.logBreadcrumb(
+            message = "Developer apps fetch",
+            attributes = mapOf("baseUrl" to baseUrl),
+        )
         runSuspendCatching {
             client.get(baseUrl)
         }.onSuccess { response ->

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/data/repository/FavoritesRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/data/repository/FavoritesRepositoryImpl.kt
@@ -2,15 +2,28 @@ package com.d4rk.android.apps.apptoolkit.app.apps.common.data.repository
 
 import com.d4rk.android.apps.apptoolkit.app.apps.common.data.local.FavoritesLocalDataSource
 import com.d4rk.android.apps.apptoolkit.app.apps.common.domain.repository.FavoritesRepository
+import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.onStart
 
 class FavoritesRepositoryImpl(
-    private val local: FavoritesLocalDataSource ,
+    private val local: FavoritesLocalDataSource,
+    private val firebaseController: FirebaseController,
 ) : FavoritesRepository {
 
     override fun observeFavorites(): Flow<Set<String>> = local.observeFavorites()
+        .onStart {
+            firebaseController.logBreadcrumb(
+                message = "Favorites observe",
+                attributes = mapOf("source" to "FavoritesRepositoryImpl"),
+            )
+        }
 
     override suspend fun toggleFavorite(packageName: String) {
+        firebaseController.logBreadcrumb(
+            message = "Favorite toggled",
+            attributes = mapOf("packageName" to packageName),
+        )
         local.toggleFavorite(packageName)
     }
 }

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/domain/usecases/FetchDeveloperAppsUseCase.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/domain/usecases/FetchDeveloperAppsUseCase.kt
@@ -4,12 +4,15 @@ import com.d4rk.android.apps.apptoolkit.app.apps.common.domain.model.AppInfo
 import com.d4rk.android.apps.apptoolkit.app.apps.common.domain.repository.DeveloperAppsRepository
 import com.d4rk.android.apps.apptoolkit.core.domain.model.network.AppErrors
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
+import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.flow
+import kotlinx.coroutines.flow.onStart
 
 class FetchDeveloperAppsUseCase(
-    private val repository: DeveloperAppsRepository
+    private val repository: DeveloperAppsRepository,
+    private val firebaseController: FirebaseController,
 ) {
     /**
      * Returns developer apps.
@@ -19,6 +22,15 @@ class FetchDeveloperAppsUseCase(
      * presentation concerns out of the domain layer.
      */
     operator fun invoke(): Flow<DataState<List<AppInfo>, AppErrors>> = flow {
+        firebaseController.logBreadcrumb(
+            message = "Fetch developer apps started",
+            attributes = mapOf("source" to "FetchDeveloperAppsUseCase"),
+        )
         emitAll(repository.fetchDeveloperApps())
+    }.onStart {
+        firebaseController.logBreadcrumb(
+            message = "Fetch developer apps collecting",
+            attributes = mapOf("stage" to "onStart"),
+        )
     }
 }

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/domain/usecases/ObserveFavoriteAppsUseCase.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/domain/usecases/ObserveFavoriteAppsUseCase.kt
@@ -3,6 +3,7 @@ package com.d4rk.android.apps.apptoolkit.app.apps.common.domain.usecases
 import com.d4rk.android.apps.apptoolkit.app.apps.common.domain.model.AppInfo
 import com.d4rk.android.apps.apptoolkit.core.domain.model.network.AppErrors
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
+import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.distinctUntilChanged
@@ -11,10 +12,17 @@ import kotlinx.coroutines.flow.onStart
 class ObserveFavoriteAppsUseCase(
     private val fetchDeveloperAppsUseCase: FetchDeveloperAppsUseCase,
     private val observeFavoritesUseCase: ObserveFavoritesUseCase,
+    private val firebaseController: FirebaseController,
 ) {
     operator fun invoke(): Flow<DataState<List<AppInfo>, AppErrors>> =
         combine(
-            fetchDeveloperAppsUseCase().onStart { emit(DataState.Loading()) },
+            fetchDeveloperAppsUseCase().onStart {
+                firebaseController.logBreadcrumb(
+                    message = "Observe favorite apps fetch started",
+                    attributes = mapOf("source" to "ObserveFavoriteAppsUseCase"),
+                )
+                emit(DataState.Loading())
+            },
             observeFavoritesUseCase(),
         ) { appsState, favorites ->
             when (appsState) {

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/domain/usecases/ObserveFavoritesUseCase.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/domain/usecases/ObserveFavoritesUseCase.kt
@@ -1,10 +1,19 @@
 package com.d4rk.android.apps.apptoolkit.app.apps.common.domain.usecases
 
 import com.d4rk.android.apps.apptoolkit.app.apps.common.domain.repository.FavoritesRepository
+import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.onStart
 
 class ObserveFavoritesUseCase(
     private val repository: FavoritesRepository,
+    private val firebaseController: FirebaseController,
 ) {
     operator fun invoke(): Flow<Set<String>> = repository.observeFavorites()
+        .onStart {
+            firebaseController.logBreadcrumb(
+                message = "Observe favorites started",
+                attributes = mapOf("source" to "ObserveFavoritesUseCase"),
+            )
+        }
 }

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/domain/usecases/ToggleFavoriteUseCase.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/domain/usecases/ToggleFavoriteUseCase.kt
@@ -1,11 +1,17 @@
 package com.d4rk.android.apps.apptoolkit.app.apps.common.domain.usecases
 
 import com.d4rk.android.apps.apptoolkit.app.apps.common.domain.repository.FavoritesRepository
+import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
 
 class ToggleFavoriteUseCase(
     private val repository: FavoritesRepository,
+    private val firebaseController: FirebaseController,
 ) {
     suspend operator fun invoke(packageName: String) {
+        firebaseController.logBreadcrumb(
+            message = "Toggle favorite",
+            attributes = mapOf("packageName" to packageName),
+        )
         repository.toggleFavorite(packageName)
     }
 }

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsViewModel.kt
@@ -74,10 +74,18 @@ class FavoriteAppsViewModel(
         )
 
     init {
+        firebaseController.logBreadcrumb(
+            message = "FavoriteAppsViewModel initialized",
+            attributes = mapOf("screen" to "FavoriteApps"),
+        )
         onEvent(FavoriteAppsEvent.LoadFavorites)
     }
 
     override fun onEvent(event: FavoriteAppsEvent) {
+        firebaseController.logBreadcrumb(
+            message = "FavoriteAppsViewModel event",
+            attributes = mapOf("event" to event::class.java.simpleName),
+        )
         when (event) {
             is FavoriteAppsEvent.LoadFavorites -> observe()
             is FavoriteAppsEvent.OpenRandomApp -> {
@@ -88,6 +96,10 @@ class FavoriteAppsViewModel(
     }
 
     private fun observe() {
+        firebaseController.logBreadcrumb(
+            message = "Favorite apps observe",
+            attributes = mapOf("source" to "FavoriteAppsViewModel"),
+        )
         observeJob?.cancel()
         observeJob = viewModelScope.launch {
             observeFavoriteAppsUseCase()
@@ -128,6 +140,10 @@ class FavoriteAppsViewModel(
     }
 
     fun toggleFavorite(packageName: String) {
+        firebaseController.logBreadcrumb(
+            message = "Favorite apps toggle favorite",
+            attributes = mapOf("packageName" to packageName),
+        )
         toggleJob?.cancel()
         toggleJob = viewModelScope.launch {
             try {

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListViewModel.kt
@@ -84,11 +84,19 @@ class AppsListViewModel(
         )
 
     init {
+        firebaseController.logBreadcrumb(
+            message = "AppsListViewModel initialized",
+            attributes = mapOf("screen" to "AppsList"),
+        )
         observeFetch()
         fetchAppsTrigger.tryEmit(Unit)
     }
 
     override fun onEvent(event: HomeEvent) {
+        firebaseController.logBreadcrumb(
+            message = "AppsListViewModel event",
+            attributes = mapOf("event" to event::class.java.simpleName),
+        )
         when (event) {
             HomeEvent.FetchApps -> fetchAppsTrigger.tryEmit(Unit)
             HomeEvent.OpenRandomApp -> {
@@ -99,6 +107,10 @@ class AppsListViewModel(
     }
 
     private fun observeFetch() {
+        firebaseController.logBreadcrumb(
+            message = "Apps list fetch observe",
+            attributes = mapOf("source" to "AppsListViewModel"),
+        )
         fetchJob?.cancel()
         fetchJob = viewModelScope.launch {
             fetchAppsTrigger
@@ -151,6 +163,10 @@ class AppsListViewModel(
     }
 
     fun toggleFavorite(packageName: String) {
+        firebaseController.logBreadcrumb(
+            message = "Apps list toggle favorite",
+            attributes = mapOf("packageName" to packageName),
+        )
         toggleJob?.cancel()
         toggleJob = viewModelScope.launch {
             try {

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/data/repository/MainNavigationRepositoryImpl.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/data/repository/MainNavigationRepositoryImpl.kt
@@ -12,13 +12,16 @@ import com.d4rk.android.apps.apptoolkit.app.main.utils.constants.NavigationRoute
 import com.d4rk.android.apps.apptoolkit.core.data.local.DataStore
 import com.d4rk.android.libs.apptoolkit.app.main.domain.repository.NavigationRepository
 import com.d4rk.android.libs.apptoolkit.app.main.utils.constants.NavigationDrawerRoutes
+import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
 import com.d4rk.android.libs.apptoolkit.core.ui.model.navigation.NavigationDrawerItem
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
 import com.d4rk.android.libs.apptoolkit.R as ToolkitR
 
 class MainNavigationRepositoryImpl(
     private val dataStore: DataStore,
+    private val firebaseController: FirebaseController,
 ) : NavigationRepository {
     override fun getNavigationDrawerItems(): Flow<List<NavigationDrawerItem>> =
         dataStore.componentsShowcaseUnlocked.map { isUnlocked ->
@@ -61,5 +64,10 @@ class MainNavigationRepositoryImpl(
                     ),
                 )
             }
+        }.onStart {
+            firebaseController.logBreadcrumb(
+                message = "Navigation drawer items requested",
+                attributes = mapOf("source" to "MainNavigationRepositoryImpl"),
+            )
         }
 }

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/domain/usecases/GetNavigationDrawerItemsUseCase.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/domain/usecases/GetNavigationDrawerItemsUseCase.kt
@@ -1,12 +1,23 @@
 package com.d4rk.android.apps.apptoolkit.app.main.domain.usecases
 
 import com.d4rk.android.libs.apptoolkit.app.main.domain.repository.NavigationRepository
+import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
 import com.d4rk.android.libs.apptoolkit.core.ui.model.navigation.NavigationDrawerItem
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.onStart
 
-class GetNavigationDrawerItemsUseCase(private val navigationRepository: NavigationRepository) {
+class GetNavigationDrawerItemsUseCase(
+    private val navigationRepository: NavigationRepository,
+    private val firebaseController: FirebaseController,
+) {
 
     operator fun invoke(): Flow<List<NavigationDrawerItem>> {
         return navigationRepository.getNavigationDrawerItems()
+            .onStart {
+                firebaseController.logBreadcrumb(
+                    message = "Navigation drawer load started",
+                    attributes = mapOf("source" to "GetNavigationDrawerItemsUseCase"),
+                )
+            }
     }
 }

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainViewModel.kt
@@ -42,10 +42,18 @@ class MainViewModel(
 ) {
 
     init {
+        firebaseController.logBreadcrumb(
+            message = "MainViewModel initialized",
+            attributes = mapOf("screen" to "Main"),
+        )
         onEvent(MainEvent.LoadNavigation)
     }
 
     override fun onEvent(event: MainEvent) {
+        firebaseController.logBreadcrumb(
+            message = "MainViewModel event",
+            attributes = mapOf("event" to event::class.java.simpleName),
+        )
         when (event) {
             MainEvent.LoadNavigation -> loadNavigationItems()
             is MainEvent.RequestConsent -> requestConsent(event.host)
@@ -53,6 +61,10 @@ class MainViewModel(
     }
 
     private fun loadNavigationItems() {
+        firebaseController.logBreadcrumb(
+            message = "Main navigation load started",
+            attributes = mapOf("source" to "MainViewModel"),
+        )
         viewModelScope.launch {
             getNavigationDrawerItemsUseCase()
                 .flowOn(dispatchers.io)
@@ -95,6 +107,10 @@ class MainViewModel(
     }
 
     private fun requestConsent(host: ConsentHost) {
+        firebaseController.logBreadcrumb(
+            message = "Main consent request",
+            attributes = mapOf("host" to host.activity::class.java.name),
+        )
         generalJob?.cancel()
         generalJob = requestConsentUseCase(host = host)
             .flowOn(dispatchers.main)

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/app/modules/AdsModule.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/app/modules/AdsModule.kt
@@ -20,11 +20,12 @@ val adsModule: Module = module {
         AdsSettingsRepositoryImpl(
             dataStore = get(),
             buildInfoProvider = get<BuildInfoProvider>(),
+            firebaseController = get(),
         )
     }
 
-    single { ObserveAdsEnabledUseCase(repo = get()) }
-    single { SetAdsEnabledUseCase(repo = get()) }
+    single { ObserveAdsEnabledUseCase(repo = get(), firebaseController = get()) }
+    single { SetAdsEnabledUseCase(repo = get(), firebaseController = get()) }
 
     viewModel {
         AdsSettingsViewModel(

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/app/modules/AppModule.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/app/modules/AppModule.kt
@@ -14,8 +14,10 @@ import org.koin.core.qualifier.named
 import org.koin.dsl.module
 
 val appModule: Module = module {
-    single<NavigationRepository> { MainNavigationRepositoryImpl(dataStore = get()) }
-    single<GetNavigationDrawerItemsUseCase> { GetNavigationDrawerItemsUseCase(navigationRepository = get()) }
+    single<NavigationRepository> { MainNavigationRepositoryImpl(dataStore = get(), firebaseController = get()) }
+    single<GetNavigationDrawerItemsUseCase> {
+        GetNavigationDrawerItemsUseCase(navigationRepository = get(), firebaseController = get())
+    }
     viewModel {
         MainViewModel(
             getNavigationDrawerItemsUseCase = get(),

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/app/modules/AppsListModule.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/app/modules/AppsListModule.kt
@@ -22,10 +22,11 @@ val appsListModule: Module = module {
         DeveloperAppsRepositoryImpl(
             client = get(),
             baseUrl = get(qualifier = named(name = "developer_apps_api_url")),
+            firebaseController = get(),
         )
     }
 
-    single { FetchDeveloperAppsUseCase(repository = get()) }
+    single { FetchDeveloperAppsUseCase(repository = get(), firebaseController = get()) }
     viewModel {
         AppsListViewModel(
             fetchDeveloperAppsUseCase = get(),
@@ -37,14 +38,15 @@ val appsListModule: Module = module {
     }
 
     single<FavoritesLocalDataSource> { FavoritesLocalDataSourceImpl(dataStore = get()) }
-    single<FavoritesRepository> { FavoritesRepositoryImpl(local = get()) }
+    single<FavoritesRepository> { FavoritesRepositoryImpl(local = get(), firebaseController = get()) }
 
-    single { ObserveFavoritesUseCase(repository = get()) }
-    single { ToggleFavoriteUseCase(repository = get()) }
+    single { ObserveFavoritesUseCase(repository = get(), firebaseController = get()) }
+    single { ToggleFavoriteUseCase(repository = get(), firebaseController = get()) }
     single {
         ObserveFavoriteAppsUseCase(
             fetchDeveloperAppsUseCase = get(),
-            observeFavoritesUseCase = get()
+            observeFavoritesUseCase = get(),
+            firebaseController = get(),
         )
     }
 

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/app/modules/ConsentModule.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/app/modules/ConsentModule.kt
@@ -11,5 +11,5 @@ import org.koin.dsl.module
 val consentModule: Module = module {
     single<ConsentRemoteDataSource> { UmpConsentRemoteDataSource() }
     single<ConsentRepository> { ConsentRepositoryImpl(remote = get()) }
-    single { RequestConsentUseCase(repository = get()) }
+    single { RequestConsentUseCase(repository = get(), firebaseController = get()) }
 }

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/app/modules/OnboardingModule.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/app/modules/OnboardingModule.kt
@@ -16,9 +16,9 @@ import org.koin.dsl.module
 val onboardingModule: Module = module {
     single<OnboardingProvider> { AppOnboardingProvider() }
     single<OnboardingPreferencesDataSource> { get<CommonDataStore>() }
-    single<OnboardingRepository> { OnboardingRepositoryImpl(dataStore = get()) }
-    single { ObserveOnboardingCompletionUseCase(repository = get()) }
-    single { CompleteOnboardingUseCase(repository = get()) }
+    single<OnboardingRepository> { OnboardingRepositoryImpl(dataStore = get(), firebaseController = get()) }
+    single { ObserveOnboardingCompletionUseCase(repository = get(), firebaseController = get()) }
+    single { CompleteOnboardingUseCase(repository = get(), firebaseController = get()) }
     viewModel {
         OnboardingViewModel(
             observeOnboardingCompletionUseCase = get(),

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/apptoolkit/modules/HelpModule.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/apptoolkit/modules/HelpModule.kt
@@ -26,9 +26,10 @@ val helpModule: Module =
                     isDebugBuild = BuildConfig.DEBUG
                 ),
                 productId = HelpConstants.FAQ_PRODUCT_ID,
+                firebaseController = get(),
             )
         }
-        single { GetFaqUseCase(repository = get()) }
+        single { GetFaqUseCase(repository = get(), firebaseController = get()) }
         viewModel {
             HelpViewModel(
                 getFaqUseCase = get(),

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/apptoolkit/modules/IssueReporterModule.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/apptoolkit/modules/IssueReporterModule.kt
@@ -24,8 +24,8 @@ val issueReporterModule: Module =
     module {
         single { IssueReporterRemoteDataSource(client = get()) }
         single<DeviceInfoProvider> { DeviceInfoLocalDataSource(get(), get()) }
-        single<IssueReporterRepository> { IssueReporterRepositoryImpl(get(), get()) }
-        single { SendIssueReportUseCase(get(), get()) }
+        single<IssueReporterRepository> { IssueReporterRepositoryImpl(get(), get(), get()) }
+        single { SendIssueReportUseCase(get(), get(), get()) }
 
         single(qualifier = named(name = "github_repository")) { "App-Toolkit-for-Android" }
         single<GithubTarget> {

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/settings/modules/AboutModule.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/settings/modules/AboutModule.kt
@@ -22,10 +22,11 @@ val aboutModule: Module =
                 deviceProvider = get(),
                 buildInfoProvider = get(),
                 context = get(),
+                firebaseController = get(),
             )
         }
-        single { GetAboutInfoUseCase(repository = get()) }
-        single { CopyDeviceInfoUseCase(repository = get()) }
+        single { GetAboutInfoUseCase(repository = get(), firebaseController = get()) }
+        single { CopyDeviceInfoUseCase(repository = get(), firebaseController = get()) }
 
         viewModel {
             AboutViewModel(

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/settings/modules/AdvancedSettingsModule.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/settings/modules/AdvancedSettingsModule.kt
@@ -11,7 +11,7 @@ import org.koin.dsl.module
 
 val advancedSettingsModule: Module = module {
     single<AdvancedSettingsProvider> { AppAdvancedSettingsProvider(context = get()) }
-    single<CacheRepository> { CacheRepositoryImpl(context = get()) }
+    single<CacheRepository> { CacheRepositoryImpl(context = get(), firebaseController = get()) }
 
     viewModel {
         AdvancedSettingsViewModel(

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/settings/modules/GeneralSettingsModule.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/settings/modules/GeneralSettingsModule.kt
@@ -29,7 +29,7 @@ val generalSettingsModule: Module = module {
             }
         )
     }
-    single<GeneralSettingsRepository> { GeneralSettingsRepositoryImpl() }
+    single<GeneralSettingsRepository> { GeneralSettingsRepositoryImpl(firebaseController = get()) }
 
     viewModel {
         GeneralSettingsViewModel(

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/settings/modules/PermissionsModule.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/settings/modules/PermissionsModule.kt
@@ -12,7 +12,8 @@ val permissionsModule: Module =
         single<PermissionsRepository> {
             PermissionsRepositoryImpl(
                 context = get(),
-                dispatchers = get()
+                dispatchers = get(),
+                firebaseController = get(),
             )
         }
         viewModel {

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/settings/modules/UsageAndDiagnosticsModule.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/settings/modules/UsageAndDiagnosticsModule.kt
@@ -15,6 +15,7 @@ val usageAndDiagnosticsModule: Module =
                 dataSource = get<CommonDataStore>(),
                 configProvider = get(),
                 dispatchers = get(),
+                firebaseController = get(),
             )
         }
 

--- a/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModelBase.kt
+++ b/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/favorites/TestFavoriteAppsViewModelBase.kt
@@ -30,14 +30,15 @@ open class TestFavoriteAppsViewModelBase {
     ) {
         println("\uD83E\uDDEA [SETUP] Initial favorites: $initialFavorites")
         val developerAppsRepository = FakeDeveloperAppsRepository(fetchApps)
-        val fetchUseCase = FetchDeveloperAppsUseCase(developerAppsRepository)
+        val fetchUseCase = FetchDeveloperAppsUseCase(developerAppsRepository, firebaseController)
         val favoritesRepository =
             FakeFavoritesRepository(initialFavorites, favoritesFlow, toggleError)
-        val observeFavoritesUseCase = ObserveFavoritesUseCase(favoritesRepository)
-        val toggleFavoriteUseCase = ToggleFavoriteUseCase(favoritesRepository)
+        val observeFavoritesUseCase = ObserveFavoritesUseCase(favoritesRepository, firebaseController)
+        val toggleFavoriteUseCase = ToggleFavoriteUseCase(favoritesRepository, firebaseController)
         val observeFavoriteAppsUseCase = ObserveFavoriteAppsUseCase(
             fetchUseCase,
-            observeFavoritesUseCase
+            observeFavoritesUseCase,
+            firebaseController,
         )
         viewModel = FavoriteAppsViewModel(
             observeFavoriteAppsUseCase = observeFavoriteAppsUseCase,

--- a/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/favorites/domain/usecases/FavoritesUseCasesTest.kt
+++ b/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/favorites/domain/usecases/FavoritesUseCasesTest.kt
@@ -1,10 +1,11 @@
 package com.d4rk.android.apps.apptoolkit.app.apps.favorites.domain.usecases
 
 import app.cash.turbine.test
-import com.d4rk.android.apps.apptoolkit.app.apps.favorites.FakeFavoritesRepository
 import com.d4rk.android.apps.apptoolkit.app.apps.common.domain.repository.FavoritesRepository
 import com.d4rk.android.apps.apptoolkit.app.apps.common.domain.usecases.ObserveFavoritesUseCase
 import com.d4rk.android.apps.apptoolkit.app.apps.common.domain.usecases.ToggleFavoriteUseCase
+import com.d4rk.android.apps.apptoolkit.app.apps.favorites.FakeFavoritesRepository
+import com.d4rk.android.apps.apptoolkit.core.utils.FakeFirebaseController
 import com.google.common.truth.Truth.assertThat
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flowOf
@@ -17,7 +18,7 @@ class FavoritesUseCasesTest {
     @Test
     fun `observe favorites emits initial set`() = runBlocking {
         val repository = FakeFavoritesRepository(initialFavorites = setOf("pkg1", "pkg2"))
-        val useCase = ObserveFavoritesUseCase(repository)
+        val useCase = ObserveFavoritesUseCase(repository, FakeFirebaseController())
 
         useCase().test {
             assertThat(awaitItem()).containsExactly("pkg1", "pkg2")
@@ -28,8 +29,9 @@ class FavoritesUseCasesTest {
     @Test
     fun `toggle favorite updates repository`() = runBlocking {
         val repository = FakeFavoritesRepository()
-        val toggleUseCase = ToggleFavoriteUseCase(repository)
-        val observeUseCase = ObserveFavoritesUseCase(repository)
+        val firebaseController = FakeFirebaseController()
+        val toggleUseCase = ToggleFavoriteUseCase(repository, firebaseController)
+        val observeUseCase = ObserveFavoritesUseCase(repository, firebaseController)
 
         observeUseCase().test {
             assertThat(awaitItem()).isEmpty()
@@ -44,7 +46,7 @@ class FavoritesUseCasesTest {
     @Test
     fun `toggle favorite use case invokes repository exactly once`() = runTest {
         val repository = RecordingFavoritesRepository()
-        val useCase = ToggleFavoriteUseCase(repository)
+        val useCase = ToggleFavoriteUseCase(repository, FakeFirebaseController())
 
         val result = useCase("pkg")
 
@@ -59,7 +61,7 @@ class FavoritesUseCasesTest {
         runTest {
             val expectedFlow = flowOf(setOf("pkg"))
             val repository = RecordingFavoritesRepository(observeResult = expectedFlow)
-            val useCase = ObserveFavoritesUseCase(repository)
+            val useCase = ObserveFavoritesUseCase(repository, FakeFirebaseController())
 
             val result = useCase()
 

--- a/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModelBase.kt
+++ b/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/TestAppsListViewModelBase.kt
@@ -37,11 +37,11 @@ open class TestAppsListViewModelBase {
     ) {
         println("\uD83E\uDDEA [SETUP] Initial favorites: $initialFavorites")
         val developerAppsRepository = FakeDeveloperAppsRepository(fetchApps, fetchError)
-        val fetchUseCase = FetchDeveloperAppsUseCase(developerAppsRepository)
+        val fetchUseCase = FetchDeveloperAppsUseCase(developerAppsRepository, firebaseController)
         val favoritesRepository =
             FakeFavoritesRepository(initialFavorites, favoritesFlow, toggleError)
-        val observeFavoritesUseCase = ObserveFavoritesUseCase(favoritesRepository)
-        val toggleFavoriteUseCase = ToggleFavoriteUseCase(favoritesRepository)
+        val observeFavoritesUseCase = ObserveFavoritesUseCase(favoritesRepository, firebaseController)
+        val toggleFavoriteUseCase = ToggleFavoriteUseCase(favoritesRepository, firebaseController)
         viewModel = AppsListViewModel(
             fetchUseCase,
             observeFavoritesUseCase,

--- a/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/usecases/FetchDeveloperAppsUseCaseTest.kt
+++ b/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/usecases/FetchDeveloperAppsUseCaseTest.kt
@@ -4,6 +4,7 @@ import com.d4rk.android.apps.apptoolkit.app.apps.common.domain.model.AppInfo
 import com.d4rk.android.apps.apptoolkit.app.apps.common.domain.repository.DeveloperAppsRepository
 import com.d4rk.android.apps.apptoolkit.app.apps.common.domain.usecases.FetchDeveloperAppsUseCase
 import com.d4rk.android.apps.apptoolkit.core.domain.model.network.AppErrors
+import com.d4rk.android.apps.apptoolkit.core.utils.FakeFirebaseController
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Errors
 import io.mockk.every
@@ -40,7 +41,7 @@ class FetchDeveloperAppsUseCaseTest {
         val repository = mockk<DeveloperAppsRepository> {
             every { fetchDeveloperApps() } returns repositoryEmissions.asFlow()
         }
-        val useCase = FetchDeveloperAppsUseCase(repository)
+        val useCase = FetchDeveloperAppsUseCase(repository, FakeFirebaseController())
 
         val result = useCase().toList()
 
@@ -59,7 +60,7 @@ class FetchDeveloperAppsUseCaseTest {
         val repository = mockk<DeveloperAppsRepository> {
             every { fetchDeveloperApps() } returns flow { throw exception }
         }
-        val useCase = FetchDeveloperAppsUseCase(repository)
+        val useCase = FetchDeveloperAppsUseCase(repository, FakeFirebaseController())
 
         val thrown = assertFailsWith<IllegalStateException> {
             useCase().toList()

--- a/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainViewModelTest.kt
+++ b/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainViewModelTest.kt
@@ -54,13 +54,14 @@ class MainViewModelTest {
         )
 
         val repo = FakeNavigationRepository(flowOf(expectedItems))
-        val useCase = GetNavigationDrawerItemsUseCase(repo)
+        val firebaseController = FakeFirebaseController()
+        val useCase = GetNavigationDrawerItemsUseCase(repo, firebaseController)
         val dispatchers = TestDispatchers(dispatcherExtension.testDispatcher)
 
         MainViewModel(
             getNavigationDrawerItemsUseCase = useCase,
-            requestConsentUseCase = RequestConsentUseCase(FakeConsentRepository()),
-            firebaseController = FakeFirebaseController(),
+            requestConsentUseCase = RequestConsentUseCase(FakeConsentRepository(), firebaseController),
+            firebaseController = firebaseController,
             dispatchers = dispatchers,
         )
 
@@ -83,13 +84,14 @@ class MainViewModelTest {
             )
 
             val repo = FakeNavigationRepository(flowOf(expectedItems))
-            val useCase = GetNavigationDrawerItemsUseCase(repo)
+            val firebaseController = FakeFirebaseController()
+            val useCase = GetNavigationDrawerItemsUseCase(repo, firebaseController)
             val dispatchers = TestDispatchers(dispatcherExtension.testDispatcher)
 
             val viewModel = MainViewModel(
                 getNavigationDrawerItemsUseCase = useCase,
-                requestConsentUseCase = RequestConsentUseCase(FakeConsentRepository()),
-                firebaseController = FakeFirebaseController(),
+                requestConsentUseCase = RequestConsentUseCase(FakeConsentRepository(), firebaseController),
+                firebaseController = firebaseController,
                 dispatchers = dispatchers,
             )
 
@@ -111,13 +113,14 @@ class MainViewModelTest {
         val repo = FakeNavigationRepository(
             upstream = flow { throw error }
         )
-        val useCase = GetNavigationDrawerItemsUseCase(repo)
+        val firebaseController = FakeFirebaseController()
+        val useCase = GetNavigationDrawerItemsUseCase(repo, firebaseController)
         val dispatchers = TestDispatchers(dispatcherExtension.testDispatcher)
 
         val viewModel = MainViewModel(
             getNavigationDrawerItemsUseCase = useCase,
-            requestConsentUseCase = RequestConsentUseCase(FakeConsentRepository()),
-            firebaseController = FakeFirebaseController(),
+            requestConsentUseCase = RequestConsentUseCase(FakeConsentRepository(), firebaseController),
+            firebaseController = firebaseController,
             dispatchers = dispatchers,
         )
 
@@ -140,11 +143,12 @@ class MainViewModelTest {
     @Test
     fun `empty navigation list shows snackbar`() = runTest(dispatcherExtension.testDispatcher) {
         val repo = FakeNavigationRepository(flowOf(emptyList()))
-        val useCase = GetNavigationDrawerItemsUseCase(repo)
+        val firebaseController = FakeFirebaseController()
+        val useCase = GetNavigationDrawerItemsUseCase(repo, firebaseController)
         val viewModel = MainViewModel(
             useCase,
-            RequestConsentUseCase(FakeConsentRepository()),
-            FakeFirebaseController(),
+            RequestConsentUseCase(FakeConsentRepository(), firebaseController),
+            firebaseController,
             TestDispatchers(dispatcherExtension.testDispatcher)
         )
 

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/about/data/repository/AboutRepositoryImpl.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/about/data/repository/AboutRepositoryImpl.kt
@@ -8,6 +8,7 @@ import com.d4rk.android.libs.apptoolkit.app.about.domain.model.CopyDeviceInfoRes
 import com.d4rk.android.libs.apptoolkit.app.about.domain.repository.AboutRepository
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.AboutSettingsProvider
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoProvider
+import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
 import com.d4rk.android.libs.apptoolkit.core.logging.CLIPBOARD_HELPER_LOG_TAG
 import com.d4rk.android.libs.apptoolkit.core.utils.extensions.context.copyTextToClipboard
 
@@ -20,6 +21,7 @@ class AboutRepositoryImpl(
     private val deviceProvider: AboutSettingsProvider,
     private val buildInfoProvider: BuildInfoProvider,
     private val context: Context,
+    private val firebaseController: FirebaseController,
     private val sdkIntProvider: () -> Int = { Build.VERSION.SDK_INT },
 ) : AboutRepository {
 
@@ -31,6 +33,10 @@ class AboutRepositoryImpl(
         )
 
     override fun copyDeviceInfo(label: String, deviceInfo: String): CopyDeviceInfoResult {
+        firebaseController.logBreadcrumb(
+            message = "Copy device info requested",
+            attributes = mapOf("label" to label),
+        )
         val allowFeedback = sdkIntProvider() <= Build.VERSION_CODES.S_V2
         var shouldShowFeedback = false
         val copied = runCatching {

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/about/domain/usecases/CopyDeviceInfoUseCase.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/about/domain/usecases/CopyDeviceInfoUseCase.kt
@@ -4,6 +4,7 @@ import com.d4rk.android.libs.apptoolkit.app.about.domain.model.CopyDeviceInfoRes
 import com.d4rk.android.libs.apptoolkit.app.about.domain.repository.AboutRepository
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Errors
+import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
@@ -15,13 +16,23 @@ import kotlinx.coroutines.flow.flow
  *
  * @property repository The repository used to perform the copy operation.
  */
-class CopyDeviceInfoUseCase(private val repository: AboutRepository) {
+class CopyDeviceInfoUseCase(
+    private val repository: AboutRepository,
+    private val firebaseController: FirebaseController,
+) {
 
     operator fun invoke(
         label: String,
         deviceInfo: String,
     ): Flow<DataState<CopyDeviceInfoResult, Errors>> =
         flow {
+            firebaseController.logBreadcrumb(
+                message = "Copy device info started",
+                attributes = mapOf(
+                    "label" to label,
+                    "deviceInfoLength" to deviceInfo.length.toString(),
+                ),
+            )
             val result = runCatching {
                 repository.copyDeviceInfo(
                     label = label,

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/about/domain/usecases/GetAboutInfoUseCase.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/about/domain/usecases/GetAboutInfoUseCase.kt
@@ -4,6 +4,7 @@ import com.d4rk.android.libs.apptoolkit.app.about.domain.model.AboutInfo
 import com.d4rk.android.libs.apptoolkit.app.about.domain.repository.AboutRepository
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Errors
+import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
@@ -15,9 +16,16 @@ import kotlinx.coroutines.flow.flow
  *
  * @property repository The repository instance used to fetch the about information.
  */
-class GetAboutInfoUseCase(private val repository: AboutRepository) {
+class GetAboutInfoUseCase(
+    private val repository: AboutRepository,
+    private val firebaseController: FirebaseController,
+) {
 
     operator fun invoke(): Flow<DataState<AboutInfo, Errors>> = flow {
+        firebaseController.logBreadcrumb(
+            message = "About info load started",
+            attributes = mapOf("source" to "GetAboutInfoUseCase"),
+        )
         val info = repository.getAboutInfo()
         emit(DataState.Success(info))
     }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/about/ui/AboutViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/about/ui/AboutViewModel.kt
@@ -61,10 +61,18 @@ open class AboutViewModel(
     private var copyJob: Job? = null
 
     init {
+        firebaseController.logBreadcrumb(
+            message = "AboutViewModel initialized",
+            attributes = mapOf("screen" to "About"),
+        )
         onEvent(AboutEvent.Load)
     }
 
     override fun onEvent(event: AboutEvent) {
+        firebaseController.logBreadcrumb(
+            message = "AboutViewModel event",
+            attributes = mapOf("event" to event::class.java.simpleName),
+        )
         when (event) {
             is AboutEvent.Load -> loadAboutInfo()
             is AboutEvent.CopyDeviceInfo -> copyDeviceInfo(event.label)
@@ -73,6 +81,10 @@ open class AboutViewModel(
     }
 
     private fun loadAboutInfo() {
+        firebaseController.logBreadcrumb(
+            message = "About info load started",
+            attributes = mapOf("source" to "AboutViewModel"),
+        )
         loadJob?.cancel()
         loadJob = getAboutInfo()
             .flowOn(dispatchers.io)
@@ -99,6 +111,10 @@ open class AboutViewModel(
     }
 
     private fun copyDeviceInfo(label: String) {
+        firebaseController.logBreadcrumb(
+            message = "About copy device info",
+            attributes = mapOf("label" to label),
+        )
         val deviceInfo = screenData?.deviceInfo.orEmpty()
         if (deviceInfo.isBlank()) {
             screenState.showSnackbar(

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/ads/data/repository/AdsSettingsRepositoryImpl.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/ads/data/repository/AdsSettingsRepositoryImpl.kt
@@ -3,8 +3,10 @@ package com.d4rk.android.libs.apptoolkit.app.ads.data.repository
 import com.d4rk.android.libs.apptoolkit.app.ads.domain.repository.AdsSettingsRepository
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoProvider
 import com.d4rk.android.libs.apptoolkit.core.domain.model.Result
+import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
 import com.d4rk.android.libs.apptoolkit.data.local.datastore.CommonDataStore
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.onStart
 
 /**
  * Concrete implementation of [AdsSettingsRepository].
@@ -20,14 +22,25 @@ import kotlinx.coroutines.flow.Flow
 class AdsSettingsRepositoryImpl(
     private val dataStore: CommonDataStore,
     buildInfoProvider: BuildInfoProvider,
+    private val firebaseController: FirebaseController,
 ) : AdsSettingsRepository {
 
     override val defaultAdsEnabled: Boolean = !buildInfoProvider.isDebugBuild
 
     override fun observeAdsEnabled(): Flow<Boolean> =
         dataStore.ads(default = defaultAdsEnabled)
+            .onStart {
+                firebaseController.logBreadcrumb(
+                    message = "Ads settings observe",
+                    attributes = mapOf("defaultAdsEnabled" to defaultAdsEnabled.toString()),
+                )
+            }
 
     override suspend fun setAdsEnabled(enabled: Boolean): Result<Unit> {
+        firebaseController.logBreadcrumb(
+            message = "Ads settings updated",
+            attributes = mapOf("enabled" to enabled.toString()),
+        )
         dataStore.saveAds(isChecked = enabled)
         return Result.Success(Unit)
     }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/ads/domain/usecases/ObserveAdsEnabledUseCase.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/ads/domain/usecases/ObserveAdsEnabledUseCase.kt
@@ -1,11 +1,22 @@
 package com.d4rk.android.libs.apptoolkit.app.ads.domain.usecases
 
 import com.d4rk.android.libs.apptoolkit.app.ads.domain.repository.AdsSettingsRepository
+import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.onStart
 
 /**
  * Exposes a stream of the ads-enabled flag from the repository.
  */
-class ObserveAdsEnabledUseCase(private val repo: AdsSettingsRepository) {
+class ObserveAdsEnabledUseCase(
+    private val repo: AdsSettingsRepository,
+    private val firebaseController: FirebaseController,
+) {
     operator fun invoke(): Flow<Boolean> = repo.observeAdsEnabled()
+        .onStart {
+            firebaseController.logBreadcrumb(
+                message = "Observe ads enabled started",
+                attributes = mapOf("source" to "ObserveAdsEnabledUseCase"),
+            )
+        }
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/ads/domain/usecases/SetAdsEnabledUseCase.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/ads/domain/usecases/SetAdsEnabledUseCase.kt
@@ -2,6 +2,7 @@ package com.d4rk.android.libs.apptoolkit.app.ads.domain.usecases
 
 import com.d4rk.android.libs.apptoolkit.app.ads.domain.repository.AdsSettingsRepository
 import com.d4rk.android.libs.apptoolkit.core.domain.model.Result
+import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
 
 /**
  * A use case for setting the enabled state of advertisements.
@@ -12,6 +13,15 @@ import com.d4rk.android.libs.apptoolkit.core.domain.model.Result
  *
  * @property repo The repository responsible for handling ad settings persistence.
  */
-class SetAdsEnabledUseCase(private val repo: AdsSettingsRepository) {
-    suspend operator fun invoke(enabled: Boolean): Result<Unit> = repo.setAdsEnabled(enabled)
+class SetAdsEnabledUseCase(
+    private val repo: AdsSettingsRepository,
+    private val firebaseController: FirebaseController,
+) {
+    suspend operator fun invoke(enabled: Boolean): Result<Unit> {
+        firebaseController.logBreadcrumb(
+            message = "Set ads enabled",
+            attributes = mapOf("enabled" to enabled.toString()),
+        )
+        return repo.setAdsEnabled(enabled)
+    }
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/ads/ui/AdsSettingsViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/ads/ui/AdsSettingsViewModel.kt
@@ -69,10 +69,18 @@ class AdsSettingsViewModel(
     private var consentJob: Job? = null
 
     init {
+        firebaseController.logBreadcrumb(
+            message = "AdsSettingsViewModel initialized",
+            attributes = mapOf("screen" to "AdsSettings"),
+        )
         onEvent(event = AdsSettingsEvent.Initialize)
     }
 
     override fun onEvent(event: AdsSettingsEvent) {
+        firebaseController.logBreadcrumb(
+            message = "AdsSettingsViewModel event",
+            attributes = mapOf("event" to event::class.java.simpleName),
+        )
         when (event) {
             is AdsSettingsEvent.Initialize -> observe()
             is AdsSettingsEvent.SetAdsEnabled -> persist(enabled = event.enabled)
@@ -95,6 +103,10 @@ class AdsSettingsViewModel(
      * The entire flow is launched within the `viewModelScope`.
      */
     private fun observe() {
+        firebaseController.logBreadcrumb(
+            message = "Ads settings observe started",
+            attributes = mapOf("source" to "AdsSettingsViewModel"),
+        )
         observeJob?.cancel()
         observeJob = observeAdsEnabled()
             .flowOn(dispatchers.io)
@@ -153,6 +165,10 @@ class AdsSettingsViewModel(
      * @param enabled A boolean indicating whether ads should be enabled (`true`) or disabled (`false`).
      */
     private fun persist(enabled: Boolean) {
+        firebaseController.logBreadcrumb(
+            message = "Ads settings persist",
+            attributes = mapOf("enabled" to enabled.toString()),
+        )
         persistJob?.cancel()
 
         var previousValue = repository.defaultAdsEnabled
@@ -231,6 +247,10 @@ class AdsSettingsViewModel(
             }
 
     private fun requestConsent(host: ConsentHost) {
+        firebaseController.logBreadcrumb(
+            message = "Ads consent request",
+            attributes = mapOf("host" to host.activity::class.java.name),
+        )
         consentJob?.cancel()
         consentJob = requestConsentUseCase(host = host, showIfRequired = false)
             .flowOn(dispatchers.main)

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/advanced/data/repository/CacheRepositoryImpl.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/advanced/data/repository/CacheRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.d4rk.android.libs.apptoolkit.app.advanced.data.repository
 import android.content.Context
 import com.d4rk.android.libs.apptoolkit.app.advanced.domain.repository.CacheRepository
 import com.d4rk.android.libs.apptoolkit.core.domain.model.Result
+import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import java.io.File
@@ -15,9 +16,14 @@ import java.io.File
  */
 class CacheRepositoryImpl(
     private val context: Context,
+    private val firebaseController: FirebaseController,
 ) : CacheRepository {
 
     override fun clearCache(): Flow<Result<Unit>> = flow {
+        firebaseController.logBreadcrumb(
+            message = "Cache clear requested",
+            attributes = mapOf("source" to "CacheRepositoryImpl"),
+        )
         val cacheDirs: List<File> = buildList {
             add(context.cacheDir)
             add(context.codeCacheDir)

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/advanced/ui/AdvancedSettingsViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/advanced/ui/AdvancedSettingsViewModel.kt
@@ -50,6 +50,10 @@ class AdvancedSettingsViewModel(
 ) {
 
     override fun onEvent(event: AdvancedSettingsEvent) {
+        firebaseController.logBreadcrumb(
+            message = "AdvancedSettingsViewModel event",
+            attributes = mapOf("event" to event::class.java.simpleName),
+        )
         when (event) {
             AdvancedSettingsEvent.ClearCache -> clearCache()
             AdvancedSettingsEvent.MessageShown -> onMessageShown()
@@ -65,6 +69,10 @@ class AdvancedSettingsViewModel(
      * to the user. It also handles potential exceptions during the flow execution.
      */
     private fun clearCache() {
+        firebaseController.logBreadcrumb(
+            message = "Advanced settings clear cache",
+            attributes = mapOf("source" to "AdvancedSettingsViewModel"),
+        )
         generalJob?.cancel()
 
         generalJob = repository.clearCache()

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/consent/domain/usecases/RequestConsentUseCase.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/consent/domain/usecases/RequestConsentUseCase.kt
@@ -4,13 +4,16 @@ import com.d4rk.android.libs.apptoolkit.app.consent.domain.model.ConsentHost
 import com.d4rk.android.libs.apptoolkit.app.consent.domain.repository.ConsentRepository
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Errors
+import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.onStart
 
 /**
  * Emits consent-loading results as a [Flow] so callers can react to loading, success, or errors.
  */
 class RequestConsentUseCase(
     private val repository: ConsentRepository,
+    private val firebaseController: FirebaseController,
 ) {
 
     operator fun invoke(
@@ -20,6 +23,14 @@ class RequestConsentUseCase(
         return repository.requestConsent(
             host = host,
             showIfRequired = showIfRequired,
-        )
+        ).onStart {
+            firebaseController.logBreadcrumb(
+                message = "Consent request started",
+                attributes = mapOf(
+                    "host" to host.activity::class.java.name,
+                    "showIfRequired" to showIfRequired.toString(),
+                ),
+            )
+        }
     }
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/diagnostics/ui/UsageAndDiagnosticsViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/diagnostics/ui/UsageAndDiagnosticsViewModel.kt
@@ -55,10 +55,18 @@ class UsageAndDiagnosticsViewModel(
 ) {
 
     init {
+        firebaseController.logBreadcrumb(
+            message = "UsageAndDiagnosticsViewModel initialized",
+            attributes = mapOf("screen" to "UsageAndDiagnostics"),
+        )
         observeConsents()
     }
 
     override fun onEvent(event: UsageAndDiagnosticsEvent) {
+        firebaseController.logBreadcrumb(
+            message = "UsageAndDiagnosticsViewModel event",
+            attributes = mapOf("event" to event::class.java.simpleName),
+        )
         when (event) {
             is UsageAndDiagnosticsEvent.SetUsageAndDiagnostics -> updateUsageAndDiagnostics(event.enabled)
             is UsageAndDiagnosticsEvent.SetAnalyticsConsent -> updateAnalyticsConsent(event.granted)
@@ -71,6 +79,10 @@ class UsageAndDiagnosticsViewModel(
     }
 
     private fun observeConsents() {
+        firebaseController.logBreadcrumb(
+            message = "Usage diagnostics observe started",
+            attributes = mapOf("source" to "UsageAndDiagnosticsViewModel"),
+        )
         repository.observeSettings()
             .onStart { screenState.setLoading() }
             .map<UsageAndDiagnosticsSettings, DataState<UsageAndDiagnosticsSettings, Errors>> { settings ->
@@ -109,22 +121,42 @@ class UsageAndDiagnosticsViewModel(
     }
 
     private fun updateUsageAndDiagnostics(enabled: Boolean) {
+        firebaseController.logBreadcrumb(
+            message = "Usage diagnostics toggle",
+            attributes = mapOf("enabled" to enabled.toString()),
+        )
         viewModelScope.launch { repository.setUsageAndDiagnostics(enabled) }
     }
 
     private fun updateAnalyticsConsent(granted: Boolean) {
+        firebaseController.logBreadcrumb(
+            message = "Analytics consent toggle",
+            attributes = mapOf("granted" to granted.toString()),
+        )
         viewModelScope.launch { repository.setAnalyticsConsent(granted) }
     }
 
     private fun updateAdStorageConsent(granted: Boolean) {
+        firebaseController.logBreadcrumb(
+            message = "Ad storage consent toggle",
+            attributes = mapOf("granted" to granted.toString()),
+        )
         viewModelScope.launch { repository.setAdStorageConsent(granted) }
     }
 
     private fun updateAdUserDataConsent(granted: Boolean) {
+        firebaseController.logBreadcrumb(
+            message = "Ad user data consent toggle",
+            attributes = mapOf("granted" to granted.toString()),
+        )
         viewModelScope.launch { repository.setAdUserDataConsent(granted) }
     }
 
     private fun updateAdPersonalizationConsent(granted: Boolean) {
+        firebaseController.logBreadcrumb(
+            message = "Ad personalization consent toggle",
+            attributes = mapOf("granted" to granted.toString()),
+        )
         viewModelScope.launch { repository.setAdPersonalizationConsent(granted) }
     }
 

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/help/data/repository/FaqRepositoryImpl.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/help/data/repository/FaqRepositoryImpl.kt
@@ -8,6 +8,7 @@ import com.d4rk.android.libs.apptoolkit.app.help.domain.model.FaqItem
 import com.d4rk.android.libs.apptoolkit.app.help.domain.repository.FaqRepository
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Errors
+import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
 import com.d4rk.android.libs.apptoolkit.core.utils.extensions.errors.toError
 import com.d4rk.android.libs.apptoolkit.core.utils.extensions.result.runSuspendCatching
 import kotlinx.coroutines.flow.Flow
@@ -30,9 +31,17 @@ class FaqRepositoryImpl(
     private val remoteDataSource: HelpRemoteDataSource,
     private val catalogUrl: String,
     private val productId: String,
+    private val firebaseController: FirebaseController,
 ) : FaqRepository {
 
     override fun fetchFaq(): Flow<DataState<List<FaqItem>, Errors>> = flow {
+        firebaseController.logBreadcrumb(
+            message = "FAQ repository fetch",
+            attributes = mapOf(
+                "catalogUrl" to catalogUrl,
+                "productId" to productId,
+            ),
+        )
         val remoteResult: Result<List<FaqItem>> = runSuspendCatching {
             fetchRemoteFaqItems()
         }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/help/domain/usecases/GetFaqUseCase.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/help/domain/usecases/GetFaqUseCase.kt
@@ -4,15 +4,24 @@ import com.d4rk.android.libs.apptoolkit.app.help.domain.model.FaqItem
 import com.d4rk.android.libs.apptoolkit.app.help.domain.repository.FaqRepository
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Errors
+import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
 
 class GetFaqUseCase(
     private val repository: FaqRepository,
+    private val firebaseController: FirebaseController,
 ) {
 
     operator fun invoke(): Flow<DataState<List<FaqItem>, Errors>> {
         return repository.fetchFaq()
+            .onStart {
+                firebaseController.logBreadcrumb(
+                    message = "FAQ fetch started",
+                    attributes = mapOf("source" to "GetFaqUseCase"),
+                )
+            }
             .map { result ->
                 when (result) {
                     is DataState.Success -> {

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpViewModel.kt
@@ -43,10 +43,18 @@ class HelpViewModel(
 ) {
 
     init {
+        firebaseController.logBreadcrumb(
+            message = "HelpViewModel initialized",
+            attributes = mapOf("screen" to "Help"),
+        )
         onEvent(event = HelpEvent.LoadFaq)
     }
 
     override fun onEvent(event: HelpEvent) {
+        firebaseController.logBreadcrumb(
+            message = "HelpViewModel event",
+            attributes = mapOf("event" to event::class.java.simpleName),
+        )
         when (event) {
             is HelpEvent.LoadFaq -> loadFaq()
             is HelpEvent.DismissSnackbar -> screenState.dismissSnackbar()
@@ -54,6 +62,10 @@ class HelpViewModel(
     }
 
     private fun loadFaq() {
+        firebaseController.logBreadcrumb(
+            message = "Help FAQ load started",
+            attributes = mapOf("source" to "HelpViewModel"),
+        )
         generalJob?.cancel()
         generalJob = getFaqUseCase()
             .flowOn(context = dispatchers.io)

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/issuereporter/data/repository/IssueReporterRepositoryImpl.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/issuereporter/data/repository/IssueReporterRepositoryImpl.kt
@@ -7,11 +7,13 @@ import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.Report
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.github.GithubTarget
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.repository.IssueReporterRepository
 import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
+import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
 import kotlinx.coroutines.withContext
 
 class IssueReporterRepositoryImpl(
     private val remoteDataSource: IssueReporterRemoteDataSource,
     private val dispatchers: DispatcherProvider,
+    private val firebaseController: FirebaseController,
 ) : IssueReporterRepository {
 
     override suspend fun sendReport(
@@ -19,6 +21,13 @@ class IssueReporterRepositoryImpl(
         target: GithubTarget,
         token: String?,
     ): IssueReportResult = withContext(dispatchers.io) {
+        firebaseController.logBreadcrumb(
+            message = "Issue report sending",
+            attributes = mapOf(
+                "targetRepo" to target.repository,
+                "hasToken" to (!token.isNullOrBlank()).toString(),
+            ),
+        )
         val payload = report.toCreateIssueRequest()
         remoteDataSource.createIssue(
             payload = payload,

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/issuereporter/domain/usecases/SendIssueReportUseCase.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/issuereporter/domain/usecases/SendIssueReportUseCase.kt
@@ -5,6 +5,7 @@ import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.Report
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.github.GithubTarget
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.repository.IssueReporterRepository
 import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
+import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
 import io.ktor.http.HttpStatusCode
 import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.flow.Flow
@@ -15,6 +16,7 @@ import kotlinx.coroutines.flow.flowOn
 class SendIssueReportUseCase(
     private val repository: IssueReporterRepository,
     private val dispatchers: DispatcherProvider,
+    private val firebaseController: FirebaseController,
 ) {
 
     data class Params(
@@ -25,6 +27,13 @@ class SendIssueReportUseCase(
 
     operator fun invoke(param: Params): Flow<IssueReportResult> =
         flow {
+            firebaseController.logBreadcrumb(
+                message = "Issue report send started",
+                attributes = mapOf(
+                    "targetRepo" to param.target.repository,
+                    "hasToken" to (!param.token.isNullOrBlank()).toString(),
+                ),
+            )
             val result = repository.sendReport(param.report, param.target, param.token)
             emit(result)
         }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/IssueReporterViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/IssueReporterViewModel.kt
@@ -51,6 +51,10 @@ class IssueReporterViewModel(
     )
 ) {
     override fun onEvent(event: IssueReporterEvent) {
+        firebaseController.logBreadcrumb(
+            message = "IssueReporterViewModel event",
+            attributes = mapOf("event" to event::class.java.simpleName),
+        )
         when (event) {
             is IssueReporterEvent.UpdateTitle -> update { it.copy(title = event.value) }
             is IssueReporterEvent.UpdateDescription -> update { it.copy(description = event.value) }
@@ -72,6 +76,14 @@ class IssueReporterViewModel(
 
         if (generalJob?.isActive == true) return
 
+        firebaseController.logBreadcrumb(
+            message = "Issue report send requested",
+            attributes = mapOf(
+                "hasTitle" to data.title.isNotBlank().toString(),
+                "hasDescription" to data.description.isNotBlank().toString(),
+                "anonymous" to data.anonymous.toString(),
+            ),
+        )
         if (data.title.isBlank() || data.description.isBlank()) {
             screenState.showSnackbar(
                 snackbar = UiSnackbar(

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/data/repository/OnboardingRepositoryImpl.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/data/repository/OnboardingRepositoryImpl.kt
@@ -2,20 +2,33 @@ package com.d4rk.android.libs.apptoolkit.app.onboarding.data.repository
 
 import com.d4rk.android.libs.apptoolkit.app.onboarding.data.local.OnboardingPreferencesDataSource
 import com.d4rk.android.libs.apptoolkit.app.onboarding.domain.repository.OnboardingRepository
+import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
 
 class OnboardingRepositoryImpl(
     private val dataStore: OnboardingPreferencesDataSource,
+    private val firebaseController: FirebaseController,
 ) : OnboardingRepository {
 
     override fun observeOnboardingCompletion(): Flow<Boolean> =
         dataStore.startup
             .map { isFirstTime -> !isFirstTime }
             .distinctUntilChanged()
+            .onStart {
+                firebaseController.logBreadcrumb(
+                    message = "Onboarding completion observe",
+                    attributes = mapOf("source" to "OnboardingRepositoryImpl"),
+                )
+            }
 
     override suspend fun setOnboardingCompleted() {
+        firebaseController.logBreadcrumb(
+            message = "Onboarding completion updated",
+            attributes = mapOf("completed" to "true"),
+        )
         dataStore.saveStartup(isFirstTime = false)
     }
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/domain/usecases/CompleteOnboardingUseCase.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/domain/usecases/CompleteOnboardingUseCase.kt
@@ -1,12 +1,18 @@
 package com.d4rk.android.libs.apptoolkit.app.onboarding.domain.usecases
 
 import com.d4rk.android.libs.apptoolkit.app.onboarding.domain.repository.OnboardingRepository
+import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
 
 class CompleteOnboardingUseCase(
     private val repository: OnboardingRepository,
+    private val firebaseController: FirebaseController,
 ) {
 
     suspend operator fun invoke() {
+        firebaseController.logBreadcrumb(
+            message = "Complete onboarding",
+            attributes = mapOf("source" to "CompleteOnboardingUseCase"),
+        )
         repository.setOnboardingCompleted()
     }
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/domain/usecases/ObserveOnboardingCompletionUseCase.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/domain/usecases/ObserveOnboardingCompletionUseCase.kt
@@ -1,11 +1,20 @@
 package com.d4rk.android.libs.apptoolkit.app.onboarding.domain.usecases
 
 import com.d4rk.android.libs.apptoolkit.app.onboarding.domain.repository.OnboardingRepository
+import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.onStart
 
 class ObserveOnboardingCompletionUseCase(
     private val repository: OnboardingRepository,
+    private val firebaseController: FirebaseController,
 ) {
 
     operator fun invoke(): Flow<Boolean> = repository.observeOnboardingCompletion()
+        .onStart {
+            firebaseController.logBreadcrumb(
+                message = "Observe onboarding completion started",
+                attributes = mapOf("source" to "ObserveOnboardingCompletionUseCase"),
+            )
+        }
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingViewModel.kt
@@ -41,10 +41,18 @@ class OnboardingViewModel(
     private var consentJob: Job? = null
 
     init {
+        firebaseController.logBreadcrumb(
+            message = "OnboardingViewModel initialized",
+            attributes = mapOf("screen" to "Onboarding"),
+        )
         observeCompletion()
     }
 
     override fun onEvent(event: OnboardingEvent) {
+        firebaseController.logBreadcrumb(
+            message = "OnboardingViewModel event",
+            attributes = mapOf("event" to event::class.java.simpleName),
+        )
         when (event) {
             is OnboardingEvent.UpdateCurrentTab -> updateCurrentTab(event.index)
             is OnboardingEvent.CompleteOnboarding -> completeOnboarding()
@@ -55,6 +63,10 @@ class OnboardingViewModel(
     }
 
     private fun observeCompletion() {
+        firebaseController.logBreadcrumb(
+            message = "Observe onboarding completion",
+            attributes = mapOf("source" to "OnboardingViewModel"),
+        )
         observeCompletionJob?.cancel()
         observeCompletionJob = observeOnboardingCompletionUseCase()
             .flowOn(dispatchers.io)
@@ -78,6 +90,10 @@ class OnboardingViewModel(
     }
 
     private fun completeOnboarding() {
+        firebaseController.logBreadcrumb(
+            message = "Complete onboarding requested",
+            attributes = mapOf("source" to "OnboardingViewModel"),
+        )
         completeJob?.cancel()
         completeJob = flow<DataState<Unit, Errors.UseCase>> {
             emit(DataState.Loading())
@@ -109,6 +125,10 @@ class OnboardingViewModel(
     }
 
     private fun requestConsent(host: ConsentHost) {
+        firebaseController.logBreadcrumb(
+            message = "Onboarding consent requested",
+            attributes = mapOf("host" to host.activity::class.java.name),
+        )
         consentJob?.cancel()
         consentJob = requestConsentUseCase(host = host)
             .flowOn(dispatchers.main)

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/permissions/data/repository/PermissionsRepositoryImpl.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/permissions/data/repository/PermissionsRepositoryImpl.kt
@@ -7,6 +7,7 @@ import com.d4rk.android.libs.apptoolkit.app.settings.settings.domain.model.Setti
 import com.d4rk.android.libs.apptoolkit.app.settings.settings.domain.model.SettingsConfig
 import com.d4rk.android.libs.apptoolkit.app.settings.settings.domain.model.SettingsPreference
 import com.d4rk.android.libs.apptoolkit.core.di.DispatcherProvider
+import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
@@ -18,10 +19,15 @@ import kotlinx.coroutines.flow.flowOn
 class PermissionsRepositoryImpl(
     private val context: Context,
     private val dispatchers: DispatcherProvider,
+    private val firebaseController: FirebaseController,
 ) : PermissionsRepository {
 
     override fun getPermissionsConfig(): Flow<SettingsConfig> =
         flow {
+            firebaseController.logBreadcrumb(
+                message = "Permissions config requested",
+                attributes = mapOf("source" to "PermissionsRepositoryImpl"),
+            )
             emit(
                 SettingsConfig(
                     title = context.getString(R.string.permissions),

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/permissions/ui/PermissionsViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/permissions/ui/PermissionsViewModel.kt
@@ -51,12 +51,20 @@ class PermissionsViewModel(
     ) {
 
     override fun onEvent(event: PermissionsEvent) {
+        firebaseController.logBreadcrumb(
+            message = "PermissionsViewModel event",
+            attributes = mapOf("event" to event::class.java.simpleName),
+        )
         when (event) {
             PermissionsEvent.Load -> loadPermissions()
         }
     }
 
     private fun loadPermissions() {
+        firebaseController.logBreadcrumb(
+            message = "Permissions load started",
+            attributes = mapOf("source" to "PermissionsViewModel"),
+        )
         viewModelScope.launch {
             permissionsRepository.getPermissionsConfig()
                 .map<SettingsConfig, DataState<SettingsConfig, Errors>> { config ->

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/general/data/repository/GeneralSettingsRepositoryImpl.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/general/data/repository/GeneralSettingsRepositoryImpl.kt
@@ -1,12 +1,19 @@
 package com.d4rk.android.libs.apptoolkit.app.settings.general.data.repository
 
 import com.d4rk.android.libs.apptoolkit.app.settings.general.domain.repository.GeneralSettingsRepository
+import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
-class GeneralSettingsRepositoryImpl : GeneralSettingsRepository {
+class GeneralSettingsRepositoryImpl(
+    private val firebaseController: FirebaseController,
+) : GeneralSettingsRepository {
 
     override fun getContentKey(contentKey: String?): Flow<String> = flow {
+        firebaseController.logBreadcrumb(
+            message = "General settings content requested",
+            attributes = mapOf("hasContentKey" to (!contentKey.isNullOrBlank()).toString()),
+        )
         val key = contentKey?.takeIf { it.isNotBlank() }
             ?: throw IllegalArgumentException("Invalid content key")
         emit(key)

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/GeneralSettingsViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/GeneralSettingsViewModel.kt
@@ -41,12 +41,20 @@ class GeneralSettingsViewModel(
 ) {
 
     override fun onEvent(event: GeneralSettingsEvent) {
+        firebaseController.logBreadcrumb(
+            message = "GeneralSettingsViewModel event",
+            attributes = mapOf("event" to event::class.java.simpleName),
+        )
         when (event) {
             is GeneralSettingsEvent.Load -> loadContent(contentKey = event.contentKey)
         }
     }
 
     private fun loadContent(contentKey: String?) {
+        firebaseController.logBreadcrumb(
+            message = "General settings load started",
+            attributes = mapOf("hasContentKey" to (!contentKey.isNullOrBlank()).toString()),
+        )
         generalJob?.cancel()
         generalJob = viewModelScope.launch {
             repository.getContentKey(contentKey)

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsViewModel.kt
@@ -56,12 +56,20 @@ class SettingsViewModel(
 ) {
 
     override fun onEvent(event: SettingsEvent) {
+        firebaseController.logBreadcrumb(
+            message = "SettingsViewModel event",
+            attributes = mapOf("event" to event::class.java.simpleName),
+        )
         when (event) {
             is SettingsEvent.Load -> loadSettings(context = event.context)
         }
     }
 
     private fun loadSettings(context: Context) {
+        firebaseController.logBreadcrumb(
+            message = "Settings load started",
+            attributes = mapOf("context" to context::class.java.name),
+        )
         viewModelScope.launch {
             flow {
                 val config = withContext(dispatchers.io) {

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupViewModel.kt
@@ -29,6 +29,10 @@ class StartupViewModel(
 ) {
 
     override fun onEvent(event: StartupEvent) {
+        firebaseController.logBreadcrumb(
+            message = "StartupViewModel event",
+            attributes = mapOf("event" to event::class.java.simpleName),
+        )
         when (event) {
             is StartupEvent.RequestConsent -> requestConsent(event.host)
             StartupEvent.ConsentFormLoaded -> screenState.updateData(

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportViewModel.kt
@@ -68,6 +68,10 @@ class SupportViewModel(
     private var billingTimeoutJob: Job? = null
 
     init {
+        firebaseController.logBreadcrumb(
+            message = "SupportViewModel initialized",
+            attributes = mapOf("screen" to "Support"),
+        )
         billingRepository.productDetails
             .onStart {
                 if (screenData?.donationOptions?.isNotEmpty() == true) {
@@ -203,6 +207,10 @@ class SupportViewModel(
     }
 
     override fun onEvent(event: SupportEvent) {
+        firebaseController.logBreadcrumb(
+            message = "SupportViewModel event",
+            attributes = mapOf("event" to event::class.java.simpleName),
+        )
         when (event) {
             is SupportEvent.QueryProductDetails -> queryProductDetails()
 
@@ -211,6 +219,13 @@ class SupportViewModel(
     }
 
     fun onDonateClicked(activity: Activity, productId: String) {
+        firebaseController.logBreadcrumb(
+            message = "Support donation clicked",
+            attributes = mapOf(
+                "productId" to productId,
+                "activity" to activity::class.java.name,
+            ),
+        )
         if (!activity.isValidForBilling()) {
             return
         }

--- a/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/app/about/ui/TestAboutViewModel.kt
+++ b/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/app/about/ui/TestAboutViewModel.kt
@@ -56,8 +56,8 @@ class TestAboutViewModel {
         val testDispatchers: DispatcherProvider = TestDispatchers(testDispatcher)
 
         return AboutViewModel(
-            getAboutInfo = GetAboutInfoUseCase(repository),
-            copyDeviceInfo = CopyDeviceInfoUseCase(repository),
+            getAboutInfo = GetAboutInfoUseCase(repository, firebaseController),
+            copyDeviceInfo = CopyDeviceInfoUseCase(repository, firebaseController),
             dispatchers = testDispatchers,
             firebaseController = firebaseController,
         )

--- a/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/app/ads/ui/TestAdsSettingsViewModel.kt
+++ b/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/app/ads/ui/TestAdsSettingsViewModel.kt
@@ -58,12 +58,12 @@ class TestAdsSettingsViewModel {
     }
 
     private fun createViewModel(repository: AdsSettingsRepository): AdsSettingsViewModel {
-        val observeUseCase = ObserveAdsEnabledUseCase(repository)
-        val setUseCase = SetAdsEnabledUseCase(repository)
+        val observeUseCase = ObserveAdsEnabledUseCase(repository, firebaseController)
+        val setUseCase = SetAdsEnabledUseCase(repository, firebaseController)
         return AdsSettingsViewModel(
             observeAdsEnabled = observeUseCase,
             setAdsEnabled = setUseCase,
-            requestConsentUseCase = RequestConsentUseCase(FakeConsentRepository()),
+            requestConsentUseCase = RequestConsentUseCase(FakeConsentRepository(), firebaseController),
             repository = repository,
             dispatchers = testDispatchers(),
             firebaseController = firebaseController,

--- a/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/app/consent/domain/usecases/RequestConsentUseCaseTest.kt
+++ b/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/app/consent/domain/usecases/RequestConsentUseCaseTest.kt
@@ -4,6 +4,7 @@ import com.d4rk.android.libs.apptoolkit.app.consent.domain.model.ConsentHost
 import com.d4rk.android.libs.apptoolkit.app.consent.domain.repository.ConsentRepository
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Errors
+import com.d4rk.android.libs.apptoolkit.core.utils.FakeFirebaseController
 import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
@@ -29,7 +30,10 @@ class RequestConsentUseCaseTest {
                 flowOf(DataState.Success(Unit))
         }
 
-        val useCase = RequestConsentUseCase(repository = repository)
+        val useCase = RequestConsentUseCase(
+            repository = repository,
+            firebaseController = FakeFirebaseController(),
+        )
         val result = useCase(host = host, showIfRequired = false).toList()
         val expected: List<DataState<Unit, Errors.UseCase>> = listOf(DataState.Success(Unit))
 

--- a/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpViewModelTest.kt
+++ b/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpViewModelTest.kt
@@ -51,7 +51,7 @@ class HelpViewModelTest {
                     )
             }
             val viewModel = HelpViewModel(
-                getFaqUseCase = GetFaqUseCase(repository),
+                getFaqUseCase = GetFaqUseCase(repository, firebaseController),
                 dispatchers = testDispatcherProvider(),
                 firebaseController = firebaseController,
             )
@@ -76,7 +76,7 @@ class HelpViewModelTest {
                 }
             }
             val viewModel = HelpViewModel(
-                getFaqUseCase = GetFaqUseCase(repository),
+                getFaqUseCase = GetFaqUseCase(repository, firebaseController),
                 dispatchers = testDispatcherProvider(),
                 firebaseController = firebaseController,
             )

--- a/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/app/issuereporter/domain/usecases/SendIssueReportUseCaseTest.kt
+++ b/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/app/issuereporter/domain/usecases/SendIssueReportUseCaseTest.kt
@@ -6,6 +6,7 @@ import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.github.Ex
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.github.GithubTarget
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.repository.IssueReporterRepository
 import com.d4rk.android.libs.apptoolkit.core.di.TestDispatchers
+import com.d4rk.android.libs.apptoolkit.core.utils.FakeFirebaseController
 import com.google.common.truth.Truth.assertThat
 import io.ktor.http.HttpStatusCode
 import io.mockk.coEvery
@@ -41,7 +42,7 @@ class SendIssueReportUseCaseTest {
             )
         } returns IssueReportResult.Success("url")
 
-        val useCase = SendIssueReportUseCase(repository, dispatchers)
+        val useCase = SendIssueReportUseCase(repository, dispatchers, FakeFirebaseController())
         val result = useCase(params).first()
 
         assertThat(result).isInstanceOf(IssueReportResult.Success::class.java)
@@ -53,7 +54,7 @@ class SendIssueReportUseCaseTest {
         val repository = mockk<IssueReporterRepository>()
         coEvery { repository.sendReport(any(), any(), any()) } throws IllegalStateException("boom")
 
-        val useCase = SendIssueReportUseCase(repository, dispatchers)
+        val useCase = SendIssueReportUseCase(repository, dispatchers, FakeFirebaseController())
         val result = useCase(params).first()
 
         assertThat(result).isInstanceOf(IssueReportResult.Error::class.java)
@@ -73,11 +74,10 @@ class SendIssueReportUseCaseTest {
             )
         } throws CancellationException("cancel")
 
-        val useCase = SendIssueReportUseCase(repository, dispatchers)
+        val useCase = SendIssueReportUseCase(repository, dispatchers, FakeFirebaseController())
 
         assertFailsWith<CancellationException> {
             useCase(params).first()
         }
     }
 }
-

--- a/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/TestOnboardingViewModel.kt
+++ b/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/TestOnboardingViewModel.kt
@@ -167,9 +167,12 @@ class TestOnboardingViewModel {
 
     private fun createViewModel(repository: OnboardingRepository): OnboardingViewModel =
         OnboardingViewModel(
-            observeOnboardingCompletionUseCase = ObserveOnboardingCompletionUseCase(repository),
-            completeOnboardingUseCase = CompleteOnboardingUseCase(repository),
-            requestConsentUseCase = RequestConsentUseCase(FakeConsentRepository()),
+            observeOnboardingCompletionUseCase = ObserveOnboardingCompletionUseCase(
+                repository,
+                firebaseController,
+            ),
+            completeOnboardingUseCase = CompleteOnboardingUseCase(repository, firebaseController),
+            requestConsentUseCase = RequestConsentUseCase(FakeConsentRepository(), firebaseController),
             dispatchers = TestDispatchers(testDispatcher = dispatcherExtension.testDispatcher),
             firebaseController = firebaseController,
         )

--- a/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupViewModelTest.kt
+++ b/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupViewModelTest.kt
@@ -33,10 +33,11 @@ class StartupViewModelTest {
 
     @Test
     fun `consent event updates state`() = runTest(dispatcherExtension.testDispatcher) {
+        val firebaseController = FakeFirebaseController()
         val viewModel = StartupViewModel(
-            requestConsentUseCase = RequestConsentUseCase(FakeConsentRepository()),
+            requestConsentUseCase = RequestConsentUseCase(FakeConsentRepository(), firebaseController),
             dispatchers = testDispatcherProvider(),
-            firebaseController = FakeFirebaseController(),
+            firebaseController = firebaseController,
         )
         viewModel.onEvent(StartupEvent.ConsentFormLoaded)
         val state = viewModel.uiState.value
@@ -46,10 +47,11 @@ class StartupViewModelTest {
 
     @Test
     fun `continue event emits navigation action`() = runTest(dispatcherExtension.testDispatcher) {
+        val firebaseController = FakeFirebaseController()
         val viewModel = StartupViewModel(
-            requestConsentUseCase = RequestConsentUseCase(FakeConsentRepository()),
+            requestConsentUseCase = RequestConsentUseCase(FakeConsentRepository(), firebaseController),
             dispatchers = testDispatcherProvider(),
-            firebaseController = FakeFirebaseController(),
+            firebaseController = firebaseController,
         )
         val actions = mutableListOf<StartupAction>()
         val job = launch { viewModel.actionEvent.collect { actions.add(it) } }
@@ -62,10 +64,11 @@ class StartupViewModelTest {
     @Test
     fun `request consent event completes startup state`() =
         runTest(dispatcherExtension.testDispatcher) {
+            val firebaseController = FakeFirebaseController()
             val viewModel = StartupViewModel(
-                requestConsentUseCase = RequestConsentUseCase(FakeConsentRepository()),
+                requestConsentUseCase = RequestConsentUseCase(FakeConsentRepository(), firebaseController),
                 dispatchers = testDispatcherProvider(),
-                firebaseController = FakeFirebaseController(),
+                firebaseController = firebaseController,
             )
 
             viewModel.onEvent(StartupEvent.RequestConsent(host = FakeConsentHost()))


### PR DESCRIPTION
### Motivation
- Improve debugging and reproduction by emitting Crashlytics breadcrumbs (`logBreadcrumb`) at key points in ViewModels, UseCases and Repository implementations so flows and user actions are visible in the Firebase console.
- The new breadcrumbs complement existing `reportViewModelError` calls to provide sequencing/context around errors and important lifecycle/actions.

### Description
- Inserted `firebaseController.logBreadcrumb(...)` calls in many ViewModels to log initialization, incoming events and notable user actions (examples: `SupportViewModel`, `AppsListViewModel`, `FavoriteAppsViewModel`, `MainViewModel`, `HelpViewModel`, `AboutViewModel`, `AdsSettingsViewModel`, `OnboardingViewModel`, `UsageAndDiagnosticsViewModel`, `AdvancedSettingsViewModel`, `IssueReporterViewModel`, `PermissionsViewModel`, `SettingsViewModel`, `StartupViewModel`).
- Propagated `FirebaseController` into domain and data layers and added breadcrumbs to use cases and repositories (examples: `GetFaqUseCase`, `RequestConsentUseCase`, `ObserveAdsEnabledUseCase`, `SetAdsEnabledUseCase`, `FetchDeveloperAppsUseCase`, `ObserveFavoritesUseCase`, `ToggleFavoriteUseCase`, `ObserveFavoriteAppsUseCase`, `GetNavigationDrawerItemsUseCase`, `IssueReporter` use/repo, `About` use/repo, `UsageAndDiagnosticsRepository`, `AdsSettingsRepositoryImpl`, `OnboardingRepositoryImpl`, etc.).
- Updated Koin DI wiring to provide the new `FirebaseController` dependencies where required and adjusted module factories to construct the modified classes.
- Updated unit tests and test helpers to pass a `FakeFirebaseController` where constructors changed so tests compile (several test files modified to inject fake controller).

### Testing
- Unit tests were updated to supply `FakeFirebaseController` to changed constructors but no automated test suite was executed as part of this change.
- Files modified include unit tests for apps list, favorites, ads settings, help, onboarding, startup, about and issue reporter to keep tests compiling after DI/use-case signature changes (these tests were prepared but not run).
- Manual verification steps were not performed in this change; CI/test execution was not requested.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d1a3f5ad0832d8b0d1271d121e688)