### PR TITLE
Refactor settings list sections into Screen composables with ViewModels

### DIFF
--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/settings/modules/GeneralSettingsModule.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/settings/modules/GeneralSettingsModule.kt
@@ -5,6 +5,8 @@ import com.d4rk.android.apps.apptoolkit.app.components.ui.ComponentsUnlockViewMo
 import com.d4rk.android.apps.apptoolkit.app.settings.about.ui.AppAboutSettingsContent
 import com.d4rk.android.apps.apptoolkit.app.settings.settings.utils.providers.AppDisplaySettingsProvider
 import com.d4rk.android.apps.apptoolkit.app.settings.settings.utils.providers.AppPrivacySettingsProvider
+import com.d4rk.android.libs.apptoolkit.app.display.ui.DisplaySettingsViewModel
+import com.d4rk.android.libs.apptoolkit.app.privacy.ui.PrivacySettingsViewModel
 import com.d4rk.android.libs.apptoolkit.app.settings.general.data.repository.GeneralSettingsRepositoryImpl
 import com.d4rk.android.libs.apptoolkit.app.settings.general.domain.repository.GeneralSettingsRepository
 import com.d4rk.android.libs.apptoolkit.app.settings.general.ui.GeneralSettingsViewModel
@@ -45,5 +47,13 @@ val generalSettingsModule: Module = module {
             dispatchers = get(),
             firebaseController = get(),
         )
+    }
+
+    viewModel {
+        DisplaySettingsViewModel(firebaseController = get())
+    }
+
+    viewModel {
+        PrivacySettingsViewModel(firebaseController = get())
     }
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/advanced/ui/AdvancedSettingsList.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/advanced/ui/AdvancedSettingsList.kt
@@ -36,7 +36,7 @@ import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 
 private const val ADVANCED_SETTINGS_SCREEN_NAME = "AdvancedSettings"
-private const val ADVANCED_SETTINGS_SCREEN_CLASS = "AdvancedSettingsList"
+private const val ADVANCED_SETTINGS_SCREEN_CLASS = "AdvancedSettingsScreen"
 
 /**
  * A Composable function that displays a list of advanced settings.
@@ -53,7 +53,7 @@ private const val ADVANCED_SETTINGS_SCREEN_CLASS = "AdvancedSettingsList"
  * typically provided by a Scaffold. Defaults to an empty `PaddingValues`.
  */
 @Composable
