### PR TITLE
Standardize icon sizes across buttons and navigation components

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
 # Version 2.0.7:
 
 - **Minor**: Made selected labels bold for the bottom navigation bar and navigation rail.
+- **Minor**: Improved icon sizing consistency across buttons, the top app bar, navigation drawer,
+  and navigation rail.
+- **Minor**: Refined some loading indicators for a more expressive look and feel.
 - **Patch**: Fixed feedback sheet icons alignment with preference content on the Help screen.
 - **Patch**: Restyled the Help feedback sheet to use grouped preference cards with rounded-section corners.
+- **Patch**: Improved accessibility for some icon-only buttons and dialog actions.
+- **Patch**: Updated dependencies and polished internal resources.
 
 # Version 2.0.6:
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -54,7 +54,7 @@ android {
         applicationIdSuffix = ".apptoolkit"
         minSdk = 26
         targetSdk = 36
-        versionCode = 110
+        versionCode = 109
         versionName = providers.gradleProperty("PUBLISHING_VERSION").get()
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         @Suppress("UnstableApiUsage")

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/ui/views/AppCard.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/ui/views/AppCard.kt
@@ -89,12 +89,10 @@ fun AppCard(
                 GeneralTextButton(
                     onClick = onFavoriteToggle,
                     vectorIcon = if (isFavorite) Icons.Filled.Star else Icons.Outlined.StarOutline,
-                    iconContentDescription = null
                 )
                 GeneralTextButton(
                     onClick = { onShareClick(appInfo) },
                     vectorIcon = Icons.Outlined.Share,
-                    iconContentDescription = null
                 )
             }
             Column(

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/ui/views/AppDetailsBottomSheet.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/ui/views/AppDetailsBottomSheet.kt
@@ -41,7 +41,7 @@ import androidx.compose.material.icons.outlined.Info
 import androidx.compose.material.icons.outlined.Share
 import androidx.compose.material.icons.outlined.StarOutline
 import androidx.compose.material3.Card
-import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.CircularWavyProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -152,7 +152,7 @@ fun AppDetailsBottomSheet(
                 }
 
                 null -> {
-                    CircularProgressIndicator()
+                    CircularWavyProgressIndicator()
                 }
             }
         }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/main/ui/views/dialogs/ChangelogDialog.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/main/ui/views/dialogs/ChangelogDialog.kt
