### PR TITLE
Use `launchReport` for Support billing launch and document ViewModel rule

### DIFF
--- a/docs/viewmodels/viewmoel-rules-coroutines-flows-state.md
+++ b/docs/viewmodels/viewmoel-rules-coroutines-flows-state.md
@@ -199,6 +199,19 @@ When you receive a `DataState`, handle it using the provided extension functions
 * Use `onFailure { ... }` for error UI.
 * Use `onLoading { ... }` only when you need to reflect loading state during active emission.
 
+---
+
+## Rule 6: Use `launchReport` for one-off, non-Flow work
+
+When a ViewModel needs to trigger a one-off operation that is not modeled as a `Flow`, use
+`launchReport` instead of ad-hoc `viewModelScope.launch` + `runCatching`.
+
+This keeps Firebase breadcrumbs, analytics, and error reporting consistent while ensuring errors
+are handled in one place.
+
+* Use `launchReport` for fire-and-forget work (e.g., billing launch, toggles without a `Flow`).
+* Reserve `viewModelScope.launch` for local UI state updates only.
+
 ### Example
 
 ```kotlin


### PR DESCRIPTION
### Motivation

- Replace ad-hoc `viewModelScope.launch` + `runCatching` in billing launch with the centralized `launchReport` helper to keep analytics, breadcrumbs and error reporting consistent and to follow the ViewModel rule against `runCatching` usage. 
- Make the expectation explicit in the docs by adding a rule that ViewModels should use `launchReport` for one-off non-`Flow` work so future changes follow the same pattern.

### Description

- Updated `SupportViewModel` to add a dedicated `billingLaunchJob` and replace the previous `viewModelScope.launch { ... runCatching { ... } }` with `billingLaunchJob.restart { launchReport(...) }`, preserving billing progress state, timeout handling and the existing error UI behavior. 
- Kept the `productDetails`, `purchaseResult` and other jobs unchanged; the support billing flow is now wired into `launchReport` with `ExtraKeys.ACTIVITY` set to the host class name. 
- Documented the pattern in `docs/viewmodels/viewmoel-rules-coroutines-flows-state.md` by adding a new Rule 6 titled "Use `launchReport` for one-off, non-Flow work" and guidance to prefer `launchReport` over ad-hoc `runCatching` in ViewModels. 
- Performed a scan of other ViewModels referenced in the rollout and found they already follow the intended patterns, so no further code changes were required.

### Testing

- No automated tests were executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698103690d70832d93577c75fc125ff9)