### PR TITLE
Add scrollable Glance widget for developer app shortcuts

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -71,5 +71,17 @@
                 <action android:name="com.d4rk.android.apps.apptoolkit.action.FAVORITES_CHANGED" />
             </intent-filter>
         </receiver>
+
+        <receiver
+            android:name=".app.widgets.apps.AppIconsWidgetReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.appwidget.action.APPWIDGET_UPDATE" />
+            </intent-filter>
+
+            <meta-data
+                android:name="android.appwidget.provider"
+                android:resource="@xml/app_icons_widget_info" />
+        </receiver>
     </application>
 </manifest>

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/widgets/apps/AppIconsWidget.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/widgets/apps/AppIconsWidget.kt
@@ -1,0 +1,160 @@
+/*
+ * Copyright (©) 2026 Mihai-Cristian Condrea
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.d4rk.android.apps.apptoolkit.app.widgets.apps
+
+import android.content.Context
+import android.graphics.Bitmap
+import android.graphics.Canvas
+import android.graphics.drawable.Drawable
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.unit.DpSize
+import androidx.compose.ui.unit.dp
+import androidx.glance.GlanceId
+import androidx.glance.GlanceModifier
+import androidx.glance.Image
+import androidx.glance.ImageProvider
+import androidx.glance.action.actionParametersOf
+import androidx.glance.action.clickable
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.SizeMode
+import androidx.glance.appwidget.action.actionRunCallback
+import androidx.glance.appwidget.lazy.LazyColumn
+import androidx.glance.appwidget.lazy.items
+import androidx.glance.appwidget.provideContent
+import androidx.glance.layout.Alignment
+import androidx.glance.layout.Row
+import androidx.glance.layout.Spacer
+import androidx.glance.layout.fillMaxSize
+import androidx.glance.layout.fillMaxWidth
+import androidx.glance.layout.height
+import androidx.glance.layout.padding
+import androidx.glance.layout.size
+import androidx.glance.text.Text
+import com.d4rk.android.apps.apptoolkit.app.apps.common.domain.model.AppInfo
+import com.d4rk.android.apps.apptoolkit.app.apps.common.domain.usecases.FetchDeveloperAppsUseCase
+import com.d4rk.android.apps.apptoolkit.app.widgets.apps.domain.actions.OpenAppOrStoreAction
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
+import kotlinx.coroutines.flow.first
+import org.koin.core.context.GlobalContext
+
+/**
+ * Scrollable widget that lists developer app icons and opens app/install page on tap.
+ */
+class AppIconsWidget : GlanceAppWidget() {
+
+    override val sizeMode: SizeMode = SizeMode.Responsive(
+        sizes = setOf(DpSize(width = 120.dp, height = 120.dp)),
+    )
+
+    override suspend fun provideGlance(context: Context, id: GlanceId) {
+        val apps = loadApps(context = context)
+        provideContent { AppIconsWidgetContent(apps = apps) }
+    }
+
+    private suspend fun loadApps(context: Context): List<WidgetAppEntry> {
+        val fetchAppsUseCase = GlobalContext.get().get<FetchDeveloperAppsUseCase>()
+        val apps = when (val state = fetchAppsUseCase().first { it !is DataState.Loading }) {
+            is DataState.Success -> state.data
+            is DataState.Error -> state.data ?: emptyList()
+            is DataState.Loading -> emptyList()
+        }
+
+        val source = if (apps.isNotEmpty()) apps else listOf(createFallbackEntry(context))
+        return source.map { app ->
+            WidgetAppEntry(
+                app = app,
+                icon = resolveAppIcon(context = context, packageName = app.packageName),
+            )
+        }
+    }
+
+    private fun createFallbackEntry(context: Context): AppInfo {
+        val appName = context.applicationInfo.loadLabel(context.packageManager).toString()
+        return AppInfo(
+            name = appName,
+            packageName = context.packageName,
+            iconUrl = "",
+            description = "",
+            screenshots = emptyList(),
+            category = null,
+        )
+    }
+
+    private fun resolveAppIcon(context: Context, packageName: String): Bitmap {
+        val drawable = runCatching {
+            context.packageManager.getApplicationIcon(packageName)
+        }.getOrElse {
+            context.packageManager.getApplicationIcon(context.packageName)
+        }
+
+        return drawable.toBitmap(sizePx = 96)
+    }
+}
+
+@Composable
+private fun AppIconsWidgetContent(apps: List<WidgetAppEntry>) {
+    LazyColumn(
+        modifier = GlanceModifier
+            .fillMaxSize()
+            .padding(8.dp),
+    ) {
+        items(apps) { item ->
+            Row(
+                modifier = GlanceModifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 6.dp, vertical = 4.dp)
+                    .appWidgetClickAction(item.app.packageName),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Image(
+                    provider = ImageProvider(item.icon),
+                    contentDescription = item.app.name,
+                    modifier = GlanceModifier.size(36.dp),
+                )
+                Spacer(modifier = GlanceModifier.size(10.dp))
+                Text(
+                    text = item.app.name,
+                    maxLines = 1,
+                )
+            }
+            Spacer(modifier = GlanceModifier.height(4.dp))
+        }
+    }
+}
+
+private data class WidgetAppEntry(
+    val app: AppInfo,
+    val icon: Bitmap,
+)
+
+private fun GlanceModifier.appWidgetClickAction(packageName: String): GlanceModifier =
+    clickable(
+        onClick = actionRunCallback<OpenAppOrStoreAction>(
+            parameters = actionParametersOf(OpenAppOrStoreAction.PACKAGE_NAME_KEY to packageName),
+        ),
+    )
+
+private fun Drawable.toBitmap(sizePx: Int): Bitmap {
+    val width = intrinsicWidth.takeIf { it > 0 } ?: sizePx
+    val height = intrinsicHeight.takeIf { it > 0 } ?: sizePx
+    return Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888).also { bitmap ->
+        val canvas = Canvas(bitmap)
+        setBounds(0, 0, canvas.width, canvas.height)
+        draw(canvas)
+    }
+}

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/widgets/apps/AppIconsWidgetReceiver.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/widgets/apps/AppIconsWidgetReceiver.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright (©) 2026 Mihai-Cristian Condrea
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.d4rk.android.apps.apptoolkit.app.widgets.apps
+
+import androidx.glance.appwidget.GlanceAppWidget
+import androidx.glance.appwidget.GlanceAppWidgetReceiver
+
+/**
+ * Broadcast receiver entry point for the scrollable developer apps widget.
+ */
+class AppIconsWidgetReceiver : GlanceAppWidgetReceiver() {
+    override val glanceAppWidget: GlanceAppWidget = AppIconsWidget()
+}

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/widgets/apps/domain/actions/OpenAppOrStoreAction.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/widgets/apps/domain/actions/OpenAppOrStoreAction.kt
@@ -1,0 +1,49 @@
+/*
+ * Copyright (©) 2026 Mihai-Cristian Condrea
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.d4rk.android.apps.apptoolkit.app.widgets.apps.domain.actions
+
+import android.content.Context
+import androidx.glance.GlanceId
+import androidx.glance.action.ActionParameters
+import androidx.glance.appwidget.action.ActionCallback
+import com.d4rk.android.libs.apptoolkit.core.utils.extensions.context.openPlayStoreForApp
+import com.d4rk.android.libs.apptoolkit.core.utils.extensions.context.startActivitySafely
+
+/**
+ * Tries to launch an installed app from the widget and falls back to Play Store when missing.
+ */
+class OpenAppOrStoreAction : ActionCallback {
+    override suspend fun onAction(
+        context: Context,
+        glanceId: GlanceId,
+        parameters: ActionParameters,
+    ) {
+        val packageName = parameters[PACKAGE_NAME_KEY].orEmpty()
+        if (packageName.isBlank()) return
+
+        val launchIntent = context.packageManager.getLaunchIntentForPackage(packageName)
+        val openedApp = launchIntent != null && context.startActivitySafely(intent = launchIntent)
+        if (!openedApp) {
+            context.openPlayStoreForApp(packageName)
+        }
+    }
+
+    companion object {
+        val PACKAGE_NAME_KEY: ActionParameters.Key<String> = ActionParameters.Key(name = "package_name")
+    }
+}

