### PR TITLE
Add theme settings section headers and complete localization

### DIFF
--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/theme/ui/ThemeSettingsList.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/theme/ui/ThemeSettingsList.kt
@@ -25,6 +25,8 @@ import androidx.compose.material.icons.filled.Contrast
 import androidx.compose.material.icons.filled.DarkMode
 import androidx.compose.material.icons.filled.LightMode
 import androidx.compose.material3.ColorScheme
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SegmentedButton
 import androidx.compose.material3.SegmentedButtonDefaults
 import androidx.compose.material3.SingleChoiceSegmentedButtonRow
@@ -41,6 +43,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.onboarding.ui.views.pages.theme.previews.DarkModePreview
 import com.d4rk.android.libs.apptoolkit.app.onboarding.ui.views.pages.theme.previews.LightModePreview
@@ -236,6 +239,19 @@ fun ThemeSettingsList(paddingValues: PaddingValues) {
                 )
             }
 
+            item {
+                HorizontalDivider(modifier = Modifier.padding(all = SizeConstants.SmallSize))
+            }
+
+            item {
+                Text(
+                    modifier = Modifier.padding(horizontal = SizeConstants.LargeSize),
+                    text = stringResource(id = R.string.color_palette),
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+
             if (supportsDynamic) {
                 item {
                     SingleChoiceSegmentedButtonRow(
@@ -404,6 +420,19 @@ fun ThemeSettingsList(paddingValues: PaddingValues) {
                         }
                     }
                 }
+            }
+
+            item {
+                HorizontalDivider(modifier = Modifier.padding(all = SizeConstants.SmallSize))
+            }
+
+            item {
+                Text(
+                    modifier = Modifier.padding(horizontal = SizeConstants.LargeSize),
+                    text = stringResource(id = R.string.theme_mode),
+                    style = MaterialTheme.typography.titleLarge,
+                    fontWeight = FontWeight.SemiBold,
+                )
             }
 
             item {

--- a/apptoolkit/src/main/res/values-ar-rEG/strings.xml
+++ b/apptoolkit/src/main/res/values-ar-rEG/strings.xml
@@ -99,6 +99,8 @@
     <string name="follow_system">اتباع وضع النظام</string>
     <string name="light_mode">الوضع الفاتح</string>
     <string name="dark_mode">الوضع الداكن</string>
+    <string name="color_palette">لوحة الألوان</string>
+    <string name="theme_mode">وضع المظهر</string>
     <string name="summary_dark_theme">ﻲﻓ ﻚﻳﺪﻟ ﺔﻠﻀﻔﻤﻟﺍ ﺔﻤﺴﻟﺍ ﺩﺪﺣﻭ Android ﻡﺎﻈﻧ ﺮﻳﺪﻣ ﻰﻟﺇ ﻝﺎﻘﺘﻧﻻﺍ ﻯﻮﺳ ﻚﻴﻠﻋ ﺎﻣ ، ﻪﻠﻴﻌﻔﺘﻟ</string>
     <string name="screen_and_display_settings">.ﺽﺮﻌﻟﺍﻭ ﺔﺷﺎﺸﻟﺍ ﺕﺍﺩﺍﺪﻋﺇ</string>
 

--- a/apptoolkit/src/main/res/values-bg-rBG/strings.xml
+++ b/apptoolkit/src/main/res/values-bg-rBG/strings.xml
@@ -99,6 +99,8 @@
     <string name="follow_system">Следвай системния режим</string>
     <string name="light_mode">Светъл режим</string>
     <string name="dark_mode">Тъмен режим</string>
+    <string name="color_palette">Цветова палитра</string>
+    <string name="theme_mode">Режим на тема</string>
     <string name="summary_dark_theme">Тъмната тема използва дълбок фон, за да удължи значително живота на батерията ви. За да го активирате, просто отидете до системния мениджър на вашия Android и изберете предпочитаната от вас тема в</string>
     <string name="screen_and_display_settings">Настройки на екрана и дисплея.</string>
 

--- a/apptoolkit/src/main/res/values-bn-rBD/strings.xml
+++ b/apptoolkit/src/main/res/values-bn-rBD/strings.xml
@@ -99,6 +99,8 @@
     <string name="follow_system">সিস্টেম মোড অনুসরণ করুন</string>
     <string name="light_mode">লাইট মোড</string>
     <string name="dark_mode">ডার্ক মোড</string>
+    <string name="color_palette">রঙের প্যালেট</string>
+    <string name="theme_mode">থিম মোড</string>
     <string name="summary_dark_theme">গা dark ় থিম আপনার ব্যাটারির জীবনকে উল্লেখযোগ্যভাবে প্রসারিত করতে একটি গভীর পটভূমি উপার্জন করে। এটি সক্রিয় করতে, কেবল আপনার অ্যান্ড্রয়েডের সিস্টেম ম্যানেজারে নেভিগেট করুন এবং আপনার পছন্দসই থিমটি নির্বাচন করুন</string>
     <string name="screen_and_display_settings">স্ক্রিন এবং প্রদর্শন সেটিংস।</string>
 

--- a/apptoolkit/src/main/res/values-de-rDE/strings.xml
+++ b/apptoolkit/src/main/res/values-de-rDE/strings.xml
@@ -99,6 +99,8 @@
     <string name="follow_system">Systemmodus folgen</string>
     <string name="light_mode">Helles thema</string>
     <string name="dark_mode">Dunkles thema</string>
+    <string name="color_palette">Farbpalette</string>
+    <string name="theme_mode">Themenmodus</string>
     <string name="summary_dark_theme">Das Dunkle Thema nutzt einen tiefen Hintergrund, um Ihre Akkulaufzeit erheblich zu verlängern. Um es zu aktivieren, navigieren Sie einfach zum Systemmanager Ihres Android -Systems und wählen Sie Ihr bevorzugtes Thema in</string>
     <string name="screen_and_display_settings">Bildschirm und Einstellungen anzeigen.</string>
 

--- a/apptoolkit/src/main/res/values-es-rGQ/strings.xml
+++ b/apptoolkit/src/main/res/values-es-rGQ/strings.xml
@@ -99,6 +99,8 @@
     <string name="follow_system">Seguir modo del sistema</string>
     <string name="light_mode">Modo claro</string>
     <string name="dark_mode">Modo oscuro</string>
+    <string name="color_palette">Paleta de colores</string>
+    <string name="theme_mode">Modo de tema</string>
     <string name="summary_dark_theme">El tema oscuro aprovecha un fondo profundo para extender significativamente la duración de su batería. Para activarlo, simplemente navegue al Administrador de sistemas de su Android y seleccione su tema preferido en</string>
     <string name="screen_and_display_settings">Configuración de pantalla y visualización.</string>
 

--- a/apptoolkit/src/main/res/values-es-rMX/strings.xml
+++ b/apptoolkit/src/main/res/values-es-rMX/strings.xml
@@ -99,6 +99,8 @@
     <string name="follow_system">Seguir modo del sistema</string>
     <string name="light_mode">Modo claro</string>
     <string name="dark_mode">Modo oscuro</string>
+    <string name="color_palette">Paleta de colores</string>
+    <string name="theme_mode">Modo de tema</string>
     <string name="summary_dark_theme">El tema oscuro aprovecha un fondo profundo para extender significativamente la duración de su batería. Para activarlo, simplemente navegue al Administrador de sistemas de su Android y seleccione su tema preferido en</string>
     <string name="screen_and_display_settings">Configuración de pantalla y visualización.</string>
 

--- a/apptoolkit/src/main/res/values-fil-rPH/strings.xml
+++ b/apptoolkit/src/main/res/values-fil-rPH/strings.xml
@@ -99,6 +99,8 @@
     <string name="follow_system">Sundin ang system mode</string>
     <string name="light_mode">Light mode</string>
     <string name="dark_mode">Dark mode</string>
+    <string name="color_palette">Paleta ng kulay</string>
+    <string name="theme_mode">Mode ng tema</string>
     <string name="summary_dark_theme">Ang madilim na tema ay gumagamit ng isang malalim na background upang makabuluhang mapalawak ang iyong buhay ng baterya. Upang maisaaktibo ito, mag -navigate lamang sa manager ng system ng iyong Android at piliin ang iyong ginustong tema sa</string>
     <string name="screen_and_display_settings">Mga Setting ng Screen at Display.</string>
 

--- a/apptoolkit/src/main/res/values-fr-rFR/strings.xml
+++ b/apptoolkit/src/main/res/values-fr-rFR/strings.xml
@@ -99,6 +99,8 @@
     <string name="follow_system">Suivre le mode système</string>
     <string name="light_mode">Mode clair</string>
     <string name="dark_mode">Mode sombre</string>
+    <string name="color_palette">Palette de couleurs</string>
+    <string name="theme_mode">Mode du thème</string>
     <string name="summary_dark_theme">Le thème sombre exploite un fond profond pour étendre considérablement la durée de vie de votre batterie. Pour l\'activer, accédez simplement au gestionnaire de systèmes de votre Android et sélectionnez votre thème préféré dans</string>
     <string name="screen_and_display_settings">Paramètres d\'écran et d\'affichage.</string>
 

--- a/apptoolkit/src/main/res/values-hi-rIN/strings.xml
+++ b/apptoolkit/src/main/res/values-hi-rIN/strings.xml
@@ -99,6 +99,8 @@
     <string name="follow_system">सिस्टम मोड का अनुसरण करें</string>
     <string name="light_mode">लाइट मोड</string>
     <string name="dark_mode">डार्क मोड</string>
+    <string name="color_palette">रंग पैलेट</string>
+    <string name="theme_mode">थीम मोड</string>
     <string name="summary_dark_theme">डार्क थीम एक गहरी पृष्ठभूमि का लाभ उठाती है ताकि आपके बैटरी जीवन को महत्वपूर्ण रूप से बढ़ाया जा सके। इसे सक्रिय करने के लिए, बस अपने Android के सिस्टम मैनेजर पर नेविगेट करें और अपने पसंदीदा विषय का चयन करें</string>
     <string name="screen_and_display_settings">स्क्रीन और प्रदर्शन सेटिंग्स।</string>
 

--- a/apptoolkit/src/main/res/values-hu-rHU/strings.xml
+++ b/apptoolkit/src/main/res/values-hu-rHU/strings.xml
@@ -99,6 +99,8 @@
     <string name="follow_system">Rendszerbeállítás követése</string>
     <string name="light_mode">Világos mód</string>
     <string name="dark_mode">Sötét mód</string>
+    <string name="color_palette">Színpaletta</string>
+    <string name="theme_mode">Téma mód</string>
     <string name="summary_dark_theme">A sötét téma mély hátteret használ ki, hogy jelentősen meghosszabbítsa az akkumulátor élettartamát. Az aktiváláshoz egyszerűen keresse meg az Android Rendszerkezelőjét, és válassza ki a kívánt témát</string>
     <string name="screen_and_display_settings">képernyő és megjelenítés a beállítások.</string>
 

--- a/apptoolkit/src/main/res/values-in-rID/strings.xml
+++ b/apptoolkit/src/main/res/values-in-rID/strings.xml
@@ -99,6 +99,8 @@
     <string name="follow_system">Ikuti mode sistem</string>
     <string name="light_mode">Mode terang</string>
     <string name="dark_mode">Mode gelap</string>
+    <string name="color_palette">Palet warna</string>
+    <string name="theme_mode">Mode tema</string>
     <string name="summary_dark_theme">Tema gelap memanfaatkan latar belakang yang dalam untuk secara signifikan memperpanjang masa pakai baterai Anda. Untuk mengaktifkannya, cukup arahkan ke manajer sistem Android Anda dan pilih tema pilihan Anda</string>
     <string name="screen_and_display_settings">Layar dan Tampilan Pengaturan.</string>
 

--- a/apptoolkit/src/main/res/values-it-rIT/strings.xml
+++ b/apptoolkit/src/main/res/values-it-rIT/strings.xml
@@ -99,6 +99,8 @@
     <string name="follow_system">Segui modalità sistema</string>
     <string name="light_mode">Modalità chiara</string>
     <string name="dark_mode">Modalità scura</string>
+    <string name="color_palette">Palette colori</string>
+    <string name="theme_mode">Modalità tema</string>
     <string name="summary_dark_theme">Il tema oscuro sfrutta uno sfondo profondo per prolungare significativamente la durata della batteria. Per attivarlo, basta passare al gestore di sistemi del tuo Android e selezionare il tema preferito in</string>
     <string name="screen_and_display_settings">Impostazioni di schermata e visualizzazione.</string>
 

--- a/apptoolkit/src/main/res/values-ja-rJP/strings.xml
+++ b/apptoolkit/src/main/res/values-ja-rJP/strings.xml
@@ -99,6 +99,8 @@
     <string name="follow_system">システムモードに従う</string>
     <string name="light_mode">ライトモード</string>
     <string name="dark_mode">ダークモード</string>
+    <string name="color_palette">カラーパレット</string>
+    <string name="theme_mode">テーマモード</string>
     <string name="summary_dark_theme">暗いテーマは、バッテリー寿命を大幅に延長するために深い背景を活用します。それをアクティブにするには、Androidのシステムマネージャーに移動して、希望するテーマを選択してください</string>
     <string name="screen_and_display_settings">画面と表示設定。</string>
 

--- a/apptoolkit/src/main/res/values-ko-rKR/strings.xml
+++ b/apptoolkit/src/main/res/values-ko-rKR/strings.xml
@@ -99,6 +99,8 @@
     <string name="follow_system">시스템 모드 따르기</string>
     <string name="light_mode">라이트 모드</string>
     <string name="dark_mode">다크 모드</string>
+    <string name="color_palette">색상 팔레트</string>
+    <string name="theme_mode">테마 모드</string>
     <string name="summary_dark_theme">다크 테마는 깊은 배경을 활용하여 배터리 수명을 크게 연장합니다. 활성화하려면 Android의 시스템 관리자로 이동하여 선호하는 테마를 선택하십시오.</string>
     <string name="screen_and_display_settings">화면 및 디스플레이 설정.</string>
 

--- a/apptoolkit/src/main/res/values-pl-rPL/strings.xml
+++ b/apptoolkit/src/main/res/values-pl-rPL/strings.xml
@@ -99,6 +99,8 @@
     <string name="follow_system">Podążaj za ustawieniami systemu</string>
     <string name="light_mode">Tryb jasny</string>
     <string name="dark_mode">Tryb ciemny</string>
+    <string name="color_palette">Paleta kolorów</string>
+    <string name="theme_mode">Tryb motywu</string>
     <string name="summary_dark_theme">Mroczny motyw wykorzystuje głębokie tło, aby znacznie wydłużyć żywotność baterii. Aby go aktywować, po prostu przejdź do menedżera systemu Androida i wybierz preferowany motyw w</string>
     <string name="screen_and_display_settings">Ustawienia ekranu i wyświetlania.</string>
 

--- a/apptoolkit/src/main/res/values-pt-rBR/strings.xml
+++ b/apptoolkit/src/main/res/values-pt-rBR/strings.xml
@@ -99,6 +99,8 @@
     <string name="follow_system">Seguir o sistema</string>
     <string name="light_mode">Modo claro</string>
     <string name="dark_mode">Modo escuro</string>
+    <string name="color_palette">Paleta de cores</string>
+    <string name="theme_mode">Modo de tema</string>
     <string name="summary_dark_theme">O tema escuro aproveita um fundo profundo para estender significativamente a vida útil da bateria. Para ativá -lo, simplesmente navegue para o gerente de sistema do seu Android e selecione seu tema preferido em</string>
     <string name="screen_and_display_settings">Configurações de tela e exibição.</string>
 

--- a/apptoolkit/src/main/res/values-ro-rRO/strings.xml
+++ b/apptoolkit/src/main/res/values-ro-rRO/strings.xml
@@ -99,6 +99,8 @@
     <string name="follow_system">Urmărește setările sistemului</string>
     <string name="light_mode">Mod luminos</string>
     <string name="dark_mode">Mod întunecat</string>
+    <string name="color_palette">Paletă de culori</string>
+    <string name="theme_mode">Mod temă</string>
     <string name="summary_dark_theme">Tema întunecată folosește un fundal profund pentru a -ți extinde semnificativ durata de viață a bateriei. Pentru a -l activa, pur și simplu navigați la managerul de sistem Android și selectați tema preferată în</string>
     <string name="screen_and_display_settings">Setări de ecran și afișare.</string>
 

--- a/apptoolkit/src/main/res/values-ru-rRU/strings.xml
+++ b/apptoolkit/src/main/res/values-ru-rRU/strings.xml
@@ -99,6 +99,8 @@
     <string name="follow_system">Следовать за системой</string>
     <string name="light_mode">Светлый режим</string>
     <string name="dark_mode">Тёмный режим</string>
+    <string name="color_palette">Цветовая палитра</string>
+    <string name="theme_mode">Режим темы</string>
     <string name="summary_dark_theme">Темная тема использует глубокий фон, чтобы значительно продлить срок службы батареи. Чтобы активировать его, просто перейдите к системному менеджеру Android и выберите свою предпочтительную тему в</string>
     <string name="screen_and_display_settings">Настройки экрана и отображения.</string>
 

--- a/apptoolkit/src/main/res/values-sv-rSE/strings.xml
+++ b/apptoolkit/src/main/res/values-sv-rSE/strings.xml
@@ -99,6 +99,8 @@
     <string name="follow_system">Följ systeminställningar</string>
     <string name="light_mode">Ljust läge</string>
     <string name="dark_mode">Mörkt läge</string>
+    <string name="color_palette">Färgpalett</string>
+    <string name="theme_mode">Temaläge</string>
     <string name="summary_dark_theme">Dark Theme utnyttjar en djup bakgrund för att avsevärt förlänga batteritiden. För att aktivera det, navigera bara till din Androids systemhanterare och välj ditt föredragna tema i</string>
     <string name="screen_and_display_settings">Skärm- och visningsinställningar.</string>
 

--- a/apptoolkit/src/main/res/values-th-rTH/strings.xml
+++ b/apptoolkit/src/main/res/values-th-rTH/strings.xml
@@ -99,6 +99,8 @@
     <string name="follow_system">ตามการตั้งค่าระบบ</string>
     <string name="light_mode">โหมดสว่าง</string>
     <string name="dark_mode">โหมดมืด</string>
+    <string name="color_palette">พาเลตสี</string>
+    <string name="theme_mode">โหมดธีม</string>
     <string name="summary_dark_theme">ธีมมืดใช้ประโยชน์จากพื้นหลังลึกเพื่อยืดอายุการใช้งานแบตเตอรี่ของคุณอย่างมีนัยสำคัญ ในการเปิดใช้งานเพียงแค่นำทางไปยังตัวจัดการระบบของ Android และเลือกธีมที่คุณต้องการใน</string>
     <string name="screen_and_display_settings">การตั้งค่าหน้าจอและการแสดงผล</string>
 

--- a/apptoolkit/src/main/res/values-tr-rTR/strings.xml
+++ b/apptoolkit/src/main/res/values-tr-rTR/strings.xml
@@ -99,6 +99,8 @@
     <string name="follow_system">Sistem modunu takip et</string>
     <string name="light_mode">Aydınlık mod</string>
     <string name="dark_mode">Koyu mod</string>
+    <string name="color_palette">Renk paleti</string>
+    <string name="theme_mode">Tema modu</string>
     <string name="summary_dark_theme">Karanlık tema, pil ömrünüzü önemli ölçüde uzatmak için derin bir arka plandan yararlanır. Etkinleştirmek için, Android\'in sistem yöneticisine gidin ve tercih ettiğiniz temayı seçin</string>
     <string name="screen_and_display_settings">Ekran ve görüntüleme ayarları.</string>
 

--- a/apptoolkit/src/main/res/values-uk-rUA/strings.xml
+++ b/apptoolkit/src/main/res/values-uk-rUA/strings.xml
@@ -99,6 +99,8 @@
     <string name="follow_system">Дотримуватися системного режиму</string>
     <string name="light_mode">Світла тема</string>
     <string name="dark_mode">Темна тема</string>
+    <string name="color_palette">Палітра кольорів</string>
+    <string name="theme_mode">Режим теми</string>
     <string name="summary_dark_theme">Темна тема використовує глибокий фон, щоб значно продовжити час роботи акумулятора. Щоб активувати його, просто перейдіть до системного менеджера Android та виберіть бажану тему в</string>
     <string name="screen_and_display_settings">Налаштування екрана та відображення.</string>
 

--- a/apptoolkit/src/main/res/values-ur-rPK/strings.xml
+++ b/apptoolkit/src/main/res/values-ur-rPK/strings.xml
@@ -99,6 +99,8 @@
     <string name="follow_system">سسٹم موڈ فالو کریں</string>
     <string name="light_mode">لائٹ موڈ</string>
     <string name="dark_mode">ڈارک موڈ</string>
+    <string name="color_palette">رنگ پیلیٹ</string>
+    <string name="theme_mode">تھیم موڈ</string>
     <string name="summary_dark_theme">ﮟﯾﺮﮐ ﺐﺨﺘﻨﻣ ﻮﮐ ﻢﯿﮭﺗ ﯽﺤﯿﺟﺮﺗ ﮯﻨﭘﺍ ﺭﻭﺍ ﮟﯿﺋﺎﺟ ﺮﭘ ﺮﺠﯿﻨﯿﻣ ﻢﭩﺴﺳ ﮯﮐ Android ﮯﻨﭘﺍ ﻑﺮﺻ ،</string>
     <string name="screen_and_display_settings">۔ﺕﺎﺒﯿﺗﺮﺗ ﯽﮐ ﮯﻠﭙﺳﮈ ﺭﻭﺍ ﻦﯾﺮﮑﺳﺍ</string>
 

--- a/apptoolkit/src/main/res/values-vi-rVN/strings.xml
+++ b/apptoolkit/src/main/res/values-vi-rVN/strings.xml
@@ -99,6 +99,8 @@
     <string name="follow_system">Theo chế độ hệ thống</string>
     <string name="light_mode">Chế độ sáng</string>
     <string name="dark_mode">Chế độ tối</string>
+    <string name="color_palette">Bảng màu</string>
+    <string name="theme_mode">Chế độ chủ đề</string>
     <string name="summary_dark_theme">Chủ đề tối tận dụng một nền sâu để mở rộng đáng kể thời lượng pin của bạn. Để kích hoạt nó, chỉ cần điều hướng đến Trình quản lý hệ thống Android của bạn và chọn chủ đề ưa thích của bạn trong</string>
     <string name="screen_and_display_settings">màn hình và cài đặt hiển thị.</string>
 

--- a/apptoolkit/src/main/res/values-zh-rTW/strings.xml
+++ b/apptoolkit/src/main/res/values-zh-rTW/strings.xml
@@ -99,6 +99,8 @@
     <string name="follow_system">跟隨系統模式</string>
     <string name="light_mode">淺色模式</string>
     <string name="dark_mode">深色模式</string>
+    <string name="color_palette">色彩調色盤</string>
+    <string name="theme_mode">主題模式</string>
     <string name="summary_dark_theme">深色主題利用深厚的背景來顯著延長電池壽命。要激活它，只需導航到您的Android系統管理器，然後在</string>
     <string name="screen_and_display_settings">屏幕和顯示設置。</string>
 

--- a/apptoolkit/src/main/res/values/strings.xml
+++ b/apptoolkit/src/main/res/values/strings.xml
@@ -101,6 +101,8 @@
     <string name="follow_system">Follow system mode</string>
     <string name="light_mode">Light mode</string>
     <string name="dark_mode">Dark mode</string>
+    <string name="color_palette">Color palette</string>
+    <string name="theme_mode">Theme mode</string>
     <string name="summary_dark_theme">Dark theme leverages a deep background to significantly extend your battery life. To activate it, simply navigate to your Android\'s system manager and select your preferred theme in</string>
     <string name="screen_and_display_settings">screen and display settings.</string>
 


### PR DESCRIPTION
### Motivation
- Improve the theme settings screen visual hierarchy by adding clear section dividers and headers for the color palette and theme mode areas to match Material 3 grouping guidance.  
- Ensure full localization coverage by adding the new `color_palette` and `theme_mode` string keys across all supported locales declared for the module.  
- Change rationale: previously the UI lacked explicit section headings and several locale resource files were missing the new strings; this change adds lightweight UI labels without altering state management and fills missing translations so resource merging succeeds for all locales.

### Description
- UI: add `HorizontalDivider` and `Text` headers (using `MaterialTheme.typography.titleLarge` and semi-bold weight) before the palette and theme mode controls in `ThemeSettingsList.kt`, plus the necessary imports for `HorizontalDivider`, `MaterialTheme`, and `FontWeight`.  
- Strings: introduce `color_palette` and `theme_mode` in `apptoolkit/src/main/res/values/strings.xml` and add those keys to all locale resource files under `apptoolkit/src/main/res/values-*/strings.xml` to cover the full language list.  
- Files changed include `ThemeSettingsList.kt` and the `strings.xml` files for the following locales: ar-rEG, bg-rBG, bn-rBD, de-rDE, en, es-rGQ, es-rMX, fil-rPH, fr-rFR, hi-rIN, hu-rHU, in-rID, it-rIT, ja-rJP, ko-rKR, pl-rPL, pt-rBR, ro-rRO, ru-rRU, sv-rSE, th-rTH, tr-rTR, uk-rUA, ur-rPK, vi-rVN, zh-rTW.

### Testing
- Automated resource verification script was run to check presence of `color_palette` and `theme_mode` in each targeted `strings.xml`, and the script reported all keys present for the supported locales.  
- No unit or instrumentation test suites were executed as part of this change; recommended CI validations are `./gradlew :apptoolkit:assemble` and relevant test tasks to confirm resource merging and compilation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981065f3400832d8c457a558830f410)