### PR TITLE
Add GA4 coverage for remaining usage/diagnostics preference toggles

### DIFF
--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/ads/ui/AdsSettingsScreen.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/ads/ui/AdsSettingsScreen.kt
@@ -19,7 +19,9 @@ import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.ads.ui.contract.AdsSettingsEvent
 import com.d4rk.android.libs.apptoolkit.app.ads.ui.state.AdsSettingsUiState
 import com.d4rk.android.libs.apptoolkit.app.consent.domain.model.ConsentHost
+import com.d4rk.android.libs.apptoolkit.core.domain.model.analytics.AnalyticsValue
 import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
+import com.d4rk.android.libs.apptoolkit.core.ui.model.analytics.Ga4EventData
 import com.d4rk.android.libs.apptoolkit.core.ui.state.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.views.layouts.LoadingScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.views.layouts.NoDataScreen
@@ -30,6 +32,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.views.layouts.sections.InfoMessa
 import com.d4rk.android.libs.apptoolkit.core.ui.views.navigation.LargeTopAppBarWithScaffold
 import com.d4rk.android.libs.apptoolkit.core.ui.views.preferences.PreferenceItem
 import com.d4rk.android.libs.apptoolkit.core.ui.views.preferences.SwitchCardItem
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.analytics.SettingsAnalytics
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.links.AppLinks
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import org.koin.compose.koinInject
@@ -92,6 +95,17 @@ fun AdsSettingsScreen() {
                             switchState = rememberUpdatedState(data.adsEnabled),
                             onSwitchToggled = { isChecked: Boolean ->
                                 viewModel.onEvent(AdsSettingsEvent.SetAdsEnabled(isChecked))
+                            },
+                            firebaseController = firebaseController,
+                            ga4EventProvider = { isChecked ->
+                                Ga4EventData(
+                                    name = SettingsAnalytics.Events.PREFERENCE_TOGGLE,
+                                    params = mapOf(
+                                        SettingsAnalytics.Params.SCREEN to AnalyticsValue.Str(ADS_SETTINGS_SCREEN_NAME),
+                                        SettingsAnalytics.Params.PREFERENCE_KEY to AnalyticsValue.Str("display_ads"),
+                                        SettingsAnalytics.Params.ENABLED to AnalyticsValue.Str(isChecked.toString()),
+                                    ),
+                                )
                             }
                         )
                     }
@@ -106,7 +120,15 @@ fun AdsSettingsScreen() {
                                     consentHost?.let { host ->
                                         viewModel.onEvent(AdsSettingsEvent.RequestConsent(host))
                                     }
-                                }
+                                },
+                                firebaseController = firebaseController,
+                                ga4Event = Ga4EventData(
+                                    name = SettingsAnalytics.Events.PREFERENCE_VIEW,
+                                    params = mapOf(
+                                        SettingsAnalytics.Params.SCREEN to AnalyticsValue.Str(ADS_SETTINGS_SCREEN_NAME),
+                                        SettingsAnalytics.Params.PREFERENCE_KEY to AnalyticsValue.Str("personalized_ads"),
+                                    ),
+                                )
                             )
                         }
                     }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/diagnostics/ui/UsageAndDiagnosticsList.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/diagnostics/ui/UsageAndDiagnosticsList.kt
@@ -30,13 +30,16 @@ import com.d4rk.android.libs.apptoolkit.app.diagnostics.ui.state.UsageAndDiagnos
 import com.d4rk.android.libs.apptoolkit.app.diagnostics.ui.views.cards.ConsentToggleCard
 import com.d4rk.android.libs.apptoolkit.app.diagnostics.ui.views.headers.ConsentSectionHeader
 import com.d4rk.android.libs.apptoolkit.app.diagnostics.ui.views.headers.ExpandableConsentSectionHeader
+import com.d4rk.android.libs.apptoolkit.core.domain.model.analytics.AnalyticsValue
 import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
