### PR TITLE
Generalize ThemePalettePager page handling

### DIFF
--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/views/pages/theme/ThemeOnboardingPageTab.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/views/pages/theme/ThemeOnboardingPageTab.kt
@@ -1,24 +1,38 @@
 package com.d4rk.android.libs.apptoolkit.app.onboarding.ui.views.pages.theme
 
+import android.os.Build
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.material.icons.filled.Palette
+import androidx.compose.material.icons.filled.Wallpaper
 import androidx.compose.foundation.selection.selectableGroup
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.BrightnessAuto
 import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.LightMode
+import androidx.compose.material3.ColorScheme
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.dynamicDarkColorScheme
+import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
@@ -26,27 +40,54 @@ import androidx.compose.ui.unit.sp
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.onboarding.domain.model.OnboardingThemeChoice
 import com.d4rk.android.libs.apptoolkit.app.onboarding.ui.views.pages.theme.cards.AmoledModeToggleCard
-import com.d4rk.android.libs.apptoolkit.app.onboarding.ui.views.pages.theme.cards.ThemeChoicePreviewCard
 import com.d4rk.android.libs.apptoolkit.app.onboarding.ui.views.pages.theme.previews.DarkModePreview
 import com.d4rk.android.libs.apptoolkit.app.onboarding.ui.views.pages.theme.previews.LightModePreview
 import com.d4rk.android.libs.apptoolkit.app.onboarding.ui.views.pages.theme.previews.SystemModePreview
+import com.d4rk.android.libs.apptoolkit.app.theme.domain.model.WallpaperSwatchColors
+import com.d4rk.android.libs.apptoolkit.app.theme.ui.dedupeStaticPaletteIds
+import com.d4rk.android.libs.apptoolkit.app.theme.ui.filterSeasonalStaticPalettes
+import com.d4rk.android.libs.apptoolkit.app.theme.ui.style.colors.ThemePaletteProvider.paletteById
+import com.d4rk.android.libs.apptoolkit.app.theme.ui.views.ThemePalettePreviewDots
+import com.d4rk.android.libs.apptoolkit.app.theme.ui.views.WallpaperColorOptionCard
+import com.d4rk.android.libs.apptoolkit.core.ui.views.cards.ThemeChoicePreviewCard
+import com.d4rk.android.libs.apptoolkit.core.ui.views.carousel.ThemePalettePager
 import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.LargeVerticalSpacer
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.colorscheme.DynamicPaletteVariant
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.colorscheme.StaticPaletteIds
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.datastore.DataStoreNamesConstants
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
+import com.d4rk.android.libs.apptoolkit.core.utils.extensions.colorscheme.applyDynamicVariant
 import com.d4rk.android.libs.apptoolkit.core.utils.extensions.datastore.rememberThemePreferencesState
+import com.d4rk.android.libs.apptoolkit.core.utils.extensions.date.isChristmasSeason
+import com.d4rk.android.libs.apptoolkit.core.utils.extensions.date.isHalloweenSeason
 import com.d4rk.android.libs.apptoolkit.data.local.datastore.rememberCommonDataStore
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import java.time.LocalDate
+import java.time.ZoneId
+
+private data class ThemePaletteChoice(
+    val index: Int,
+    val title: String,
+    val icon: androidx.compose.ui.graphics.vector.ImageVector,
+    val previewColors: WallpaperSwatchColors?,
+)
 
 @Composable
 fun ThemeOnboardingPageTab() {
     val coroutineScope: CoroutineScope = rememberCoroutineScope()
     val dataStore = rememberCommonDataStore()
     val themePreferences = rememberThemePreferencesState()
+    val context = LocalContext.current
 
     val defaultThemeModeKey: String = DataStoreNamesConstants.THEME_MODE_FOLLOW_SYSTEM
     val currentThemeMode: String = themePreferences.themeMode.ifBlank { defaultThemeModeKey }
     val isAmoledMode: Boolean = themePreferences.amoledMode
+    val isDynamicColors: Boolean = themePreferences.dynamicColors
+    val dynamicVariantIndex: Int = themePreferences.dynamicPaletteVariant
+    val staticPaletteId: String = themePreferences.staticPaletteId
+
+    val supportsDynamic = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S
 
     val isLightSelected = currentThemeMode == DataStoreNamesConstants.THEME_MODE_LIGHT
     val amoledAllowed = !isLightSelected
@@ -71,6 +112,86 @@ fun ThemeOnboardingPageTab() {
             description = stringResource(R.string.onboarding_theme_system_desc)
         )
     )