-fun AdvancedSettingsList(
+fun AdvancedSettingsScreen(
     paddingValues: PaddingValues = PaddingValues(),
 ) {
     val viewModel: AdvancedSettingsViewModel = koinViewModel()

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/display/ui/DisplaySettingsViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/display/ui/DisplaySettingsViewModel.kt
@@ -1,0 +1,42 @@
+package com.d4rk.android.libs.apptoolkit.app.display.ui
+
+import androidx.lifecycle.viewModelScope
+import com.d4rk.android.libs.apptoolkit.app.display.ui.contract.DisplaySettingsAction
+import com.d4rk.android.libs.apptoolkit.app.display.ui.contract.DisplaySettingsEvent
+import com.d4rk.android.libs.apptoolkit.app.display.ui.state.DisplaySettingsUiState
+import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
+import com.d4rk.android.libs.apptoolkit.core.ui.base.LoggedScreenViewModel
+import com.d4rk.android.libs.apptoolkit.core.ui.state.ScreenState
+import com.d4rk.android.libs.apptoolkit.core.ui.state.UiStateScreen
+import com.d4rk.android.libs.apptoolkit.core.ui.state.setSuccess
+import kotlinx.coroutines.launch
+
+/** ViewModel for the display settings screen lifecycle state. */
+class DisplaySettingsViewModel(
+    firebaseController: FirebaseController,
+) : LoggedScreenViewModel<DisplaySettingsUiState, DisplaySettingsEvent, DisplaySettingsAction>(
+    initialState = UiStateScreen(data = DisplaySettingsUiState),
+    firebaseController = firebaseController,
+    screenName = "DisplaySettings",
+) {
+    init {
+        onEvent(DisplaySettingsEvent.Load)
+    }
+
+    override fun handleEvent(event: DisplaySettingsEvent) {
+        when (event) {
+            DisplaySettingsEvent.Load -> onLoad()
+        }
+    }
+
+    private fun onLoad() {
+        viewModelScope.launch {
+            updateStateThreadSafe {
+                screenState.setSuccess(
+                    data = DisplaySettingsUiState,
+                    newState = ScreenState.Success(),
+                )
+            }
+        }
+    }
+}

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/display/ui/contract/DisplaySettingsAction.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/display/ui/contract/DisplaySettingsAction.kt
@@ -1,0 +1,4 @@
+package com.d4rk.android.libs.apptoolkit.app.display.ui.contract
+
+/** One-off actions for the display settings screen. */
+sealed interface DisplaySettingsAction

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/display/ui/contract/DisplaySettingsEvent.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/display/ui/contract/DisplaySettingsEvent.kt
@@ -1,0 +1,6 @@
+package com.d4rk.android.libs.apptoolkit.app.display.ui.contract
+
+/** Events emitted by the display settings screen. */
+sealed interface DisplaySettingsEvent {
+    data object Load : DisplaySettingsEvent
+}

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/display/ui/state/DisplaySettingsUiState.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/display/ui/state/DisplaySettingsUiState.kt
@@ -1,0 +1,4 @@
+package com.d4rk.android.libs.apptoolkit.app.display.ui.state
+
+/** Immutable UI state holder for display settings content. */
+data object DisplaySettingsUiState

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/privacy/ui/PrivacySettingsViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/privacy/ui/PrivacySettingsViewModel.kt
@@ -1,0 +1,42 @@
+package com.d4rk.android.libs.apptoolkit.app.privacy.ui
+
+import androidx.lifecycle.viewModelScope
+import com.d4rk.android.libs.apptoolkit.app.privacy.ui.contract.PrivacySettingsAction
+import com.d4rk.android.libs.apptoolkit.app.privacy.ui.contract.PrivacySettingsEvent
+import com.d4rk.android.libs.apptoolkit.app.privacy.ui.state.PrivacySettingsUiState
+import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
+import com.d4rk.android.libs.apptoolkit.core.ui.base.LoggedScreenViewModel
+import com.d4rk.android.libs.apptoolkit.core.ui.state.ScreenState
+import com.d4rk.android.libs.apptoolkit.core.ui.state.UiStateScreen
+import com.d4rk.android.libs.apptoolkit.core.ui.state.setSuccess
+import kotlinx.coroutines.launch
+
+/** ViewModel for the privacy settings screen lifecycle state. */
+class PrivacySettingsViewModel(
+    firebaseController: FirebaseController,
+) : LoggedScreenViewModel<PrivacySettingsUiState, PrivacySettingsEvent, PrivacySettingsAction>(
+    initialState = UiStateScreen(data = PrivacySettingsUiState),
+    firebaseController = firebaseController,
+    screenName = "Privacy",
+) {
+    init {
+        onEvent(PrivacySettingsEvent.Load)
+    }
+
+    override fun handleEvent(event: PrivacySettingsEvent) {
+        when (event) {
+            PrivacySettingsEvent.Load -> onLoad()
+        }
+    }
+
+    private fun onLoad() {
+        viewModelScope.launch {
+            updateStateThreadSafe {
+                screenState.setSuccess(
+                    data = PrivacySettingsUiState,
+                    newState = ScreenState.Success(),
+                )
+            }
+        }
+    }
+}

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/privacy/ui/contract/PrivacySettingsAction.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/privacy/ui/contract/PrivacySettingsAction.kt
@@ -1,0 +1,4 @@
+package com.d4rk.android.libs.apptoolkit.app.privacy.ui.contract
+
+/** One-off actions for the privacy settings screen. */
+sealed interface PrivacySettingsAction

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/privacy/ui/contract/PrivacySettingsEvent.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/privacy/ui/contract/PrivacySettingsEvent.kt
@@ -1,0 +1,6 @@
+package com.d4rk.android.libs.apptoolkit.app.privacy.ui.contract
+
+/** Events emitted by the privacy settings screen. */
+sealed interface PrivacySettingsEvent {
+    data object Load : PrivacySettingsEvent
+}

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/privacy/ui/state/PrivacySettingsUiState.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/privacy/ui/state/PrivacySettingsUiState.kt
@@ -1,0 +1,4 @@
+package com.d4rk.android.libs.apptoolkit.app.privacy.ui.state
+
+/** Immutable UI state holder for privacy settings content. */
+data object PrivacySettingsUiState

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/utils/providers/GeneralSettingsContentProvider.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/utils/providers/GeneralSettingsContentProvider.kt
@@ -4,10 +4,10 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.material3.SnackbarHostState
 import androidx.compose.runtime.Composable
 import com.d4rk.android.libs.apptoolkit.app.about.ui.AboutScreen
-import com.d4rk.android.libs.apptoolkit.app.advanced.ui.AdvancedSettingsList
+import com.d4rk.android.libs.apptoolkit.app.advanced.ui.AdvancedSettingsScreen
 import com.d4rk.android.libs.apptoolkit.app.diagnostics.ui.UsageAndDiagnosticsList
-import com.d4rk.android.libs.apptoolkit.app.display.ui.DisplaySettingsList
-import com.d4rk.android.libs.apptoolkit.app.privacy.ui.PrivacySettingsList
+import com.d4rk.android.libs.apptoolkit.app.display.ui.DisplaySettingsScreen
+import com.d4rk.android.libs.apptoolkit.app.privacy.ui.PrivacySettingsScreen
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.constants.SettingsContent
 import com.d4rk.android.libs.apptoolkit.app.theme.ui.ThemeSettingsList
 
@@ -34,9 +34,9 @@ class GeneralSettingsContentProvider(
                 }
             }
 
-            SettingsContent.ADVANCED -> AdvancedSettingsList(paddingValues = paddingValues)
-            SettingsContent.DISPLAY -> DisplaySettingsList(paddingValues = paddingValues)
-            SettingsContent.SECURITY_AND_PRIVACY -> PrivacySettingsList(paddingValues = paddingValues)
+            SettingsContent.ADVANCED -> AdvancedSettingsScreen(paddingValues = paddingValues)
+            SettingsContent.DISPLAY -> DisplaySettingsScreen(paddingValues = paddingValues)
+            SettingsContent.SECURITY_AND_PRIVACY -> PrivacySettingsScreen(paddingValues = paddingValues)
             SettingsContent.THEME -> ThemeSettingsList(paddingValues = paddingValues)
             SettingsContent.USAGE_AND_DIAGNOSTICS -> UsageAndDiagnosticsList(paddingValues = paddingValues)
             else -> customScreens[contentKey]?.invoke(paddingValues)

--- a/docs/screens/settings/advanced/advanced.md
+++ b/docs/screens/settings/advanced/advanced.md
@@ -3,13 +3,13 @@
 ## Layers
 - **Data**: Provides advanced configuration values.
 - **Domain**: Encapsulates logic for expert options.
-- **UI**: `AdvancedSettingsList` composable exposes the controls.
+- **UI**: `AdvancedSettingsScreen` composable exposes the controls.
 
 ## Primary Screens
-- `AdvancedSettingsList` – list of power‑user preferences.
+- `AdvancedSettingsScreen` – list of power‑user preferences.
 
 ## Integration
 ```kotlin
 val snackbarHostState = remember { SnackbarHostState() }
-AdvancedSettingsList(snackbarHostState = snackbarHostState)
+AdvancedSettingsScreen(snackbarHostState = snackbarHostState)
 ```

--- a/docs/screens/settings/display/display.md
+++ b/docs/screens/settings/display/display.md
@@ -1,13 +1,13 @@
 # Display
 
 ## Layers
-- **UI**: `DisplaySettingsList` and reusable display components.
+- **UI**: `DisplaySettingsScreen` and reusable display components.
 
 ## Primary Screens
-- `DisplaySettingsList` – controls for theme and density related options.
+- `DisplaySettingsScreen` – controls for theme and density related options.
 
 ## Integration
 ```kotlin
 val snackbarHostState = remember { SnackbarHostState() }
-DisplaySettingsList(snackbarHostState = snackbarHostState)
+DisplaySettingsScreen(snackbarHostState = snackbarHostState)
 ```

--- a/docs/screens/settings/privacy/privacy.md
+++ b/docs/screens/settings/privacy/privacy.md
@@ -1,13 +1,13 @@
 # Privacy
 
 ## Layers
-- **UI**: `PrivacySettingsList` provides privacy related preferences.
+- **UI**: `PrivacySettingsScreen` provides privacy related preferences.
 
 ## Primary Screens
-- `PrivacySettingsList` – toggles telemetry and data sharing options.
+- `PrivacySettingsScreen` – toggles telemetry and data sharing options.
 
 ## Integration
 ```kotlin
 val snackbarHostState = remember { SnackbarHostState() }
-PrivacySettingsList(snackbarHostState = snackbarHostState)
+PrivacySettingsScreen(snackbarHostState = snackbarHostState)
 ```


### PR DESCRIPTION
### Motivation
- Standardize settings UI to the project’s screen + ViewModel contract so all settings sections follow the same event-driven lifecycle and state model.
- Move display/privacy sections from plain list composables into ViewModel-owned screens to enable clearer state handling, tracking, and future extensibility.

### Description
- Renamed list-style composables to screen-style APIs: `AdvancedSettingsList` → `AdvancedSettingsScreen`, `DisplaySettingsList` → `DisplaySettingsScreen`, and `PrivacySettingsList` → `PrivacySettingsScreen` and updated corresponding `screenClass` constants and references.
- Introduced `DisplaySettingsViewModel` and `PrivacySettingsViewModel` plus lightweight contracts (`*Event`, `*Action`, `*UiState`) so `Display` and `Privacy` now initialize via `init { onEvent(Load) }` and expose `uiState` for the UI to consume.
- Updated UIs to consume ViewModel state with `collectAsStateWithLifecycle()` and wrapped list rendering inside `ScreenStateHandler` where appropriate, preserving existing preference items and behavior.
- Wired new ViewModels into Koin in `GeneralSettingsModule`, updated `GeneralSettingsContentProvider` to render the new screen composables, and updated docs under `docs/screens/settings/*` to reflect the `*Screen` names.
- Change rationale: previously display and privacy sections were simple list composables while advanced already used a ViewModel, creating inconsistency and limiting lifecycle/state handling; the new approach unifies the pattern, making state, tracking, and future features easier to implement.

### Testing
- Ran a Gradle compile attempt (`./gradlew :apptoolkit:compileDebugKotlin :app:compileDebugKotlin`) which failed due to the environment missing an Android SDK location (`ANDROID_HOME`/`sdk.dir`), so the build could not be validated here.
- No other automated tests were executed in this environment due to the same SDK/configuration limitation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b5d9b34c0832d8ad0d92f6e9d28d5)