+import com.d4rk.android.libs.apptoolkit.core.ui.model.analytics.Ga4EventData
 import com.d4rk.android.libs.apptoolkit.core.ui.state.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.views.layouts.TrackScreenState
 import com.d4rk.android.libs.apptoolkit.core.ui.views.layouts.TrackScreenView
 import com.d4rk.android.libs.apptoolkit.core.ui.views.layouts.sections.InfoMessageSection
 import com.d4rk.android.libs.apptoolkit.core.ui.views.preferences.SwitchCardItem
 import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.SmallVerticalSpacer
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.analytics.SettingsAnalytics
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.links.AppLinks
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import org.koin.compose.koinInject
@@ -95,6 +98,17 @@ fun UsageAndDiagnosticsList(
                 switchState = usageState,
                 onSwitchToggled = { isChecked ->
                     viewModel.onEvent(UsageAndDiagnosticsEvent.SetUsageAndDiagnostics(isChecked))
+                },
+                firebaseController = firebaseController,
+                ga4EventProvider = { isChecked ->
+                    Ga4EventData(
+                        name = SettingsAnalytics.Events.PREFERENCE_TOGGLE,
+                        params = mapOf(
+                            SettingsAnalytics.Params.SCREEN to AnalyticsValue.Str(USAGE_DIAGNOSTICS_SCREEN_NAME),
+                            SettingsAnalytics.Params.PREFERENCE_KEY to AnalyticsValue.Str("usage_and_diagnostics"),
+                            SettingsAnalytics.Params.ENABLED to AnalyticsValue.Str(isChecked.toString()),
+                        ),
+                    )
                 }
             )
         }
@@ -123,6 +137,17 @@ fun UsageAndDiagnosticsList(
                         onCheckedChange = { isChecked ->
                             viewModel.onEvent(UsageAndDiagnosticsEvent.SetAnalyticsConsent(isChecked))
                         },
+                        firebaseController = firebaseController,
+                        ga4EventProvider = { isChecked ->
+                            Ga4EventData(
+                                name = SettingsAnalytics.Events.PREFERENCE_TOGGLE,
+                                params = mapOf(
+                                    SettingsAnalytics.Params.SCREEN to AnalyticsValue.Str(USAGE_DIAGNOSTICS_SCREEN_NAME),
+                                    SettingsAnalytics.Params.PREFERENCE_KEY to AnalyticsValue.Str("analytics_consent"),
+                                    SettingsAnalytics.Params.ENABLED to AnalyticsValue.Str(isChecked.toString()),
+                                ),
+                            )
+                        },
                     )
 
                     SmallVerticalSpacer()
@@ -135,6 +160,17 @@ fun UsageAndDiagnosticsList(
                         icon = Icons.Outlined.Storage,
                         onCheckedChange = { isChecked ->
                             viewModel.onEvent(UsageAndDiagnosticsEvent.SetAdStorageConsent(isChecked))
+                        },
+                        firebaseController = firebaseController,
+                        ga4EventProvider = { isChecked ->
+                            Ga4EventData(
+                                name = SettingsAnalytics.Events.PREFERENCE_TOGGLE,
+                                params = mapOf(
+                                    SettingsAnalytics.Params.SCREEN to AnalyticsValue.Str(USAGE_DIAGNOSTICS_SCREEN_NAME),
+                                    SettingsAnalytics.Params.PREFERENCE_KEY to AnalyticsValue.Str("ad_storage_consent"),
+                                    SettingsAnalytics.Params.ENABLED to AnalyticsValue.Str(isChecked.toString()),
+                                ),
+                            )
                         },
                     )
 
@@ -152,6 +188,17 @@ fun UsageAndDiagnosticsList(
                                 )
                             )
                         },
+                        firebaseController = firebaseController,
+                        ga4EventProvider = { isChecked ->
+                            Ga4EventData(
+                                name = SettingsAnalytics.Events.PREFERENCE_TOGGLE,
+                                params = mapOf(
+                                    SettingsAnalytics.Params.SCREEN to AnalyticsValue.Str(USAGE_DIAGNOSTICS_SCREEN_NAME),
+                                    SettingsAnalytics.Params.PREFERENCE_KEY to AnalyticsValue.Str("ad_user_data_consent"),
+                                    SettingsAnalytics.Params.ENABLED to AnalyticsValue.Str(isChecked.toString()),
+                                ),
+                            )
+                        },
                     )
 
                     SmallVerticalSpacer()
