### PR TITLE
docs: prefer catchReport for ViewModel flows and fix onboarding doc paths

### DIFF
--- a/docs/apptoolkit/screens/onboarding/onboarding.md
+++ b/docs/apptoolkit/screens/onboarding/onboarding.md
@@ -236,7 +236,7 @@ Only contract requirement:
 
 ## Suggested doc placement (to match the Help doc style)
 
-* `docs/apptoolkit/screens/onboarding/integration.md` (how to launch, how to observe completion)
-* `docs/apptoolkit/screens/onboarding/pages.md` (DefaultPage vs CustomPage patterns)
-* `docs/apptoolkit/screens/onboarding/privacy-consent.md` (FirebaseConsentDialog + rules)
-* `docs/apptoolkit/screens/onboarding/theme.md` (theme mode + palettes + seasonal behavior)
+* `docs/apptoolkit/screens/onboarding/onboarding.md` (how to launch, state/events/actions, completion flow)
+* `docs/apptoolkit/screens/onboarding/pages/pages.md` (DefaultPage vs CustomPage patterns)
+* `docs/apptoolkit/screens/onboarding/pages/privacy-consent.md` (FirebaseConsentDialog + rules)
+* `docs/apptoolkit/screens/onboarding/pages/theme.md` (theme mode + palettes + seasonal behavior)


### PR DESCRIPTION
### Motivation
- The ViewModel rules doc referenced the old pattern using simple `.catch { ... }` and direct Firebase reporting, which diverged from the codebase standardized `catchReport(...)` helper; this PR aligns the docs with the implementation and provides a clearer, safer error-reporting pattern for ViewModels. 
- Some onboarding doc paths listed under “Suggested doc placement” were stale or incorrectly referenced and needed correction to point to existing files to avoid confusion.

### Description
- Replaced guidance and examples that described simple `.catch { ... }` with `catchReport(...)` usage and updated the sample HelpViewModel and example observer to show `action`, `fallbackMessage`, and using `throwable.asUiText(...)` for UI-safe messages. 
- Updated Rule 1 wording to list `catchReport` among the standard flow operators and revised Rule 3 text to recommend `catchReport(...)` (including cancellation handling, action tagging, and fallback message guidance). 
- Adjusted the summary checklist to explicitly call out `catchReport(...)` instead of plain `.catch { ... }`. 
- Fixed the onboarding “Suggested doc placement” links to point to existing files under `docs/apptoolkit/screens/onboarding/pages/` and to the onboarding overview `onboarding.md`.

### Testing
- Ran an existence check for the updated onboarding files with `test -f docs/apptoolkit/screens/onboarding/onboarding.md && test -f docs/apptoolkit/screens/onboarding/pages/pages.md && test -f docs/apptoolkit/screens/onboarding/pages/privacy-consent.md && test -f docs/apptoolkit/screens/onboarding/pages/theme.md`, which succeeded. 
- Reviewed diffs with `git diff -- docs/apptoolkit/viewmodels/viewmoel-rules-coroutines-flows-state.md docs/apptoolkit/screens/onboarding/onboarding.md` to confirm only documentation changes were made. 
- Committed the changes locally (`git commit`) and created the PR metadata; all automated checks performed here passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e06f5d180832d8837d6e31fe05e7c)