### PR TITLE
Use mutex-protected `updateStateThreadSafe` for ViewModel UI state updates

### DIFF
--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsViewModel.kt
@@ -33,6 +33,9 @@ import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.withContext
 
+/**
+ * ViewModel for the favorites list screen.
+ */
 class FavoriteAppsViewModel(
     private val observeFavoriteAppsUseCase: ObserveFavoriteAppsUseCase,
     observeFavoritesUseCase: ObserveFavoritesUseCase,

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsViewModel.kt
@@ -112,7 +112,11 @@ class FavoriteAppsViewModel(
 
                 }
                 .catchReport(action = Actions.OBSERVE_FAVORITES) {
-                    screenState.setError(message = UiTextHelper.StringResource(R.string.error_failed_to_load_apps))
+                    updateStateThreadSafe {
+                        screenState.setError(
+                            message = UiTextHelper.StringResource(R.string.error_failed_to_load_apps)
+                        )
+                    }
                 }
                 .launchIn(viewModelScope)
         }

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListViewModel.kt
@@ -116,7 +116,9 @@ class AppsListViewModel(
                         }
                 }
                 .catchReport(action = Actions.OBSERVE_FETCH) {
-                    showLoadAppsError()
+                    updateStateThreadSafe {
+                        showLoadAppsError()
+                    }
                 }
                 .onEach { result ->
                     result
@@ -159,9 +161,11 @@ class AppsListViewModel(
                     withContext(dispatchers.io) { toggleFavoriteUseCase(packageName) }
                 },
                 onError = {
-                    screenState.setError(
-                        message = UiTextHelper.StringResource(R.string.error_failed_to_update_favorite),
-                    )
+                    updateStateThreadSafe {
+                        screenState.setError(
+                            message = UiTextHelper.StringResource(R.string.error_failed_to_update_favorite),
+                        )
+                    }
                 },
             )
         }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/about/ui/AboutViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/about/ui/AboutViewModel.kt
@@ -29,6 +29,9 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 
+/**
+ * ViewModel for the About screen, including device info sharing.
+ */
 open class AboutViewModel(
     private val getAboutInfo: GetAboutInfoUseCase,
     private val copyDeviceInfo: CopyDeviceInfoUseCase,
@@ -50,11 +53,7 @@ open class AboutViewModel(
         when (event) {
             is AboutEvent.Load -> loadAboutInfo()
             is AboutEvent.CopyDeviceInfo -> copyDeviceInfo(label = event.label)
-            is AboutEvent.DismissSnackbar -> viewModelScope.launch {
-                updateStateThreadSafe {
-                    screenState.dismissSnackbar()
-                }
-            }
+            is AboutEvent.DismissSnackbar -> dismissSnackbar()
         }
     }
 
@@ -166,6 +165,14 @@ open class AboutViewModel(
                     }
                 }
                 .launchIn(viewModelScope)