--- a/app/src/main/res/layout/widget_app_icons_loading.xml
+++ b/app/src/main/res/layout/widget_app_icons_loading.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (©) 2026 Mihai-Cristian Condrea
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program. If not, see <https://www.gnu.org/licenses/>.
+  -->
+
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:gravity="center"
+    android:orientation="vertical"
+    android:padding="12dp">
+
+    <ProgressBar
+        android:layout_width="24dp"
+        android:layout_height="24dp" />
+</LinearLayout>

--- a/app/src/main/res/xml/app_icons_widget_info.xml
+++ b/app/src/main/res/xml/app_icons_widget_info.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (©) 2026 Mihai-Cristian Condrea
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program. If not, see <https://www.gnu.org/licenses/>.
+  -->
+
+<appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    android:description="@string/app_short_description"
+    android:initialLayout="@layout/widget_app_icons_loading"
+    android:minHeight="120dp"
+    android:minWidth="120dp"
+    android:previewImage="@drawable/ic_launcher_foreground"
+    android:resizeMode="horizontal|vertical"
+    android:targetCellHeight="2"
+    android:targetCellWidth="2"
+    android:updatePeriodMillis="0"
+    android:widgetCategory="home_screen" />


### PR DESCRIPTION
### Motivation
- Provide a scrollable home-screen Glance widget that displays developer app icons and lets users tap to open the app or fall back to the Play Store, matching the app's existing behavior. 
- Keep changes inside `app/widgets/apps` and reuse existing app APIs so no new dependencies are introduced.

### Description
- Add `AppIconsWidget` (Glance) in `app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/widgets/apps/AppIconsWidget.kt` that loads developer apps via `FetchDeveloperAppsUseCase` and renders a `LazyColumn` of icons and names. 
- Add `OpenAppOrStoreAction` in `app/widgets/apps/domain/actions` which attempts to launch a package via `startActivitySafely` and falls back to `openPlayStoreForApp` when needed. 
- Add `AppIconsWidgetReceiver`, widget provider metadata `app/src/main/res/xml/app_icons_widget_info.xml`, and a small loading layout `app/src/main/res/layout/widget_app_icons_loading.xml`, and register the receiver in `AndroidManifest.xml`. 
- Provide a safe fallback app entry when remote data is unavailable and convert `Drawable` to `Bitmap` for use with `ImageProvider` in Glance.

### Testing
- Ran `./gradlew :app:compileDebugKotlin` to validate build, which failed in this environment due to an unrelated Gradle plugin resolution error (`org.gradle.toolchains.foojay-resolver-convention` could not be resolved). 
- No other automated tests were executed in this environment against the new widget code.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997f59174f8832d9f3fd7c63f42ae6f)