### PR TITLE
Fix drawer tab selection state for Components route

### DIFF
--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/views/navigation/NavigationDrawer.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/views/navigation/NavigationDrawer.kt
@@ -90,6 +90,10 @@ fun NavigationDrawer(
                 uiState.navigationDrawerItems.forEach { item: NavigationDrawerItem ->
                     NavigationDrawerItemContent(
                         item = item,
+                        selected = isDrawerItemSelected(
+                            itemRoute = item.route,
+                            currentRoute = navigationState.currentRoute,
+                        ),
                         dividerRoutes = persistentSetOf(NavigationRoutes.ROUTE_COMPONENTS),
                         handleNavigationItemClick = {
                             handleNavigationItemClick(
@@ -122,3 +126,14 @@ fun NavigationDrawer(
         )
     }
 }
+
+private fun isDrawerItemSelected(
+    itemRoute: String,
+    currentRoute: AppNavKey,
+): Boolean =
+    when (itemRoute) {
+        NavigationRoutes.ROUTE_APPS_LIST -> currentRoute == AppsListRoute
+        NavigationRoutes.ROUTE_FAVORITE_APPS -> currentRoute == FavoriteAppsRoute
+        NavigationRoutes.ROUTE_COMPONENTS -> currentRoute == ComponentsRoute
+        else -> false
+    }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/main/ui/views/navigation/NavigationDrawerItemContent.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/main/ui/views/navigation/NavigationDrawerItemContent.kt
@@ -38,6 +38,7 @@ import kotlinx.collections.immutable.persistentSetOf
 @Composable
 fun NavigationDrawerItemContent(
     item: NavigationDrawerItem,
+    selected: Boolean = false,
     dividerRoutes: ImmutableSet<String> = persistentSetOf(),
     handleNavigationItemClick: () -> Unit = {}
 ) {
@@ -45,7 +46,7 @@ fun NavigationDrawerItemContent(
     val view: View = LocalView.current
 
     NavigationDrawerItem(
-        label = { Text(text = title) }, selected = false, onClick = {
+        label = { Text(text = title) }, selected = selected, onClick = {
             view.playSoundEffect(SoundEffectConstants.CLICK)
             handleNavigationItemClick()
         }, icon = {


### PR DESCRIPTION
### Motivation
- Drawer items were always rendered as unselected because the shared composable hardcoded `selected = false`, causing the Components tab (and other top-level entries) to never reflect the active route.
- The intent is to provide correct visual feedback in the navigation drawer by deriving selection from the app navigation state.

### Description
- Updated `NavigationDrawerItemContent` to accept a `selected: Boolean` parameter and forward it to `NavigationDrawerItem` instead of using a hardcoded `false`.
- Wired the app-level `NavigationDrawer` to compute selection by comparing `item.route` against the current `navigationState.currentRoute` and pass that `selected` flag into each item.
- Added a small `isDrawerItemSelected` helper that maps drawer route strings to `AppNavKey` route objects so only the matching top-level route appears selected.

### Testing
- Attempted to run the unit tests with `./gradlew :app:testDebugUnitTest --tests "com.d4rk.android.apps.apptoolkit.app.main.ui.views.navigation.NavigationItemClickTest"` but the build failed before tests executed due to an unresolved Gradle plugin (`org.gradle.toolchains.foojay-resolver-convention:1.0.0`) in this environment, so automated tests could not be completed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699436f788cc832db38672a1771aa411)