@@ -166,6 +213,17 @@ fun UsageAndDiagnosticsList(
                                 UsageAndDiagnosticsEvent.SetAdPersonalizationConsent(
                                     isChecked
                                 )
+                            )
+                        },
+                        firebaseController = firebaseController,
+                        ga4EventProvider = { isChecked ->
+                            Ga4EventData(
+                                name = SettingsAnalytics.Events.PREFERENCE_TOGGLE,
+                                params = mapOf(
+                                    SettingsAnalytics.Params.SCREEN to AnalyticsValue.Str(USAGE_DIAGNOSTICS_SCREEN_NAME),
+                                    SettingsAnalytics.Params.PREFERENCE_KEY to AnalyticsValue.Str("ad_personalization_consent"),
+                                    SettingsAnalytics.Params.ENABLED to AnalyticsValue.Str(isChecked.toString()),
+                                ),
                             )
                         },
                     )

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/theme/ui/ThemeSettingsList.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/theme/ui/ThemeSettingsList.kt
@@ -66,6 +66,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.views.preferences.SwitchCardItem
 import com.d4rk.android.libs.apptoolkit.core.ui.views.theme.ThemePalettePager
 import com.d4rk.android.libs.apptoolkit.core.ui.views.theme.dedupeStaticPaletteIds
 import com.d4rk.android.libs.apptoolkit.core.ui.views.theme.isAmoledAllowed
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.analytics.SettingsAnalytics
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.colorscheme.DynamicPaletteVariant
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.colorscheme.StaticPaletteIds
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.datastore.DataStoreNamesConstants
@@ -267,7 +268,7 @@ fun ThemeSettingsList(paddingValues: PaddingValues) {
                                         AnalyticsEvent(
                                             name = "theme_tab_select",
                                             params = mapOf(
-                                                "screen" to AnalyticsValue.Str(THEME_SCREEN_NAME),
+                                                SettingsAnalytics.Params.SCREEN to AnalyticsValue.Str(THEME_SCREEN_NAME),
                                                 "tab" to AnalyticsValue.Str(
                                                     if (index == 0) "wallpaper" else "other"
                                                 ),
@@ -401,7 +402,7 @@ fun ThemeSettingsList(paddingValues: PaddingValues) {
                                         AnalyticsEvent(
                                             name = "theme_palette_select",
                                             params = mapOf(
-                                                "screen" to AnalyticsValue.Str(THEME_SCREEN_NAME),
+                                                SettingsAnalytics.Params.SCREEN to AnalyticsValue.Str(THEME_SCREEN_NAME),
                                                 "palette_type" to AnalyticsValue.Str("static"),
                                                 "palette_id" to AnalyticsValue.Str(id),
                                                 "seasonal" to AnalyticsValue.Str(
@@ -452,10 +453,10 @@ fun ThemeSettingsList(paddingValues: PaddingValues) {
                             onClick = {
                                 firebase.value.logEvent(
                                     AnalyticsEvent(
-                                        name = "theme_mode_select",
+                                        name = SettingsAnalytics.Events.THEME_SWITCH,
                                         params = mapOf(
-                                            "screen" to AnalyticsValue.Str(THEME_SCREEN_NAME),
-                                            "mode" to AnalyticsValue.Str(choice.key),
+                                            SettingsAnalytics.Params.SCREEN to AnalyticsValue.Str(THEME_SCREEN_NAME),
+                                            SettingsAnalytics.Params.THEME_MODE to AnalyticsValue.Str(choice.key),
                                         ),
                                     ),
                                 )
@@ -501,7 +502,7 @@ fun ThemeSettingsList(paddingValues: PaddingValues) {
                             AnalyticsEvent(
                                 name = "theme_toggle_amoled",
                                 params = mapOf(
-                                    "screen" to AnalyticsValue.Str(THEME_SCREEN_NAME),
+                                    SettingsAnalytics.Params.SCREEN to AnalyticsValue.Str(THEME_SCREEN_NAME),
                                     "enabled" to AnalyticsValue.Str(isChecked.toString()),
                                 ),
                             ),
@@ -526,7 +527,7 @@ fun ThemeSettingsList(paddingValues: PaddingValues) {
                             AnalyticsEvent(
                                 name = "theme_open_display_settings",
                                 params = mapOf(
-                                    "screen" to AnalyticsValue.Str(THEME_SCREEN_NAME),
+                                    SettingsAnalytics.Params.SCREEN to AnalyticsValue.Str(THEME_SCREEN_NAME),
                                     "opened" to AnalyticsValue.Str(opened.toString()),
                                 ),
                             ),

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/preferences/PreferenceItem.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/preferences/PreferenceItem.kt
@@ -42,6 +42,7 @@ import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
  * @param onClick A callback function that is called when the entire preference item is clicked. If no action is needed on click, this can be left empty.
  * @param firebaseController Optional Firebase controller used to log GA4 events.
  * @param ga4Event Optional GA4 event data to log on click.
+ * @param ga4EventProvider Optional provider for GA4 event data resolved at click time.
  */
 @Composable
 fun PreferenceItem(
@@ -53,6 +54,7 @@ fun PreferenceItem(
     onClick: () -> Unit = {},
     firebaseController: FirebaseController? = null,
     ga4Event: Ga4EventData? = null,
+    ga4EventProvider: (() -> Ga4EventData?)? = null,
 ) {
     val hapticFeedback: HapticFeedback = LocalHapticFeedback.current
     val view: View = LocalView.current
@@ -63,7 +65,7 @@ fun PreferenceItem(
             .clickable(enabled = enabled, onClick = {
                 view.playSoundEffect(SoundEffectConstants.CLICK)
                 hapticFeedback.performHapticFeedback(hapticFeedbackType = HapticFeedbackType.ContextClick)
-                firebaseController.logGa4Event(ga4Event)
+                firebaseController.logGa4Event(ga4EventProvider?.invoke() ?: ga4Event)
                 onClick()
             }), verticalAlignment = Alignment.CenterVertically
     ) {
@@ -114,6 +116,7 @@ fun PreferenceItem(
  *                Defaults to an empty lambda, meaning no action will be performed by default.
  * @param firebaseController Optional Firebase controller used to log GA4 events.
  * @param ga4Event Optional GA4 event data to log on click.
+ * @param ga4EventProvider Optional provider for GA4 event data resolved at click time.
  */
 @Composable
 fun SettingsPreferenceItem(
@@ -124,6 +127,7 @@ fun SettingsPreferenceItem(
     onClick: () -> Unit = {},
     firebaseController: FirebaseController? = null,
     ga4Event: Ga4EventData? = null,
+    ga4EventProvider: (() -> Ga4EventData?)? = null,
 ) {
     Card(
         modifier = Modifier
@@ -140,6 +144,7 @@ fun SettingsPreferenceItem(
             },
             firebaseController = firebaseController,
             ga4Event = ga4Event,
+            ga4EventProvider = ga4EventProvider,
         )
     }
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/preferences/SwitchCardItem.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/preferences/SwitchCardItem.kt
@@ -40,6 +40,7 @@ import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
  * The card has a rounded corner shape and provides a click sound effect upon interaction.
  * @param firebaseController Optional Firebase controller used to log GA4 events.
  * @param ga4Event Optional GA4 event data to log on click.
+ * @param ga4EventProvider Optional provider for GA4 event data resolved using the toggled state.
  */
 @Composable
 fun SwitchCardItem(
@@ -51,6 +52,7 @@ fun SwitchCardItem(
     checkIcon: ImageVector = Icons.Filled.Check,
     firebaseController: FirebaseController? = null,
     ga4Event: Ga4EventData? = null,
+    ga4EventProvider: ((Boolean) -> Ga4EventData?)? = null,
 ) {
     val view: View = LocalView.current
     Card(
@@ -60,9 +62,10 @@ fun SwitchCardItem(
         modifier = modifier,
         onClick = {
             if (!enabled) return@Card
+            val updatedValue = !switchState.value
             view.playSoundEffect(SoundEffectConstants.CLICK)
-            firebaseController.logGa4Event(ga4Event)
-            onSwitchToggled(!switchState.value)
+            firebaseController.logGa4Event(ga4EventProvider?.invoke(updatedValue) ?: ga4Event)
+            onSwitchToggled(updatedValue)
         }
     ) {
         Row(
@@ -82,7 +85,7 @@ fun SwitchCardItem(
                 checked = switchState.value,
                 enabled = enabled,
                 onCheckedChange = { isChecked ->
-                    firebaseController.logGa4Event(ga4Event)
+                    firebaseController.logGa4Event(ga4EventProvider?.invoke(isChecked) ?: ga4Event)
                     onSwitchToggled(isChecked)
                 },
                 checkIcon = checkIcon

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/utils/constants/analytics/SettingsAnalytics.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/utils/constants/analytics/SettingsAnalytics.kt
@@ -1,0 +1,20 @@
+package com.d4rk.android.libs.apptoolkit.core.utils.constants.analytics
+
+/**
+ * Shared GA4 naming used by settings surfaces so dashboards stay consistent across screens.
+ */
+object SettingsAnalytics {
+    object Events {
+        const val PREFERENCE_TOGGLE: String = "settings_preference_toggle"
+        const val PREFERENCE_VIEW: String = "settings_preference_view"
+        const val THEME_SWITCH: String = "settings_theme_switch"
+    }
+
+    object Params {
+        const val SCREEN: String = "screen"
+        const val PREFERENCE_KEY: String = "preference_key"
+        const val ENABLED: String = "enabled"
+        const val THEME_MODE: String = "theme_mode"
+    }
+}
+


### PR DESCRIPTION
### Motivation
- Settings analytics were inconsistent: some preference components logged GA4 events inline while others had no standardized wiring, which made dashboards and instrumentation brittle. 
- Instrumenting the reusable preference components avoids duplicated logging logic and allows inclusion of the updated toggle state in events.

### Description
- Extended `PreferenceItem` and `SettingsPreferenceItem` to accept an optional `ga4EventProvider: (() -> Ga4EventData?)?` and prefer the provider at click time so events can be resolved lazily with current state. 
- Extended `SwitchCardItem` to accept `ga4EventProvider: ((Boolean) -> Ga4EventData?)?` and `ConsentToggleCard` to accept `firebaseController` + `ga4EventProvider: ((Boolean) -> Ga4EventData?)?`, and added logging on both card-tap and switch-tap so the toggled value is included in analytics. 
- Wired GA4 events for all Usage & Diagnostics toggles (`usage_and_diagnostics`, `analytics_consent`, `ad_storage_consent`, `ad_user_data_consent`, `ad_personalization_consent`) by passing `firebaseController` and a `Ga4EventData` provider from `UsageAndDiagnosticsList`. 
- Added a centralized `SettingsAnalytics` constants object (`Events` and `Params`) and updated Ads/Theme screens to use the standardized naming contract for consistency across settings surfaces.

Change rationale: previously some screens emitted ad-hoc event names/params and some preference components had no analytics hooks, resulting in duplication and inconsistent dashboards; moving logging into reusable components and using a shared `SettingsAnalytics` contract makes naming consistent, lets callers include runtime state (like the new toggle value) without duplicating logic, and improves maintainability.

### Testing
- Attempted a Kotlin compile check with `./gradlew :apptoolkit:compileDebugKotlin`, which failed in this environment because the Android SDK location is not configured (missing `ANDROID_HOME`/`sdk.dir`).
- No other automated tests were executed in this environment due to SDK/build constraints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69876bdcf870832da4229e4b30001849)