+        }
+    }
+
+    private fun dismissSnackbar() {
+        viewModelScope.launch {
+            updateStateThreadSafe {
+                screenState.dismissSnackbar()
+            }
         }
     }
 

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/about/ui/AboutViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/about/ui/AboutViewModel.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.launch
 
 /**
  * ViewModel for the About screen, including device info sharing.

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/ads/ui/AdsSettingsViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/ads/ui/AdsSettingsViewModel.kt
@@ -178,7 +178,11 @@ class AdsSettingsViewModel(
                     action = Actions.REQUEST_CONSENT,
                     extra = mapOf(ExtraKeys.HOST to host.activity::class.java.name)
                 ) {
-                    screenState.showSnackbar(errorSnackbar(Errors.UseCase.FAILED_TO_LOAD_CONSENT_INFO.asUiText()))
+                    updateStateThreadSafe {
+                        screenState.showSnackbar(
+                            errorSnackbar(Errors.UseCase.FAILED_TO_LOAD_CONSENT_INFO.asUiText())
+                        )
+                    }
                 }
                 .launchIn(viewModelScope)
         }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/ads/ui/AdsSettingsViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/ads/ui/AdsSettingsViewModel.kt
@@ -35,6 +35,9 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 
+/**
+ * ViewModel for ads settings and consent interaction.
+ */
 class AdsSettingsViewModel(
     private val observeAdsEnabled: ObserveAdsEnabledUseCase,
     private val setAdsEnabled: SetAdsEnabledUseCase,

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/advanced/ui/AdvancedSettingsViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/advanced/ui/AdvancedSettingsViewModel.kt
@@ -27,6 +27,9 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 
+/**
+ * ViewModel for advanced settings actions such as cache clearing.
+ */
 class AdvancedSettingsViewModel(
     private val repository: CacheRepository,
     private val dispatchers: DispatcherProvider,

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/advanced/ui/AdvancedSettingsViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/advanced/ui/AdvancedSettingsViewModel.kt
@@ -94,7 +94,11 @@ class AdvancedSettingsViewModel(
     }
 
     private fun onMessageShown() {
-        screenState.copyData { copy(cacheClearMessage = null) }
+        viewModelScope.launch {
+            updateStateThreadSafe {
+                screenState.copyData { copy(cacheClearMessage = null) }
+            }
+        }
     }
 
     private object Actions {

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/advanced/ui/AdvancedSettingsViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/advanced/ui/AdvancedSettingsViewModel.kt
@@ -26,6 +26,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.launch
 
 /**
  * ViewModel for advanced settings actions such as cache clearing.

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpViewModel.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.launch
 
 /**
  * ViewModel for the FAQ/help screen.

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/help/ui/HelpViewModel.kt
@@ -29,6 +29,9 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 
+/**
+ * ViewModel for the FAQ/help screen.
+ */
 class HelpViewModel(
     private val getFaqUseCase: GetFaqUseCase,
     private val dispatchers: DispatcherProvider,
@@ -47,11 +50,7 @@ class HelpViewModel(
     override fun handleEvent(event: HelpEvent) {
         when (event) {
             is HelpEvent.LoadFaq -> loadFaq()
-            is HelpEvent.DismissSnackbar -> viewModelScope.launch {
-                updateStateThreadSafe {
-                    screenState.dismissSnackbar()
-                }
-            }
+            is HelpEvent.DismissSnackbar -> dismissSnackbar()
         }
     }
 
@@ -91,6 +90,14 @@ class HelpViewModel(
                     }
                 }
                 .launchIn(scope = viewModelScope)
+        }
+    }
+
+    private fun dismissSnackbar() {
+        viewModelScope.launch {
+            updateStateThreadSafe {
+                screenState.dismissSnackbar()
+            }
         }
     }
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/IssueReporterViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/IssueReporterViewModel.kt
@@ -36,6 +36,9 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Error as RootError
 
+/**
+ * ViewModel for composing and sending issue reports.
+ */
 class IssueReporterViewModel(
     private val sendIssueReport: SendIssueReportUseCase,
     private val githubTarget: GithubTarget,
@@ -56,15 +59,35 @@ class IssueReporterViewModel(
 
     override fun handleEvent(event: IssueReporterEvent) {
         when (event) {
-            is IssueReporterEvent.UpdateTitle -> updateForm { copy(title = event.value) }
-            is IssueReporterEvent.UpdateDescription -> updateForm { copy(description = event.value) }
-            is IssueReporterEvent.UpdateEmail -> updateForm { copy(email = event.value) }
-            is IssueReporterEvent.SetAnonymous -> updateForm { copy(anonymous = event.anonymous) }
+            is IssueReporterEvent.UpdateTitle -> updateTitle(event.value)
+            is IssueReporterEvent.UpdateDescription -> updateDescription(event.value)
+            is IssueReporterEvent.UpdateEmail -> updateEmail(event.value)
+            is IssueReporterEvent.SetAnonymous -> updateAnonymous(event.anonymous)
             is IssueReporterEvent.Send -> sendReport()
-            is IssueReporterEvent.DismissSnackbar -> viewModelScope.launch {
-                updateStateThreadSafe {
-                    screenState.dismissSnackbar()
-                }
+            is IssueReporterEvent.DismissSnackbar -> dismissSnackbar()
+        }
+    }
+
+    private fun updateTitle(value: String) {
+        updateForm { copy(title = value) }
+    }
+
+    private fun updateDescription(value: String) {
+        updateForm { copy(description = value) }
+    }
+
+    private fun updateEmail(value: String) {
+        updateForm { copy(email = value) }
+    }
+
+    private fun updateAnonymous(anonymous: Boolean) {
+        updateForm { copy(anonymous = anonymous) }
+    }
+
+    private fun dismissSnackbar() {
+        viewModelScope.launch {
+            updateStateThreadSafe {
+                screenState.dismissSnackbar()
             }
         }
     }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/IssueReporterViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/IssueReporterViewModel.kt
@@ -34,6 +34,7 @@ import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Error as RootError
 
 /**

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingViewModel.kt
@@ -17,6 +17,7 @@ import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
 /**

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingViewModel.kt
@@ -19,6 +19,9 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.withContext
 
+/**
+ * ViewModel for the onboarding flow, including completion and consent requests.
+ */
 class OnboardingViewModel(
     private val observeOnboardingCompletionUseCase: ObserveOnboardingCompletionUseCase,
     private val completeOnboardingUseCase: CompleteOnboardingUseCase,

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingViewModel.kt
@@ -70,7 +70,11 @@ class OnboardingViewModel(
     }
 
     private fun updateCurrentTab(index: Int) {
-        screenState.copyData { copy(currentTabIndex = index) }
+        viewModelScope.launch {
+            updateStateThreadSafe {
+                screenState.copyData { copy(currentTabIndex = index) }
+            }
+        }
     }
 
     private fun completeOnboarding() {
@@ -115,7 +119,11 @@ class OnboardingViewModel(
     }
 
     private fun setCrashlyticsDialogVisibility(isVisible: Boolean) {
-        screenState.copyData { copy(isCrashlyticsDialogVisible = isVisible) }
+        viewModelScope.launch {
+            updateStateThreadSafe {
+                screenState.copyData { copy(isCrashlyticsDialogVisible = isVisible) }
+            }
+        }
     }
 
     private object Actions {

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/GeneralSettingsViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/GeneralSettingsViewModel.kt
@@ -28,6 +28,7 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.launch
 
 /**
  * ViewModel that loads and validates general settings content by key.

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/GeneralSettingsViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/GeneralSettingsViewModel.kt
@@ -56,8 +56,18 @@ class GeneralSettingsViewModel(
 
         if (!hasKey) {
             observeJob?.cancel()
-            screenState.setErrors(errors = listOf(UiSnackbar(message = UiTextHelper.StringResource(R.string.error_invalid_content_key))))
-            screenState.updateState(ScreenState.NoData())
+            viewModelScope.launch {
+                updateStateThreadSafe {
+                    screenState.setErrors(
+                        errors = listOf(
+                            UiSnackbar(
+                                message = UiTextHelper.StringResource(R.string.error_invalid_content_key)
+                            )
+                        )
+                    )
+                    screenState.updateState(ScreenState.NoData())
+                }
+            }
             return
         }
 

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/GeneralSettingsViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/GeneralSettingsViewModel.kt
@@ -29,6 +29,9 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 
+/**
+ * ViewModel that loads and validates general settings content by key.
+ */
 class GeneralSettingsViewModel(
     private val repository: GeneralSettingsRepository,
     private val dispatchers: DispatcherProvider,

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupViewModel.kt
@@ -49,7 +49,9 @@ class StartupViewModel(
             requestConsentUseCase.invoke(host = host)
                 .flowOn(dispatchers.main)
                 .onStart {
-                    screenState.setLoading()
+                    updateStateThreadSafe {
+                        screenState.setLoading()
+                    }
                 }
                 .catchReport(
                     action = Actions.REQUEST_CONSENT,
@@ -68,7 +70,11 @@ class StartupViewModel(
     }
 
     private fun markConsentFormLoaded() {
-        screenState.successData { copy(consentFormLoaded = true) }
+        viewModelScope.launch {
+            updateStateThreadSafe {
+                screenState.successData { copy(consentFormLoaded = true) }
+            }
+        }
     }
 
     private object Actions {

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupViewModel.kt
@@ -20,6 +20,11 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 
+/**
+ * ViewModel for the startup screen.
+ *
+ * Requests consent and triggers navigation when startup flow is complete.
+ */
 class StartupViewModel(
     private val requestConsentUseCase: RequestConsentUseCase,
     private val dispatchers: DispatcherProvider,

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupViewModel.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.launch
 
 /**
  * ViewModel for the startup screen.


### PR DESCRIPTION
### Motivation
- `BaseViewModel` added `stateMutex` and `updateStateThreadSafe`; previously many ViewModels performed direct `UiState` mutations from multiple coroutine contexts which can race.  
- The change aims to serialize UI state mutations to avoid lost updates and inconsistent screen state.  
- Where previous calls were non-suspending, wrapped updates in `viewModelScope.launch` so `updateStateThreadSafe` (suspending) can be used safely.  
- No Material 3/UX behavioral change; this is an internal safety/consistency improvement for screen state handling.

### Description
- Replaced direct state mutations with mutex-protected calls to `updateStateThreadSafe` across library and app sample viewmodels (notably `SupportViewModel`, `StartupViewModel`, `GeneralSettingsViewModel`, `OnboardingViewModel`, `IssueReporterViewModel`, `HelpViewModel`, `UsageAndDiagnosticsViewModel` flows, `AdvancedSettingsViewModel`, `AdsSettingsViewModel`, `AboutViewModel`, and sample `AppsListViewModel` / `FavoriteAppsViewModel`).
- For immediate/non-suspending handlers (e.g. snackbar dismissal, simple `copyData` updates), wrapped calls in `viewModelScope.launch` before invoking `updateStateThreadSafe` so suspension is allowed.  
- Hardened purchase/billing flows in `SupportViewModel` to set/reset billing progress and show snackbars inside `updateStateThreadSafe` to avoid interleaved updates.  
- Updated error/loading `onStart`/`catch`/`onEach` handlers to use `updateStateThreadSafe` where they previously mutated `screenState` directly.

### Testing
- No automated tests were executed for this patch (no unit or instrumentation tests run).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69807ef012f4832da76569e0d2a8e874)