+
+    val isSystemInDarkThemeNow: Boolean = isSystemInDarkTheme()
+
+    val wallpaperPreviewScheme: ColorScheme? = remember(supportsDynamic, isSystemInDarkThemeNow) {
+        if (!supportsDynamic) null
+        else if (isSystemInDarkThemeNow) dynamicDarkColorScheme(context)
+        else dynamicLightColorScheme(context)
+    }
+
+    val variantSwatches: List<WallpaperSwatchColors> = remember(wallpaperPreviewScheme) {
+        val base = wallpaperPreviewScheme ?: return@remember emptyList()
+        DynamicPaletteVariant.indices.map { variant ->
+            val scheme = base.applyDynamicVariant(variant)
+            WallpaperSwatchColors(
+                primary = scheme.primary,
+                secondary = scheme.secondary,
+                tertiary = scheme.tertiaryContainer,
+            )
+        }
+    }
+
+    val isChristmasSeason: Boolean = remember {
+        LocalDate.now(ZoneId.systemDefault()).isChristmasSeason
+    }
+    val isHalloweenSeason: Boolean = remember {
+        LocalDate.now(ZoneId.systemDefault()).isHalloweenSeason
+    }
+
+    val staticOptions: List<String> = remember(
+        isChristmasSeason,
+        isHalloweenSeason,
+        staticPaletteId
+    ) {
+        val seasonalOptions = filterSeasonalStaticPalettes(
+            baseOptions = StaticPaletteIds.withDefault,
+            isChristmasSeason = isChristmasSeason,
+            isHalloweenSeason = isHalloweenSeason,
+            selectedPaletteId = staticPaletteId
+        )
+        dedupeStaticPaletteIds(
+            options = seasonalOptions,
+            selectedPaletteId = staticPaletteId
+        )
+    }
+
+    val staticSwatches: List<WallpaperSwatchColors> =
+        remember(staticOptions, isSystemInDarkThemeNow) {
+            staticOptions.map { id ->
+                val p = paletteById(id)
+                val scheme = if (isSystemInDarkThemeNow) p.darkColorScheme else p.lightColorScheme
+                WallpaperSwatchColors(scheme.primary, scheme.secondary, scheme.tertiary)
+            }
+        }
+
+    val paletteChoices = listOf(
+        ThemePaletteChoice(
+            index = 0,
+            title = stringResource(id = R.string.wallpaper_colors),
+            icon = Icons.Filled.Wallpaper,
+            previewColors = variantSwatches.firstOrNull(),
+        ),
+        ThemePaletteChoice(
+            index = 1,
+            title = stringResource(id = R.string.other_colors),
+            icon = Icons.Filled.Palette,
+            previewColors = staticSwatches.firstOrNull(),
+        ),
+    )
+
+    val initialPagerPage = if (supportsDynamic && isDynamicColors) 0 else 1
+    val pagerState = rememberPagerState(
+        initialPage = initialPagerPage,
+        pageCount = { 2 }
+    )
+
+    LaunchedEffect(initialPagerPage) {
+        if (pagerState.currentPage != initialPagerPage) {
+            pagerState.scrollToPage(initialPagerPage)
+        }
+    }
 
     Column(
         modifier = Modifier
@@ -105,7 +226,9 @@ fun ThemeOnboardingPageTab() {
         ) {
             themeChoices.forEach { choice ->
                 ThemeChoicePreviewCard(
-                    choice = choice,
+                    title = choice.displayName,
+                    description = choice.description,
+                    icon = choice.icon,
                     isSelected = currentThemeMode == choice.key,
                     onClick = {
                         coroutineScope.launch {
@@ -138,7 +261,121 @@ fun ThemeOnboardingPageTab() {
             }
         )
 
-        // TODO: Think 2-3 days for the colors implementation.
+        if (supportsDynamic) {
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .selectableGroup(),
+                horizontalArrangement = Arrangement.spacedBy(SizeConstants.MediumSize),
+            ) {
+                paletteChoices.forEach { choice ->
+                    ThemeChoicePreviewCard(
+                        title = choice.title,
+                        description = null,
+                        icon = choice.icon,
+                        isSelected = pagerState.currentPage == choice.index,
+                        onClick = {
+                            coroutineScope.launch {
+                                pagerState.animateScrollToPage(choice.index)
+                            }
+                        },
+                        modifier = Modifier.weight(1f),
+                        showPreview = choice.previewColors != null,
+                        preview = {
+                            choice.previewColors?.let { colors ->
+                                ThemePalettePreviewDots(colors = colors)
+                            }
+                        }
+                    )
+                }
+            }
+
+            ThemePalettePager(
+                pagerState = pagerState,
+                pages = listOf(
+                    {
+                        LazyRow(
+                            contentPadding = PaddingValues(horizontal = SizeConstants.LargeSize),
+                            horizontalArrangement = Arrangement.spacedBy(
+                                space = SizeConstants.MediumSize,
+                                alignment = Alignment.CenterHorizontally
+                            )
+                        ) {
+                            itemsIndexed(
+                                items = variantSwatches,
+                                key = { index, _ -> index }
+                            ) { index, palette ->
+                                WallpaperColorOptionCard(
+                                    colors = palette,
+                                    selected = isDynamicColors && index == dynamicVariantIndex,
+                                    onClick = {
+                                        coroutineScope.launch {
+                                            dataStore.saveDynamicColors(true)
+                                            dataStore.saveDynamicPaletteVariant(index)
+                                        }
+                                    }
+                                )
+                            }
+                        }
+                    },
+                    {
+                        LazyRow(
+                            contentPadding = PaddingValues(horizontal = SizeConstants.LargeSize),
+                            horizontalArrangement = Arrangement.spacedBy(
+                                space = SizeConstants.MediumSize,
+                                alignment = Alignment.CenterHorizontally
+                            )
+                        ) {
+                            itemsIndexed(
+                                items = staticOptions,
+                                key = { _, id -> id }
+                            ) { index, id ->
+                                WallpaperColorOptionCard(
+                                    colors = staticSwatches[index],
+                                    selected = !isDynamicColors && id == staticPaletteId,
+                                    showSeasonalBadge = (isChristmasSeason && id == StaticPaletteIds.CHRISTMAS) ||
+                                            (isHalloweenSeason && id == StaticPaletteIds.HALLOWEEN),
+                                    onClick = {
+                                        coroutineScope.launch {
+                                            dataStore.saveDynamicColors(false)
+                                            dataStore.saveStaticPaletteId(id)
+                                        }
+                                    }
+                                )
+                            }
+                        }
+                    },
+                ),
+                modifier = Modifier.fillMaxWidth(),
+            )
+        } else {
+            LazyRow(
+                contentPadding = PaddingValues(horizontal = SizeConstants.LargeSize),
+                horizontalArrangement = Arrangement.spacedBy(
+                    space = SizeConstants.MediumSize,
+                    alignment = Alignment.CenterHorizontally
+                )
+            ) {
+                itemsIndexed(
+                    items = staticOptions,
+                    key = { _, id -> id }
+                ) { index, id ->
+                    WallpaperColorOptionCard(
+                        colors = staticSwatches[index],
+                        selected = id == staticPaletteId,
+                        showSeasonalBadge = (isChristmasSeason && id == StaticPaletteIds.CHRISTMAS) ||
+                                (isHalloweenSeason && id == StaticPaletteIds.HALLOWEEN),
+                        onClick = {
+                            coroutineScope.launch {
+                                dataStore.saveDynamicColors(false)
+                                dataStore.saveStaticPaletteId(id)
+                            }
+                        }
+                    )
+                }
+            }
+        }
+
         Spacer(modifier = Modifier.height(SizeConstants.ExtraTinySize))
     }
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/theme/ui/PaletteOptions.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/theme/ui/PaletteOptions.kt
@@ -1,0 +1,30 @@
+package com.d4rk.android.libs.apptoolkit.app.theme.ui
+
+import com.d4rk.android.libs.apptoolkit.app.theme.ui.style.colors.ThemePaletteProvider.paletteById
+
+/**
+ * Returns a list of static palette IDs with duplicate palettes removed.
+ *
+ * When the injected default palette matches a built-in palette (e.g., blue), the list would
+ * otherwise show visually identical swatches twice. This helper keeps the selected palette ID
+ * while removing duplicates, so the UI reflects the effective palette without redundancy.
+ */
+internal fun dedupeStaticPaletteIds(
+    options: List<String>,
+    selectedPaletteId: String
+): List<String> {
+    val resolvedPalettes = options.associateWith { paletteById(it) }
+    val uniqueIds = mutableListOf<String>()
+
+    for (id in options) {
+        val palette = resolvedPalettes.getValue(id)
+        val existingIndex = uniqueIds.indexOfFirst { resolvedPalettes.getValue(it) == palette }
+        if (existingIndex == -1) {
+            uniqueIds.add(id)
+        } else if (id == selectedPaletteId && uniqueIds[existingIndex] != selectedPaletteId) {
+            uniqueIds[existingIndex] = id
+        }
+    }
+
+    return uniqueIds
+}

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/theme/ui/views/ThemePalettePreviewDots.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/theme/ui/views/ThemePalettePreviewDots.kt
@@ -1,0 +1,44 @@
+package com.d4rk.android.libs.apptoolkit.app.theme.ui.views
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import com.d4rk.android.libs.apptoolkit.app.theme.domain.model.WallpaperSwatchColors
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
+
+/**
+ * Renders a compact dot-based preview for a palette choice.
+ */
+@Composable
+fun ThemePalettePreviewDots(
+    colors: WallpaperSwatchColors,
+    modifier: Modifier = Modifier,
+) {
+    Row(
+        modifier = modifier,
+        horizontalArrangement = Arrangement.spacedBy(SizeConstants.ExtraTinySize),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        ThemePaletteDot(color = colors.primary)
+        ThemePaletteDot(color = colors.secondary)
+        ThemePaletteDot(color = colors.tertiary)
+    }
+}
+
+@Composable
+private fun ThemePaletteDot(color: Color) {
+    Box(
+        modifier = Modifier
+            .size(SizeConstants.LargeSize)
+            .clip(RoundedCornerShape(SizeConstants.LargeSize))
+            .background(color = color)
+    )
+}

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/cards/ThemeChoicePreviewCard.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/cards/ThemeChoicePreviewCard.kt
@@ -1,4 +1,4 @@
-package com.d4rk.android.libs.apptoolkit.app.onboarding.ui.views.pages.theme.cards
+package com.d4rk.android.libs.apptoolkit.core.ui.views.cards
 
 import android.view.SoundEffectConstants
 import android.view.View
@@ -43,14 +43,21 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
-import com.d4rk.android.libs.apptoolkit.app.onboarding.domain.model.OnboardingThemeChoice
 import com.d4rk.android.libs.apptoolkit.core.ui.views.modifiers.bounceClick
 import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.ExtraSmallVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 
+/**
+ * Displays a selectable theme choice card with optional preview content and description.
+ *
+ * This composable is shared across onboarding and settings screens to keep theme selection
+ * interactions consistent.
+ */
 @Composable
 fun ThemeChoicePreviewCard(
-    choice: OnboardingThemeChoice,
+    title: String,
+    description: String?,
+    icon: androidx.compose.ui.graphics.vector.ImageVector,
     isSelected: Boolean,
     onClick: () -> Unit,
     modifier: Modifier = Modifier,
@@ -143,8 +150,8 @@ fun ThemeChoicePreviewCard(
                         contentAlignment = Alignment.Center
                     ) {
                         Icon(
-                            imageVector = choice.icon,
-                            contentDescription = choice.displayName,
+                            imageVector = icon,
+                            contentDescription = title,
                             tint = iconTint,
                             modifier = Modifier
                                 .size(SizeConstants.LargeSize + SizeConstants.SmallSize)
@@ -177,7 +184,7 @@ fun ThemeChoicePreviewCard(
         Spacer(modifier = Modifier.height(SizeConstants.SmallSize))
 
         Text(
-            text = choice.displayName,
+            text = title,
             style = MaterialTheme.typography.titleMedium.copy(fontWeight = FontWeight.SemiBold),
             color = MaterialTheme.colorScheme.onSurface,
             textAlign = TextAlign.Center,
@@ -186,16 +193,18 @@ fun ThemeChoicePreviewCard(
             modifier = Modifier.fillMaxWidth()
         )
 
-        Spacer(modifier = Modifier.height(SizeConstants.ExtraTinySize))
+        if (!description.isNullOrBlank()) {
+            Spacer(modifier = Modifier.height(SizeConstants.ExtraTinySize))
 
-        Text(
-            text = choice.description,
-            style = MaterialTheme.typography.bodySmall,
-            color = MaterialTheme.colorScheme.onSurfaceVariant,
-            textAlign = TextAlign.Center,
-            maxLines = 2,
-            overflow = TextOverflow.Ellipsis,
-            modifier = Modifier.fillMaxWidth()
-        )
+            Text(
+                text = description,
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+                textAlign = TextAlign.Center,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+                modifier = Modifier.fillMaxWidth()
+            )
+        }
     }
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/carousel/ThemePalettePager.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/carousel/ThemePalettePager.kt
@@ -1,0 +1,26 @@
+package com.d4rk.android.libs.apptoolkit.core.ui.views.carousel
+
+import androidx.compose.foundation.pager.HorizontalPager
+import androidx.compose.foundation.pager.PagerState
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+/**
+ * A horizontal pager used for theme palette selection.
+ *
+ * This shared container keeps onboarding and settings aligned on the same paging behavior
+ * while allowing each screen to supply its own page content.
+ */
+@Composable
+fun ThemePalettePager(
+    pagerState: PagerState,
+    pages: List<@Composable () -> Unit>,
+    modifier: Modifier = Modifier,
+) {
+    HorizontalPager(
+        state = pagerState,
+        modifier = modifier,
+    ) { page ->
+        pages.getOrNull(page)?.invoke()
+    }
+}


### PR DESCRIPTION
### Motivation
- Unify pager behavior for theme palette selection so onboarding and settings use the same paging pattern and avoid duplicated branching logic. 
- Make the pager more flexible and explicit at call sites by letting callers provide an ordered list of page composables instead of fixed dynamic/static slots. 

### Description
- Replace the two-slot API with a list-based API by changing `ThemePalettePager(pagerState, dynamicPalettePage, staticPalettePage)` to `ThemePalettePager(pagerState, pages: List<@Composable () -> Unit>)` and invoke pages by index. 
- Update call sites in `ThemeSettingsList.kt` and `ThemeOnboardingPageTab.kt` to pass explicit `pages = listOf({ /* wallpaper */ }, { /* static */ })` and align pager initialization (`rememberPagerState` + `LaunchedEffect`) for consistent initial page behavior. 
- Move and generalize the preview card into `core` as `ThemeChoicePreviewCard` with a simplified API (`title`, `description`, `icon`, preview slot) and add `ThemePalettePreviewDots` for compact palette previews. 
- Add `PaletteOptions.kt` with `dedupeStaticPaletteIds` and add local `ThemePaletteChoice` data structures to keep palette metadata consistent across screens; small readability/indentation cleanups were applied to the updated files. 
- Change rationale: previously the pager implementation contained hard-coded branching for two slots which duplicated logic across screens; switching to a list-based API centralizes the pager logic and keeps page ordering explicit at callers, improving maintainability and consistency.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697facbaf8a0832d84f68600b5ac1f7e)