### PR TITLE
Harden URL sanitization for remote image links

### DIFF
--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/utils/extensions/string/StringExtensions.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/utils/extensions/string/StringExtensions.kt
@@ -22,6 +22,8 @@ import com.d4rk.android.libs.apptoolkit.core.utils.constants.api.ApiEnvironments
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.api.ApiLanguages
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.api.ApiPaths
 import com.d4rk.android.libs.apptoolkit.core.utils.extensions.boolean.toApiEnvironment
+import java.net.URI
+import java.net.URISyntaxException
 import kotlin.io.encoding.Base64
 import kotlin.io.encoding.ExperimentalEncodingApi
 
@@ -43,10 +45,25 @@ fun String.developerAppsApiUrl(
 }
 
 /**
- * Sanitizes a URL string by trimming whitespace and returning `null` for blank inputs.
+ * Sanitizes URL-like input by trimming and validating strict http(s) absolute URLs.
+ *
+ * Returns `null` for blank values, malformed URLs, unsupported schemes, or URLs without host.
  */
-fun String?.sanitizeUrlOrNull(): String? =
-    this?.trim()?.takeIf { it.isNotEmpty() }
+fun String?.sanitizeUrlOrNull(): String? {
+    val candidate = this?.trim()?.takeIf { it.isNotEmpty() } ?: return null
+
+    val parsedUri = try {
+        URI(candidate)
+    } catch (_: URISyntaxException) {
+        return null
+    }
+
+    val normalizedScheme = parsedUri.scheme?.lowercase()
+    val hasAllowedScheme = normalizedScheme == "http" || normalizedScheme == "https"
+    val hasHost = !parsedUri.host.isNullOrBlank()
+
+    return candidate.takeIf { hasAllowedScheme && hasHost }
+}
 
 /**
  * Normalizes a navigation route by removing query/child segments and returning `null` for blanks.

--- a/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/core/utils/extensions/ExtensionsTest.kt
+++ b/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/core/utils/extensions/ExtensionsTest.kt
@@ -98,6 +98,10 @@ class ExtensionsTest {
             { assertEquals("https://d4rk.dev", " https://d4rk.dev ".sanitizeUrlOrNull()) },
             { assertNull("   ".sanitizeUrlOrNull()) },
             { assertNull(null.sanitizeUrlOrNull()) },
+            { assertNull("https://host.com/image with spaces.png".sanitizeUrlOrNull()) },
+            { assertNull("www.host.com/image.png".sanitizeUrlOrNull()) },
+            { assertNull("ftp://host.com/image.png".sanitizeUrlOrNull()) },
+            { assertNull("https:///image.png".sanitizeUrlOrNull()) },
         )
     }
 


### PR DESCRIPTION
## Summary
- tightened `sanitizeUrlOrNull()` in `StringExtensions.kt` so it now accepts only valid absolute `http`/`https` URLs
- kept whitespace trimming behavior while rejecting malformed values, unsupported schemes, and URLs without a host
- added unit-test coverage for common bad inputs (embedded spaces, missing scheme, unsupported scheme, missing host)

## Change rationale
Previously, URL sanitization only trimmed leading/trailing whitespace and treated any non-blank text as valid. That allowed malformed or unintended values to flow into image loading paths. The new approach validates URL structure and scheme up front, which is safer for API-provided image links and reduces runtime failures caused by bad pasted/edited URLs.

## Testing
- Attempted: `./gradlew :apptoolkit:testDebugUnitTest --tests com.d4rk.android.libs.apptoolkit.core.utils.extensions.ExtensionsTest`
- Result: failed before test execution because Gradle could not resolve `org.gradle.toolchains.foojay-resolver-convention:1.0.0` from configured repositories in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992bc047d68832da01435ccdb4bf8ca)