@@ -23,7 +23,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.NewReleases
-import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.CircularWavyProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -48,6 +49,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import org.koin.compose.koinInject
 
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun ChangelogDialog(
     changelogUrl: String,
@@ -103,7 +105,7 @@ fun ChangelogDialog(
 
             when {
                 currentChangelogText == null && !currentIsError -> Row(verticalAlignment = Alignment.CenterVertically) {
-                    CircularProgressIndicator()
+                    CircularWavyProgressIndicator()
                     LargeHorizontalSpacer()
                     Text(text = stringResource(id = R.string.loading_changelog_message))
                 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/main/ui/views/navigation/LeftNavigationRail.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/main/ui/views/navigation/LeftNavigationRail.kt
@@ -37,8 +37,8 @@ import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/main/ui/views/navigation/LeftNavigationRail.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/main/ui/views/navigation/LeftNavigationRail.kt
@@ -38,6 +38,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Icon
@@ -132,7 +133,9 @@ fun <T : StableNavKey> LeftNavigationRail(
                         Icon(
                             imageVector = if (isSelected) item.selectedIcon else item.icon,
                             contentDescription = stringResource(item.title),
-                            modifier = Modifier.bounceClick()
+                            modifier = Modifier
+                                .size(size = SizeConstants.TwentyFourSize)
+                                .bounceClick()
                         )
                     },
                     label = {
@@ -160,7 +163,9 @@ fun <T : StableNavKey> LeftNavigationRail(
                         Icon(
                             imageVector = item.selectedIcon,
                             contentDescription = stringResource(id = item.title),
-                            modifier = Modifier.bounceClick()
+                            modifier = Modifier
+                                .size(size = SizeConstants.TwentyFourSize)
+                                .bounceClick()
                         )
                     },
                     label = {

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/main/ui/views/navigation/MainTopAppBar.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/main/ui/views/navigation/MainTopAppBar.kt
@@ -39,6 +39,7 @@ import com.d4rk.android.libs.apptoolkit.app.support.ui.SupportActivity
 import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.AnimatedIconButtonDirection
 import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.ButtonFeedback
 import com.d4rk.android.libs.apptoolkit.core.ui.views.dropdown.CommonDropdownMenuItem
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.core.utils.extensions.context.openActivity
 
 /**
@@ -69,7 +70,8 @@ fun MainTopAppBar(
                 icon = navigationIcon,
                 contentDescription = stringResource(id = R.string.go_back),
                 onClick = onNavigationIconClick,
-                feedback = ButtonFeedback(hapticFeedbackType = null)
+                feedback = ButtonFeedback(hapticFeedbackType = null),
+                iconSize = SizeConstants.TwentyFourSize,
             )
         },
         actions = {
@@ -80,6 +82,7 @@ fun MainTopAppBar(
                 icon = Icons.Outlined.MoreVert,
                 contentDescription = stringResource(id = R.string.content_description_more_options),
                 onClick = { setExpandedMenu(true) },
+                iconSize = SizeConstants.TwentyFourSize,
             )
 
             DropdownMenu(

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/main/ui/views/navigation/NavigationDrawerItemContent.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/main/ui/views/navigation/NavigationDrawerItemContent.kt
@@ -20,6 +20,7 @@ package com.d4rk.android.libs.apptoolkit.app.main.ui.views.navigation
 import android.view.SoundEffectConstants
 import android.view.View
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationDrawerItem
@@ -50,7 +51,11 @@ fun NavigationDrawerItemContent(
             view.playSoundEffect(SoundEffectConstants.CLICK)
             handleNavigationItemClick()
         }, icon = {
-            Icon(item.selectedIcon, contentDescription = title)
+            Icon(
+                imageVector = item.selectedIcon,
+                contentDescription = title,
+                modifier = Modifier.size(size = SizeConstants.TwentyFourSize),
+            )
         }, badge = {
             if (item.badgeText.isNotBlank()) {
                 Text(text = item.badgeText)

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingScreen.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingScreen.kt
@@ -17,6 +17,7 @@
 
 package com.d4rk.android.libs.apptoolkit.app.onboarding.ui
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
@@ -29,7 +30,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PagerState
 import androidx.compose.foundation.pager.rememberPagerState
-import androidx.activity.compose.BackHandler
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.SkipNext
 import androidx.compose.material3.ExperimentalMaterial3Api

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/views/pages/firebase/text/PrivacyPolicySection.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/views/pages/firebase/text/PrivacyPolicySection.kt
@@ -76,7 +76,6 @@ fun PrivacyPolicySection() {
                 }
             },
             vectorIcon = Icons.AutoMirrored.Filled.Launch,
-            iconContentDescription = null,
             label = stringResource(id = R.string.learn_more_privacy_policy)
         )
     }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/buttons/AnimatedIconButtonDirection.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/buttons/AnimatedIconButtonDirection.kt
@@ -31,8 +31,10 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.Dp
 import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
 import com.d4rk.android.libs.apptoolkit.core.ui.model.analytics.Ga4EventData
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 
 /**
  * An animated button that slides in and out horizontally with a fade effect.
@@ -51,6 +53,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.model.analytics.Ga4EventData
  * @param feedback The feedback configuration for sound and haptics.
  * @param fromRight If true, the button will slide in from the right and slide out to the right.
  *                  If false, the button will slide in from the left and slide out to the left. Defaults to false.
+ * @param iconSize The icon size rendered inside the underlying icon-only button.
  * @param firebaseController Optional Firebase controller used to log GA4 events.
  * @param ga4Event Optional GA4 event data to log on click.
  */
@@ -66,6 +69,7 @@ fun AnimatedIconButtonDirection(
     autoAnimate: Boolean = true,
     feedback: ButtonFeedback = ButtonFeedback(),
     fromRight: Boolean = false,
+    iconSize: Dp = SizeConstants.TwentyFourSize,
     firebaseController: FirebaseController? = null,
     ga4Event: Ga4EventData? = null,
 ) {
@@ -97,6 +101,7 @@ fun AnimatedIconButtonDirection(
             enabled = true,
             iconContentDescription = contentDescription,
             vectorIcon = icon,
+            iconSize = iconSize,
             feedback = feedback,
             firebaseController = firebaseController,
             ga4Event = ga4Event,

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/buttons/GeneralButton.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/buttons/GeneralButton.kt
@@ -19,6 +19,7 @@ package com.d4rk.android.libs.apptoolkit.core.ui.views.buttons
 
 import android.view.View
 import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -28,6 +29,7 @@ import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
 import com.d4rk.android.libs.apptoolkit.core.ui.model.analytics.Ga4EventData
 import com.d4rk.android.libs.apptoolkit.core.ui.views.analytics.logGa4Event
@@ -45,6 +47,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.ButtonIconSpacer
  * @param label The text to be displayed on the button, or `null` for icon-only usage.
  * @param vectorIcon The [ImageVector] to be displayed as the leading icon.
  * @param painterIcon The [Painter] to be displayed when no vector icon is provided.
+ * @param iconSize The icon size used when this composable renders icon + text content.
  * @param feedback The feedback configuration for sound and haptics.
  * @param firebaseController Optional Firebase controller used to log GA4 events.
  * @param ga4Event Optional GA4 event data to log on click.
@@ -58,6 +61,7 @@ fun GeneralButton(
     label: String? = null,
     vectorIcon: ImageVector? = null,
     painterIcon: Painter? = null,
+    iconSize: Dp = ButtonDefaults.IconSize,
     feedback: ButtonFeedback = ButtonFeedback(),
     firebaseController: FirebaseController? = null,
     ga4Event: Ga4EventData? = null,
@@ -99,6 +103,7 @@ fun GeneralButton(
                 icon = vectorIcon,
                 painter = painterIcon,
                 contentDescription = iconContentDescription,
+                size = iconSize,
             )
             ButtonIconSpacer()
         }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/buttons/GeneralButton.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/buttons/GeneralButton.kt
@@ -19,7 +19,6 @@ package com.d4rk.android.libs.apptoolkit.core.ui.views.buttons
 
 import android.view.View
 import androidx.compose.material3.Button
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -35,6 +34,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.model.analytics.Ga4EventData
 import com.d4rk.android.libs.apptoolkit.core.ui.views.analytics.logGa4Event
 import com.d4rk.android.libs.apptoolkit.core.ui.views.modifiers.bounceClick
 import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.ButtonIconSpacer
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 
 /**
  * A Material Design [Button] that supports text-only, icon+text, or icon-only rendering.
@@ -61,7 +61,7 @@ fun GeneralButton(
     label: String? = null,
     vectorIcon: ImageVector? = null,
     painterIcon: Painter? = null,
-    iconSize: Dp = ButtonDefaults.IconSize,
+    iconSize: Dp = SizeConstants.ButtonIconSize,
     feedback: ButtonFeedback = ButtonFeedback(),
     firebaseController: FirebaseController? = null,
     ga4Event: Ga4EventData? = null,
@@ -85,6 +85,7 @@ fun GeneralButton(
             firebaseController = firebaseController,
             ga4Event = ga4Event,
             style = IconOnlyButtonStyle.Filled,
+            iconSize = iconSize,
         )
         return
     }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/buttons/GeneralOutlinedButton.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/buttons/GeneralOutlinedButton.kt
@@ -18,7 +18,6 @@
 package com.d4rk.android.libs.apptoolkit.core.ui.views.buttons
 
 import android.view.View
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -35,6 +34,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.model.analytics.Ga4EventData
 import com.d4rk.android.libs.apptoolkit.core.ui.views.analytics.logGa4Event
 import com.d4rk.android.libs.apptoolkit.core.ui.views.modifiers.bounceClick
 import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.ButtonIconSpacer
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 
 /**
  * An outlined button that supports text-only, icon+text, or icon-only rendering.
@@ -61,7 +61,7 @@ fun GeneralOutlinedButton(
     label: String? = null,
     vectorIcon: ImageVector? = null,
     painterIcon: Painter? = null,
-    iconSize: Dp = ButtonDefaults.IconSize,
+    iconSize: Dp = SizeConstants.ButtonIconSize,
     feedback: ButtonFeedback = ButtonFeedback(),
     firebaseController: FirebaseController? = null,
     ga4Event: Ga4EventData? = null,
@@ -85,6 +85,7 @@ fun GeneralOutlinedButton(
             firebaseController = firebaseController,
             ga4Event = ga4Event,
             style = IconOnlyButtonStyle.Outlined,
+            iconSize = iconSize,
         )
         return
     }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/buttons/GeneralOutlinedButton.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/buttons/GeneralOutlinedButton.kt
@@ -18,6 +18,7 @@
 package com.d4rk.android.libs.apptoolkit.core.ui.views.buttons
 
 import android.view.View
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.OutlinedButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -28,6 +29,7 @@ import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
 import com.d4rk.android.libs.apptoolkit.core.ui.model.analytics.Ga4EventData
 import com.d4rk.android.libs.apptoolkit.core.ui.views.analytics.logGa4Event
@@ -45,6 +47,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.ButtonIconSpacer
  * @param label The text to be displayed on the button, or `null` for icon-only usage.
  * @param vectorIcon The [ImageVector] to be displayed inside the button.
  * @param painterIcon The [Painter] to be displayed when no vector icon is provided.
+ * @param iconSize The icon size used when this composable renders icon + text content.
  * @param feedback The feedback configuration for sound and haptics.
  * @param firebaseController Optional Firebase controller used to log GA4 events.
  * @param ga4Event Optional GA4 event data to log on click.
@@ -58,6 +61,7 @@ fun GeneralOutlinedButton(
     label: String? = null,
     vectorIcon: ImageVector? = null,
     painterIcon: Painter? = null,
+    iconSize: Dp = ButtonDefaults.IconSize,
     feedback: ButtonFeedback = ButtonFeedback(),
     firebaseController: FirebaseController? = null,
     ga4Event: Ga4EventData? = null,
@@ -99,6 +103,7 @@ fun GeneralOutlinedButton(
                 icon = vectorIcon,
                 painter = painterIcon,
                 contentDescription = iconContentDescription,
+                size = iconSize,
             )
             ButtonIconSpacer()
         }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/buttons/GeneralTextButton.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/buttons/GeneralTextButton.kt
@@ -18,7 +18,6 @@
 package com.d4rk.android.libs.apptoolkit.core.ui.views.buttons
 
 import android.view.View
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -35,6 +34,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.model.analytics.Ga4EventData
 import com.d4rk.android.libs.apptoolkit.core.ui.views.analytics.logGa4Event
 import com.d4rk.android.libs.apptoolkit.core.ui.views.modifiers.bounceClick
 import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.ButtonIconSpacer
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 
 /**
  * A Material Design [TextButton] that supports text-only, icon+text, or icon-only rendering.
@@ -61,7 +61,7 @@ fun GeneralTextButton(
     label: String? = null,
     vectorIcon: ImageVector? = null,
     painterIcon: Painter? = null,
-    iconSize: Dp = ButtonDefaults.IconSize,
+    iconSize: Dp = SizeConstants.ButtonIconSize,
     feedback: ButtonFeedback = ButtonFeedback(),
     firebaseController: FirebaseController? = null,
     ga4Event: Ga4EventData? = null,
@@ -85,6 +85,7 @@ fun GeneralTextButton(
             firebaseController = firebaseController,
             ga4Event = ga4Event,
             style = IconOnlyButtonStyle.Standard,
+            iconSize = iconSize,
         )
         return
     }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/buttons/GeneralTextButton.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/buttons/GeneralTextButton.kt
@@ -18,6 +18,7 @@
 package com.d4rk.android.libs.apptoolkit.core.ui.views.buttons
 
 import android.view.View
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -28,6 +29,7 @@ import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
 import com.d4rk.android.libs.apptoolkit.core.ui.model.analytics.Ga4EventData
 import com.d4rk.android.libs.apptoolkit.core.ui.views.analytics.logGa4Event
@@ -45,6 +47,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.ButtonIconSpacer
  * @param label The text to be displayed on the button, or `null` for icon-only usage.
  * @param vectorIcon The [ImageVector] to be displayed as the leading icon.
  * @param painterIcon The [Painter] to be displayed when no vector icon is provided.
+ * @param iconSize The icon size used when this composable renders icon + text content.
  * @param feedback The feedback configuration for sound and haptics.
  * @param firebaseController Optional Firebase controller used to log GA4 events.
  * @param ga4Event Optional GA4 event data to log on click.
@@ -58,6 +61,7 @@ fun GeneralTextButton(
     label: String? = null,
     vectorIcon: ImageVector? = null,
     painterIcon: Painter? = null,
+    iconSize: Dp = ButtonDefaults.IconSize,
     feedback: ButtonFeedback = ButtonFeedback(),
     firebaseController: FirebaseController? = null,
     ga4Event: Ga4EventData? = null,
@@ -99,6 +103,7 @@ fun GeneralTextButton(
                 icon = vectorIcon,
                 painter = painterIcon,
                 contentDescription = iconContentDescription,
+                size = iconSize,
             )
             ButtonIconSpacer()
         }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/buttons/GeneralTonalButton.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/buttons/GeneralTonalButton.kt
@@ -18,7 +18,6 @@
 package com.d4rk.android.libs.apptoolkit.core.ui.views.buttons
 
 import android.view.View
-import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -35,6 +34,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.model.analytics.Ga4EventData
 import com.d4rk.android.libs.apptoolkit.core.ui.views.analytics.logGa4Event
 import com.d4rk.android.libs.apptoolkit.core.ui.views.modifiers.bounceClick
 import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.ButtonIconSpacer
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 
 /**
  * A filled tonal button that supports text-only, icon+text, or icon-only rendering.
@@ -60,7 +60,7 @@ fun GeneralTonalButton(
     label: String? = null,
     vectorIcon: ImageVector? = null,
     painterIcon: Painter? = null,
-    iconSize: Dp = ButtonDefaults.IconSize,
+    iconSize: Dp = SizeConstants.ButtonIconSize,
     feedback: ButtonFeedback = ButtonFeedback(),
     firebaseController: FirebaseController? = null,
     ga4Event: Ga4EventData? = null,
@@ -84,6 +84,7 @@ fun GeneralTonalButton(
             firebaseController = firebaseController,
             ga4Event = ga4Event,
             style = IconOnlyButtonStyle.FilledTonal,
+            iconSize = iconSize,
         )
         return
     }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/buttons/GeneralTonalButton.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/buttons/GeneralTonalButton.kt
@@ -18,6 +18,7 @@
 package com.d4rk.android.libs.apptoolkit.core.ui.views.buttons
 
 import android.view.View
+import androidx.compose.material3.ButtonDefaults
 import androidx.compose.material3.FilledTonalButton
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -28,6 +29,7 @@ import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.Dp
 import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
 import com.d4rk.android.libs.apptoolkit.core.ui.model.analytics.Ga4EventData
 import com.d4rk.android.libs.apptoolkit.core.ui.views.analytics.logGa4Event
@@ -58,6 +60,7 @@ fun GeneralTonalButton(
     label: String? = null,
     vectorIcon: ImageVector? = null,
     painterIcon: Painter? = null,
+    iconSize: Dp = ButtonDefaults.IconSize,
     feedback: ButtonFeedback = ButtonFeedback(),
     firebaseController: FirebaseController? = null,
     ga4Event: Ga4EventData? = null,
@@ -99,6 +102,7 @@ fun GeneralTonalButton(
                 icon = vectorIcon,
                 painter = painterIcon,
                 contentDescription = iconContentDescription,
+                size = iconSize,
             )
             ButtonIconSpacer()
         }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/buttons/IconContent.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/buttons/IconContent.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.unit.Dp
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 
 private const val IconRequirementMessage: String = "Either icon or painter must be provided"
 
@@ -34,11 +35,11 @@ internal fun IconContent(
     icon: ImageVector?,
     painter: Painter?,
     contentDescription: String?,
-    size: Dp? = null,
+    size: Dp = SizeConstants.ButtonIconSize,
 ) {
     require(icon != null || painter != null) { IconRequirementMessage }
 
-    val iconModifier: Modifier = if (size != null) Modifier.size(size = size) else Modifier
+    val iconModifier: Modifier = Modifier.size(size = size)
     val stableIcon by rememberUpdatedState(newValue = icon)
     val stablePainter by rememberUpdatedState(newValue = painter)
     when {

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/buttons/IconContent.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/buttons/IconContent.kt
@@ -17,6 +17,7 @@
 
 package com.d4rk.android.libs.apptoolkit.core.ui.views.buttons
 
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -24,6 +25,7 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.unit.Dp
 
 private const val IconRequirementMessage: String = "Either icon or painter must be provided"
 
@@ -32,11 +34,11 @@ internal fun IconContent(
     icon: ImageVector?,
     painter: Painter?,
     contentDescription: String?,
+    size: Dp? = null,
 ) {
     require(icon != null || painter != null) { IconRequirementMessage }
 
-    val iconModifier: Modifier = Modifier
-    //.size(size = SizeConstants.ButtonIconSize) // REMINDER: Enable it later when compose team adds the correct value
+    val iconModifier: Modifier = if (size != null) Modifier.size(size = size) else Modifier
     val stableIcon by rememberUpdatedState(newValue = icon)
     val stablePainter by rememberUpdatedState(newValue = painter)
     when {

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/buttons/IconOnlyButton.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/buttons/IconOnlyButton.kt
@@ -27,10 +27,12 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.unit.Dp
 import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
 import com.d4rk.android.libs.apptoolkit.core.ui.model.analytics.Ga4EventData
 import com.d4rk.android.libs.apptoolkit.core.ui.views.analytics.logGa4Event
 import com.d4rk.android.libs.apptoolkit.core.ui.views.modifiers.bounceClick
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 
 internal enum class IconOnlyButtonStyle {
     Filled,
@@ -56,6 +58,7 @@ internal fun IconOnlyButton(
     firebaseController: FirebaseController? = null,
     ga4Event: Ga4EventData? = null,
     style: IconOnlyButtonStyle = IconOnlyButtonStyle.Filled,
+    iconSize: Dp = SizeConstants.TwentyFourSize,
 ) {
     val hapticFeedback: HapticFeedback = LocalHapticFeedback.current
     val view: View = LocalView.current
@@ -76,7 +79,8 @@ internal fun IconOnlyButton(
             IconContent(
                 icon = vectorIcon,
                 painter = painterIcon,
-                contentDescription = iconContentDescription
+                contentDescription = iconContentDescription,
+                size = iconSize,
             )
         }
         IconOnlyButtonStyle.FilledTonal -> androidx.compose.material3.FilledTonalIconButton(
@@ -88,7 +92,8 @@ internal fun IconOnlyButton(
             IconContent(
                 icon = vectorIcon,
                 painter = painterIcon,
-                contentDescription = iconContentDescription
+                contentDescription = iconContentDescription,
+                size = iconSize,
             )
         }
         IconOnlyButtonStyle.Outlined -> androidx.compose.material3.OutlinedIconButton(
@@ -100,7 +105,8 @@ internal fun IconOnlyButton(
             IconContent(
                 icon = vectorIcon,
                 painter = painterIcon,
-                contentDescription = iconContentDescription
+                contentDescription = iconContentDescription,
+                size = iconSize,
             )
         }
         IconOnlyButtonStyle.Standard -> androidx.compose.material3.IconButton(
@@ -112,7 +118,8 @@ internal fun IconOnlyButton(
             IconContent(
                 icon = vectorIcon,
                 painter = painterIcon,
-                contentDescription = iconContentDescription
+                contentDescription = iconContentDescription,
+                size = iconSize,
             )
         }
     }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/dialogs/BasicFullScreenDialog.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/dialogs/BasicFullScreenDialog.kt
@@ -76,7 +76,7 @@ fun BasicFullScreenDialog(
                     GeneralTextButton(
                         onClick = onDismiss,
                         vectorIcon = Icons.Filled.Close,
-                        iconContentDescription = null
+                        iconContentDescription = title
                     )
                 }, title = { Text(text = title) }, actions = {
                     TextButton(modifier = Modifier.bounceClick(), onClick = {

--- a/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/app/consent/domain/usecases/ApplyConsentSettingsUseCaseTest.kt
+++ b/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/app/consent/domain/usecases/ApplyConsentSettingsUseCaseTest.kt
@@ -20,8 +20,8 @@ package com.d4rk.android.libs.apptoolkit.app.consent.domain.usecases
 import com.d4rk.android.libs.apptoolkit.app.consent.domain.model.ConsentSettings
 import com.d4rk.android.libs.apptoolkit.app.consent.domain.repository.ConsentRepository
 import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
-import io.mockk.mockk
 import io.mockk.coVerify
+import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test

--- a/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/app/consent/domain/usecases/ApplyInitialConsentUseCaseTest.kt
+++ b/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/app/consent/domain/usecases/ApplyInitialConsentUseCaseTest.kt
@@ -19,8 +19,8 @@ package com.d4rk.android.libs.apptoolkit.app.consent.domain.usecases
 
 import com.d4rk.android.libs.apptoolkit.app.consent.domain.repository.ConsentRepository
 import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
-import io.mockk.mockk
 import io.mockk.coVerify
+import io.mockk.mockk
 import io.mockk.verify
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test


### PR DESCRIPTION
### Motivation

- Ensure consistent icon sizing across the UI by making icon sizes configurable and explicitly applied to various buttons and navigation elements. 
- Prevent layout shifts and inconsistent visual weight when icons are used in different composables by using a single size constant as the default. 

### Description

- Added an optional `size` parameter to `IconContent` and applied it when rendering icons via `Modifier.size`, and introduced `iconSize` parameters to `AnimatedIconButtonDirection`, `IconOnlyButton`, `GeneralButton`, `GeneralOutlinedButton`, `GeneralTextButton`, and `GeneralTonalButton` to control icon sizing. 
- Wired `iconSize` through `AnimatedIconButtonDirection` into the underlying `IconOnlyButton`, and defaulted sizes to `SizeConstants.TwentyFourSize` or `ButtonDefaults.IconSize` where appropriate. 
- Updated navigation components to explicitly size icons: `LeftNavigationRail` and `NavigationDrawerItemContent` now use `Modifier.size(SizeConstants.TwentyFourSize)` for their icons, and `MainTopAppBar` forwards `iconSize` to `AnimatedIconButtonDirection`. 

### Testing

- Performed a full project build with `./gradlew assemble` which completed successfully. 
- Ran unit tests with `./gradlew test` and they passed. 
- Ran basic lint/check tasks (`./gradlew check`) which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ab3a1dc400832d87854e013e3c6577)