### PR TITLE
Handle system back navigation during onboarding

### DIFF
--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingScreen.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.activity.compose.BackHandler
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -77,6 +78,12 @@ fun OnboardingScreen() {
 
     val pagerState: PagerState =
         rememberPagerState(initialPage = uiState.currentTabIndex) { pages.size }
+
+    BackHandler(enabled = pages.isNotEmpty() && pagerState.currentPage > 0) {
+        coroutineScope.launch {
+            pagerState.animateScrollToPage(pagerState.currentPage - 1)
+        }
+    }
 
     LaunchedEffect(pagerState.currentPage) {
         viewModel.onEvent(OnboardingEvent.UpdateCurrentTab(pagerState.currentPage))


### PR DESCRIPTION
### Motivation
- Intercept system back presses during the onboarding pager so that pressing back moves to the previous onboarding page while mid-flow, and only closes the activity when on the first page; previously the system back immediately finished the activity even when the user was not on the first page.

### Description
- Added `BackHandler` to `OnboardingScreen` to detect system back presses and animate the `PagerState` to `currentPage - 1` when `pages.isNotEmpty()` and `pagerState.currentPage > 0`, implemented in `apptoolkit/src/main/kotlin/.../OnboardingScreen.kt`.

### Testing
- No automated tests were run for this change (not requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981eb5c9f5c832d93ddc684d667d44b)