### PR TITLE
Refactor consent flow to UI layer, remove blocking startup work, update settings provider and secure activities

### DIFF
--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/AppToolkit.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/AppToolkit.kt
@@ -36,18 +36,22 @@ import com.d4rk.android.libs.apptoolkit.core.data.remote.ads.AdsCoreManager
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.colorscheme.StaticPaletteIds
 import com.d4rk.android.libs.apptoolkit.core.utils.extensions.date.isChristmasSeason
 import com.d4rk.android.libs.apptoolkit.core.utils.extensions.date.isHalloweenSeason
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.supervisorScope
+import kotlinx.coroutines.withContext
 import org.koin.android.ext.android.getKoin
 import java.time.LocalDate
 import java.time.ZoneId
 
 class AppToolkit : BaseCoreManager(), DefaultLifecycleObserver {
     private var currentActivity: Activity? = null
+    private val appScope = CoroutineScope(SupervisorJob() + dispatchers.io)
 
     private val adsCoreManager: AdsCoreManager by lazy { getKoin().get<AdsCoreManager>() }
 
@@ -68,21 +72,26 @@ class AppToolkit : BaseCoreManager(), DefaultLifecycleObserver {
     }
 
     private fun applyDefaultColorPalette() {
-        val colorPalette: ColorPalette = resolveDefaultColorPalette()
-        AppThemeConfig.customLightScheme = colorPalette.lightColorScheme
-        AppThemeConfig.customDarkScheme = colorPalette.darkColorScheme
-        ThemePaletteProvider.defaultPalette = colorPalette
+        // Change rationale: startup palette resolution previously used runBlocking DataStore reads on
+        // the main thread, increasing cold-start latency risk. We now apply a deterministic palette
+        // immediately and reconcile seasonal preferences asynchronously.
+        val initialPalette: ColorPalette = getKoin().get()
+        applyColorPalette(initialPalette)
+
+        appScope.launch {
+            val palette = resolvePreferredColorPalette()
+            withContext(dispatchers.main) {
+                applyColorPalette(palette)
+            }
+        }
     }
 
-    private fun resolveDefaultColorPalette(): ColorPalette {
+    private suspend fun resolvePreferredColorPalette(): ColorPalette {
         val dataStore: CommonDataStore = CommonDataStore.getInstance(context = this)
-
-        val hasInteractedWithSettings: Boolean = runBlocking {
-            dataStore.settingsInteracted.first()
-        }
+        val hasInteractedWithSettings: Boolean = dataStore.settingsInteracted.first()
 
         if (!hasInteractedWithSettings) {
-            val staticPaletteId: String = runBlocking { dataStore.staticPaletteId.first() }
+            val staticPaletteId: String = dataStore.staticPaletteId.first()
             val today: LocalDate = LocalDate.now(ZoneId.systemDefault())
             val shouldUseSeasonalPalette: Boolean = staticPaletteId == StaticPaletteIds.DEFAULT
 
@@ -96,6 +105,12 @@ class AppToolkit : BaseCoreManager(), DefaultLifecycleObserver {
         }
 
         return getKoin().get()
+    }
+
+    private fun applyColorPalette(colorPalette: ColorPalette) {
+        AppThemeConfig.customLightScheme = colorPalette.lightColorScheme
+        AppThemeConfig.customDarkScheme = colorPalette.darkColorScheme
+        ThemePaletteProvider.defaultPalette = colorPalette
     }
 
     override fun onStart(owner: LifecycleOwner) {
@@ -124,5 +139,10 @@ class AppToolkit : BaseCoreManager(), DefaultLifecycleObserver {
         if (currentActivity === activity) {
             currentActivity = null
         }
+    }
+
+    override fun onTerminate() {
+        appScope.cancel()
+        super.onTerminate()
     }
 }

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/settings/settings/utils/providers/AppSettingsProvider.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/settings/settings/utils/providers/AppSettingsProvider.kt
@@ -34,8 +34,12 @@ import com.d4rk.android.libs.apptoolkit.app.settings.utils.constants.SettingsCon
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.interfaces.SettingsProvider
 import com.d4rk.android.libs.apptoolkit.core.utils.extensions.context.openAppNotificationSettings
 
-class AppSettingsProvider : SettingsProvider {
-    override fun provideSettingsConfig(context: Context): SettingsConfig {
+class AppSettingsProvider(
+    context: Context,
+) : SettingsProvider {
+    private val context: Context = context.applicationContext
+
+    override fun provideSettingsConfig(): SettingsConfig {
         return SettingsConfig(
             title = context.getString(R.string.settings),
             categories = listOf(

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/app/modules/OnboardingModule.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/app/modules/OnboardingModule.kt
@@ -41,7 +41,6 @@ val onboardingModule: Module = module {
         OnboardingViewModel(
             observeOnboardingCompletionUseCase = get(),
             completeOnboardingUseCase = get(),
-            requestConsentUseCase = get(),
             dispatchers = get(),
             firebaseController = get(),
         )

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/apptoolkit/modules/AppToolkitCoreModule.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/apptoolkit/modules/AppToolkitCoreModule.kt
@@ -37,8 +37,6 @@ val appToolkitCoreModule: Module = module {
 
     viewModel {
         StartupViewModel(
-            requestConsentUseCase = get(),
-            dispatchers = get(),
             firebaseController = get()
         )
     }

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/settings/modules/SettingsRootModule.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/settings/modules/SettingsRootModule.kt
@@ -25,7 +25,7 @@ import org.koin.core.module.dsl.viewModel
 import org.koin.dsl.module
 
 val settingsRootModule: Module = module {
-    single<SettingsProvider> { AppSettingsProvider() }
+    single<SettingsProvider> { AppSettingsProvider(context = get()) }
 
     viewModel {
         SettingsViewModel(

--- a/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/settings/settings/utils/providers/AppSettingsProviderTest.kt
+++ b/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/settings/settings/utils/providers/AppSettingsProviderTest.kt
@@ -39,8 +39,6 @@ import kotlin.test.assertNull
 
 class AppSettingsProviderTest {
 
-    private val provider = AppSettingsProvider()
-
     private val defaultStrings = mapOf(
         R.string.settings to "Settings",
         R.string.notifications to "Notifications",
@@ -63,12 +61,13 @@ class AppSettingsProviderTest {
     @Test
     fun `provideSettingsConfig returns expected configuration`() {
         val context = createContext(defaultStrings)
+        val provider = AppSettingsProvider(context)
         mockkStatic("com.d4rk.android.libs.apptoolkit.core.utils.extensions.context.ContextIntentExtensionsKt")
         mockkObject(GeneralSettingsActivity.Companion)
         every { context.openAppNotificationSettings() } returns true
         every { GeneralSettingsActivity.start(any(), any(), any()) } just Runs
 
-        val config = provider.provideSettingsConfig(context)
+        val config = provider.provideSettingsConfig()
 
         assertEquals(defaultStrings[R.string.settings], config.title)
         assertEquals(2, config.categories.size)
@@ -166,12 +165,13 @@ class AppSettingsProviderTest {
     @Test
     fun `notifications preference falls back to privacy screen when system settings cannot open`() {
         val context = createContext(defaultStrings)
+        val provider = AppSettingsProvider(context)
         mockkStatic("com.d4rk.android.libs.apptoolkit.core.utils.extensions.context.ContextIntentExtensionsKt")
         mockkObject(GeneralSettingsActivity.Companion)
         every { context.openAppNotificationSettings() } returns false
         every { GeneralSettingsActivity.start(any(), any(), any()) } just Runs
 
-        val config = provider.provideSettingsConfig(context)
+        val config = provider.provideSettingsConfig()
         val notifications = config.categories.first().preferences.first()
 
         assertDoesNotThrow { notifications.action.invoke() }
@@ -189,23 +189,15 @@ class AppSettingsProviderTest {
     @Test
     fun `provideSettingsConfig handles missing resources without crashing`() {
         val context = createContext(emptyMap()) { "<missing>" }
+        val provider = AppSettingsProvider(context)
 
-        val config = assertDoesNotThrow { provider.provideSettingsConfig(context) }
+        val config = assertDoesNotThrow { provider.provideSettingsConfig() }
 
         assertEquals("<missing>", config.title)
         config.categories.flatMap { it.preferences }.forEach { preference ->
             assertEquals("<missing>", preference.title)
             assertEquals("<missing>", preference.summary)
         }
-    }
-
-    @Test
-    fun `provideSettingsConfig handles null context safely`() {
-        val result = assertDoesNotThrow {
-            null
-        }
-
-        assertNull(result)
     }
 
     private fun createContext(

--- a/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/settings/settings/utils/providers/AppSettingsProviderTest.kt
+++ b/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/settings/settings/utils/providers/AppSettingsProviderTest.kt
@@ -205,6 +205,7 @@ class AppSettingsProviderTest {
         fallback: (Int) -> String = { id -> "missing-$id" }
     ): Context {
         val context = mockk<Context>(relaxed = true)
+        every { context.applicationContext } returns context
         every { context.getString(any()) } answers { overrides[arg<Int>(0)] ?: fallback(arg(0)) }
         return context
     }

--- a/apptoolkit/src/main/AndroidManifest.xml
+++ b/apptoolkit/src/main/AndroidManifest.xml
@@ -74,13 +74,15 @@
             android:name=".app.onboarding.ui.OnboardingActivity"
             android:windowSoftInputMode="adjustResize" />
 
+        <!-- Internal settings entry screen. No cross-app launch contract is exposed. -->
         <activity
             android:name=".app.settings.settings.ui.SettingsActivity"
-            android:exported="true" />
+            android:exported="false" />
 
+        <!-- Internal settings detail host. Not part of a public contract; keep non-exported. -->
         <activity
             android:name=".app.settings.general.ui.GeneralSettingsActivity"
-            android:exported="true" />
+            android:exported="false" />
 
         <activity
             android:name=".app.permissions.ui.PermissionsActivity"
@@ -95,25 +97,30 @@
             </intent-filter>
         </activity>
 
+        <!-- Internal ads/preferences screen launched only from in-app navigation. -->
         <activity
             android:name=".app.ads.ui.AdsSettingsActivity"
-            android:exported="true" />
+            android:exported="false" />
 
+        <!-- Internal help center screen. External apps should not deep-link directly. -->
         <activity
             android:name=".app.help.ui.HelpActivity"
-            android:exported="true" />
+            android:exported="false" />
 
+        <!-- Internal licenses screen displayed from settings/help flows only. -->
         <activity
             android:name=".app.licenses.ui.LicensesActivity"
-            android:exported="true" />
+            android:exported="false" />
 
+        <!-- Internal support entry screen. Keep private to reduce intent spoofing surface. -->
         <activity
             android:name=".app.support.ui.SupportActivity"
-            android:exported="true" />
+            android:exported="false" />
 
+        <!-- Internal issue reporter screen; not intended as an externally callable API. -->
         <activity
             android:name=".app.issuereporter.ui.IssueReporterActivity"
-            android:exported="true"
+            android:exported="false"
             android:theme="@style/Theme.Material3.DayNight.NoActionBar" />
 
         <service

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/display/ui/views/dialogs/SelectLanguageAlertDialog.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/display/ui/views/dialogs/SelectLanguageAlertDialog.kt
@@ -74,15 +74,13 @@ fun SelectLanguageAlertDialog(onDismiss: () -> Unit, onLanguageSelected: (String
     val coroutineScope: CoroutineScope = rememberCoroutineScope()
     val selectedLanguage = remember { mutableStateOf(value = "") }
 
-    val preferenceLanguageEntries =
-        stringArrayResource(id = R.array.preference_language_entries).toList().toImmutableList()
-    val preferenceLanguageValues =
-        stringArrayResource(id = R.array.preference_language_values).toList().toImmutableList()
-    val languageEntries: ImmutableList<String> = remember {
-        preferenceLanguageEntries
+    val preferenceLanguageEntries = stringArrayResource(id = R.array.preference_language_entries)
+    val preferenceLanguageValues = stringArrayResource(id = R.array.preference_language_values)
+    val languageEntries: ImmutableList<String> = remember(preferenceLanguageEntries) {
+        preferenceLanguageEntries.toList().toImmutableList()
     }
-    val languageValues: ImmutableList<String> = remember {
-        preferenceLanguageValues
+    val languageValues: ImmutableList<String> = remember(preferenceLanguageValues) {
+        preferenceLanguageValues.toList().toImmutableList()
     }
 
     val currentLanguageState = dataStore.getLanguage()

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingActivity.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingActivity.kt
@@ -22,18 +22,23 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleOwner
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
 import com.d4rk.android.libs.apptoolkit.app.consent.domain.model.ConsentHost
+import com.d4rk.android.libs.apptoolkit.app.consent.domain.usecases.RequestConsentUseCase
+import com.d4rk.android.libs.apptoolkit.app.onboarding.ui.contract.OnboardingAction
 import com.d4rk.android.libs.apptoolkit.app.onboarding.ui.contract.OnboardingEvent
 import com.d4rk.android.libs.apptoolkit.app.theme.ui.style.AppTheme
+import kotlinx.coroutines.launch
+import org.koin.android.ext.android.inject
 import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class OnboardingActivity : ComponentActivity() {
 
     private val viewModel: OnboardingViewModel by viewModel()
-    private val consentHost: ConsentHost = object : ConsentHost {
-        override val activity = this@OnboardingActivity
-    }
+    private val requestConsentUseCase: RequestConsentUseCase by inject()
     private val lifecycleObserver = object : DefaultLifecycleObserver {
         override fun onResume(owner: LifecycleOwner) {
             checkUserConsent()
@@ -43,6 +48,7 @@ class OnboardingActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         lifecycle.addObserver(lifecycleObserver)
+        observeActions()
         enableEdgeToEdge()
         setContent {
             AppTheme {
@@ -52,6 +58,28 @@ class OnboardingActivity : ComponentActivity() {
     }
 
     private fun checkUserConsent() {
-        viewModel.onEvent(OnboardingEvent.RequestConsent(host = consentHost))
+        viewModel.onEvent(OnboardingEvent.RequestConsent)
+    }
+
+    private fun observeActions() {
+        lifecycleScope.launch {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
+                viewModel.actionEvent.collect { action ->
+                    when (action) {
+                        OnboardingAction.RequestConsentUi -> requestConsentFromUi()
+                        OnboardingAction.OnboardingCompleted -> Unit
+                    }
+                }
+            }
+        }
+    }
+
+    private fun requestConsentFromUi() {
+        val host: ConsentHost = object : ConsentHost {
+            override val activity = this@OnboardingActivity
+        }
+        lifecycleScope.launch {
+            requestConsentUseCase.invoke(host = host).collect { }
+        }
     }
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingScreen.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingScreen.kt
@@ -109,6 +109,7 @@ fun OnboardingScreen() {
     LaunchedEffect(Unit) {
         viewModel.actionEvent.collect { action ->
             when (action) {
+                OnboardingAction.RequestConsentUi -> Unit
                 OnboardingAction.OnboardingCompleted -> onboardingProvider.onOnboardingFinished(
                     context
                 )

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/OnboardingViewModel.kt
@@ -18,8 +18,6 @@
 package com.d4rk.android.libs.apptoolkit.app.onboarding.ui
 
 import androidx.lifecycle.viewModelScope
-import com.d4rk.android.libs.apptoolkit.app.consent.domain.model.ConsentHost
-import com.d4rk.android.libs.apptoolkit.app.consent.domain.usecases.RequestConsentUseCase
 import com.d4rk.android.libs.apptoolkit.app.onboarding.domain.usecases.CompleteOnboardingUseCase
 import com.d4rk.android.libs.apptoolkit.app.onboarding.domain.usecases.ObserveOnboardingCompletionUseCase
 import com.d4rk.android.libs.apptoolkit.app.onboarding.ui.contract.OnboardingAction
@@ -44,7 +42,6 @@ import kotlinx.coroutines.withContext
 class OnboardingViewModel(
     private val observeOnboardingCompletionUseCase: ObserveOnboardingCompletionUseCase,
     private val completeOnboardingUseCase: CompleteOnboardingUseCase,
-    private val requestConsentUseCase: RequestConsentUseCase,
     private val dispatchers: DispatcherProvider,
     firebaseController: FirebaseController,
 ) : LoggedScreenViewModel<OnboardingUiState, OnboardingEvent, OnboardingAction>(
@@ -55,7 +52,6 @@ class OnboardingViewModel(
 
     private var observerJob: Job? = null
     private var completeJob: Job? = null
-    private var consentJob: Job? = null
 
     init {
         handleEvent(OnboardingEvent.ObserveCompletion)
@@ -66,7 +62,7 @@ class OnboardingViewModel(
             is OnboardingEvent.ObserveCompletion -> observeCompletion()
             is OnboardingEvent.UpdateCurrentTab -> updateCurrentTab(event.index)
             is OnboardingEvent.CompleteOnboarding -> completeOnboarding()
-            is OnboardingEvent.RequestConsent -> requestConsent(event.host)
+            is OnboardingEvent.RequestConsent -> requestConsent()
             is OnboardingEvent.ShowCrashlyticsDialog -> setCrashlyticsDialogVisibility(isVisible = true)
             is OnboardingEvent.HideCrashlyticsDialog -> setCrashlyticsDialogVisibility(isVisible = false)
         }
@@ -129,20 +125,10 @@ class OnboardingViewModel(
         }
     }
 
-    private fun requestConsent(host: ConsentHost) {
-        val hostName = host.activity::class.java.name
-        startOperation(action = Actions.REQUEST_CONSENT, extra = mapOf(ExtraKeys.HOST to hostName))
-        consentJob = consentJob.restart {
-            requestConsentUseCase.invoke(host = host)
-                .flowOn(dispatchers.main)
-                .catchReport(
-                    action = Actions.REQUEST_CONSENT,
-                    extra = mapOf(ExtraKeys.HOST to hostName)
-                ) {
-                    // No UI change requested for consent failures in onboarding.
-                    // If needed later: updateStateThreadSafe { screenState.setError(...) } or showSnackbar(...)
-                }
-                .launchIn(viewModelScope)
+    private fun requestConsent() {
+        startOperation(action = Actions.REQUEST_CONSENT)
+        viewModelScope.launch {
+            sendAction(OnboardingAction.RequestConsentUi)
         }
     }
 
@@ -160,7 +146,4 @@ class OnboardingViewModel(
         const val REQUEST_CONSENT: String = "requestConsent"
     }
 
-    private object ExtraKeys {
-        const val HOST: String = "host"
-    }
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/contract/OnboardingAction.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/contract/OnboardingAction.kt
@@ -20,5 +20,6 @@ package com.d4rk.android.libs.apptoolkit.app.onboarding.ui.contract
 import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.ActionEvent
 
 sealed interface OnboardingAction : ActionEvent {
+    data object RequestConsentUi : OnboardingAction
     data object OnboardingCompleted : OnboardingAction
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/contract/OnboardingEvent.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/contract/OnboardingEvent.kt
@@ -17,13 +17,12 @@
 
 package com.d4rk.android.libs.apptoolkit.app.onboarding.ui.contract
 
-import com.d4rk.android.libs.apptoolkit.app.consent.domain.model.ConsentHost
 import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.UiEvent
 
 sealed interface OnboardingEvent : UiEvent {
     data object ObserveCompletion : OnboardingEvent
     data class UpdateCurrentTab(val index: Int) : OnboardingEvent
-    data class RequestConsent(val host: ConsentHost) : OnboardingEvent
+    data object RequestConsent : OnboardingEvent
     data object CompleteOnboarding : OnboardingEvent
     data object ShowCrashlyticsDialog : OnboardingEvent
     data object HideCrashlyticsDialog : OnboardingEvent

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsScreen.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsScreen.kt
@@ -121,7 +121,7 @@ fun SettingsScreen() {
     )
 
     LaunchedEffect(Unit) {
-        viewModel.onEvent(event = SettingsEvent.Load(context = context))
+        viewModel.onEvent(event = SettingsEvent.Load)
     }
 
     LargeTopAppBarWithScaffold(
@@ -144,7 +144,7 @@ fun SettingsScreen() {
                         firebaseController.logGa4Event(
                             ga4Event = settingsActionGa4Event(actionName = SettingsActionNames.RETRY_LOAD)
                         )
-                        viewModel.onEvent(event = SettingsEvent.Load(context = context))
+                        viewModel.onEvent(event = SettingsEvent.Load)
                     },
                     paddingValues = paddingValues,
                 )

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsViewModel.kt
@@ -17,7 +17,6 @@
 
 package com.d4rk.android.libs.apptoolkit.app.settings.settings.ui
 
-import android.content.Context
 import androidx.lifecycle.viewModelScope
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.settings.settings.domain.model.SettingsConfig
@@ -47,7 +46,6 @@ import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
-import kotlinx.coroutines.withContext
 
 /**
  * ViewModel responsible for managing the state and logic of the settings screen.
@@ -77,22 +75,14 @@ class SettingsViewModel(
 
     override fun handleEvent(event: SettingsEvent) {
         when (event) {
-            is SettingsEvent.Load -> loadSettings(context = event.context)
+            is SettingsEvent.Load -> loadSettings()
         }
     }
 
-    private fun loadSettings(context: Context) {
-        startOperation(
-            action = Actions.LOAD_SETTINGS,
-            extra = mapOf(ExtraKeys.CONTEXT to context::class.java.name)
-        )
+    private fun loadSettings() {
+        startOperation(action = Actions.LOAD_SETTINGS)
         observeJob = observeJob.restart {
-            flow {
-                val config = withContext(dispatchers.io) {
-                    settingsProvider.provideSettingsConfig(context = context)
-                }
-                emit(config)
-            }
+            flow { emit(settingsProvider.provideSettingsConfig()) }
                 .flowOn(dispatchers.io)
                 .map<SettingsConfig, DataState<SettingsConfig, Errors>> { config ->
                     if (config.categories.isEmpty()) {
@@ -107,10 +97,7 @@ class SettingsViewModel(
                         screenState.setLoading()
                     }
                 }
-                .catchReport(
-                    action = Actions.LOAD_SETTINGS,
-                    extra = mapOf(ExtraKeys.CONTEXT to context::class.java.name)
-                ) {
+                .catchReport(action = Actions.LOAD_SETTINGS) {
                     emit(DataState.Error(error = Errors.UseCase.INVALID_STATE))
                 }
                 .onEach { result ->
@@ -159,7 +146,4 @@ class SettingsViewModel(
         const val LOAD_SETTINGS: String = "loadSettings"
     }
 
-    private object ExtraKeys {
-        const val CONTEXT: String = "context"
-    }
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/contract/SettingsEvent.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/contract/SettingsEvent.kt
@@ -17,9 +17,8 @@
 
 package com.d4rk.android.libs.apptoolkit.app.settings.settings.ui.contract
 
-import android.content.Context
 import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.UiEvent
 
 sealed interface SettingsEvent : UiEvent {
-    data class Load(val context: Context) : SettingsEvent
+    data object Load : SettingsEvent
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/utils/interfaces/SettingsProvider.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/utils/interfaces/SettingsProvider.kt
@@ -17,9 +17,8 @@
 
 package com.d4rk.android.libs.apptoolkit.app.settings.utils.interfaces
 
-import android.content.Context
 import com.d4rk.android.libs.apptoolkit.app.settings.settings.domain.model.SettingsConfig
 
 interface SettingsProvider {
-    fun provideSettingsConfig(context: Context): SettingsConfig
+    fun provideSettingsConfig(): SettingsConfig
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupActivity.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupActivity.kt
@@ -28,9 +28,11 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.d4rk.android.libs.apptoolkit.app.consent.domain.model.ConsentHost
+import com.d4rk.android.libs.apptoolkit.app.consent.domain.usecases.RequestConsentUseCase
 import com.d4rk.android.libs.apptoolkit.app.startup.ui.contract.StartupAction
 import com.d4rk.android.libs.apptoolkit.app.startup.ui.contract.StartupEvent
 import com.d4rk.android.libs.apptoolkit.app.startup.utils.interfaces.providers.StartupProvider
+import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
 import com.d4rk.android.libs.apptoolkit.core.ui.base.BaseActivity
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.logging.STARTUP_LOG_TAG
 import com.d4rk.android.libs.apptoolkit.core.utils.extensions.context.openActivity
@@ -42,12 +44,10 @@ import org.koin.androidx.viewmodel.ext.android.viewModel
 
 class StartupActivity : BaseActivity() {
     private val provider: StartupProvider by inject()
+    private val requestConsentUseCase: RequestConsentUseCase by inject()
     private val viewModel: StartupViewModel by viewModel()
     private val permissionLauncher: ActivityResultLauncher<Array<String>> =
         registerForActivityResult(ActivityResultContracts.RequestMultiplePermissions()) { }
-    private val consentHost: ConsentHost = object : ConsentHost {
-        override val activity = this@StartupActivity
-    }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -66,6 +66,7 @@ class StartupActivity : BaseActivity() {
                     }
                     .collect { action: StartupAction ->
                         when (action) {
+                            StartupAction.RequestConsentUi -> performConsentRequest()
                             StartupAction.NavigateNext -> navigateToNext()
                         }
                     }
@@ -101,6 +102,20 @@ class StartupActivity : BaseActivity() {
     }
 
     private fun checkUserConsent() {
-        viewModel.onEvent(StartupEvent.RequestConsent(host = consentHost))
+        viewModel.onEvent(StartupEvent.RequestConsent)
+    }
+
+    private fun performConsentRequest() {
+        val host: ConsentHost = object : ConsentHost {
+            override val activity = this@StartupActivity
+        }
+
+        lifecycleScope.launch {
+            requestConsentUseCase.invoke(host = host).collect { result ->
+                if (result !is DataState.Loading) {
+                    viewModel.onEvent(StartupEvent.ConsentFormLoaded)
+                }
+            }
+        }
     }
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupViewModel.kt
@@ -18,34 +18,23 @@
 package com.d4rk.android.libs.apptoolkit.app.startup.ui
 
 import androidx.lifecycle.viewModelScope
-import com.d4rk.android.libs.apptoolkit.app.consent.domain.model.ConsentHost
-import com.d4rk.android.libs.apptoolkit.app.consent.domain.usecases.RequestConsentUseCase
 import com.d4rk.android.libs.apptoolkit.app.startup.ui.contract.StartupAction
 import com.d4rk.android.libs.apptoolkit.app.startup.ui.contract.StartupEvent
 import com.d4rk.android.libs.apptoolkit.app.startup.ui.state.StartupUiState
-import com.d4rk.android.libs.apptoolkit.core.coroutines.dispatchers.DispatcherProvider
-import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
-import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Errors
 import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
 import com.d4rk.android.libs.apptoolkit.core.ui.base.LoggedScreenViewModel
 import com.d4rk.android.libs.apptoolkit.core.ui.state.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.state.setLoading
 import com.d4rk.android.libs.apptoolkit.core.ui.state.successData
-import kotlinx.coroutines.Job
-import kotlinx.coroutines.flow.flowOn
-import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onEach
-import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 
 /**
  * ViewModel for the startup screen.
  *
- * Requests consent and triggers navigation when startup flow is complete.
+ * Consent is requested by the UI layer after receiving [StartupAction.RequestConsentUi], so this
+ * ViewModel does not keep Activity-bound host references.
  */
 class StartupViewModel(
-    private val requestConsentUseCase: RequestConsentUseCase,
-    private val dispatchers: DispatcherProvider,
     firebaseController: FirebaseController,
 ) : LoggedScreenViewModel<StartupUiState, StartupEvent, StartupAction>(
     initialState = UiStateScreen(data = StartupUiState()),
@@ -53,42 +42,21 @@ class StartupViewModel(
     screenName = "Startup",
 ) {
 
-    private var observeJob: Job? = null
-
     override fun handleEvent(event: StartupEvent) {
         when (event) {
-            is StartupEvent.RequestConsent -> requestConsent(host = event.host)
-            is StartupEvent.ConsentFormLoaded -> markConsentFormLoaded()
-            is StartupEvent.Continue -> sendAction(action = StartupAction.NavigateNext)
+            StartupEvent.RequestConsent -> requestConsent()
+            StartupEvent.ConsentFormLoaded -> markConsentFormLoaded()
+            StartupEvent.Continue -> sendAction(action = StartupAction.NavigateNext)
         }
     }
 
-    private fun requestConsent(host: ConsentHost) {
-        startOperation(
-            action = Actions.REQUEST_CONSENT,
-            extra = mapOf(ExtraKeys.HOST to host.activity::class.java.name)
-        )
-        observeJob = observeJob.restart {
-            requestConsentUseCase.invoke(host = host)
-                .flowOn(dispatchers.main)
-                .onStart {
-                    updateStateThreadSafe {
-                        screenState.setLoading()
-                    }
-                }
-                .catchReport(
-                    action = Actions.REQUEST_CONSENT,
-                    extra = mapOf(ExtraKeys.HOST to host.activity::class.java.name)
-                ) {
-                    emit(DataState.Error(error = Errors.UseCase.FAILED_TO_LOAD_CONSENT_INFO))
-                }
-                .onEach { result ->
-                    when (result) {
-                        is DataState.Success, is DataState.Error -> onEvent(event = StartupEvent.ConsentFormLoaded)
-                        is DataState.Loading -> Unit
-                    }
-                }
-                .launchIn(viewModelScope)
+    private fun requestConsent() {
+        startOperation(action = Actions.REQUEST_CONSENT)
+        viewModelScope.launch {
+            updateStateThreadSafe {
+                screenState.setLoading()
+            }
+            sendAction(StartupAction.RequestConsentUi)
         }
     }
 
@@ -102,9 +70,5 @@ class StartupViewModel(
 
     private object Actions {
         const val REQUEST_CONSENT: String = "requestConsent"
-    }
-
-    private object ExtraKeys {
-        const val HOST: String = "host"
     }
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/startup/ui/contract/StartupAction.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/startup/ui/contract/StartupAction.kt
@@ -20,5 +20,6 @@ package com.d4rk.android.libs.apptoolkit.app.startup.ui.contract
 import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.ActionEvent
 
 sealed interface StartupAction : ActionEvent {
+    data object RequestConsentUi : StartupAction
     data object NavigateNext : StartupAction
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/startup/ui/contract/StartupEvent.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/startup/ui/contract/StartupEvent.kt
@@ -17,11 +17,10 @@
 
 package com.d4rk.android.libs.apptoolkit.app.startup.ui.contract
 
-import com.d4rk.android.libs.apptoolkit.app.consent.domain.model.ConsentHost
 import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.UiEvent
 
 sealed interface StartupEvent : UiEvent {
-    data class RequestConsent(val host: ConsentHost) : StartupEvent
+    data object RequestConsent : StartupEvent
     data object ConsentFormLoaded : StartupEvent
     data object Continue : StartupEvent
 }

--- a/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/TestOnboardingViewModel.kt
+++ b/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/app/onboarding/ui/TestOnboardingViewModel.kt
@@ -17,17 +17,11 @@
 
 package com.d4rk.android.libs.apptoolkit.app.onboarding.ui
 
-import com.d4rk.android.libs.apptoolkit.app.consent.domain.model.ConsentHost
-import com.d4rk.android.libs.apptoolkit.app.consent.domain.model.ConsentSettings
-import com.d4rk.android.libs.apptoolkit.app.consent.domain.repository.ConsentRepository
-import com.d4rk.android.libs.apptoolkit.app.consent.domain.usecases.RequestConsentUseCase
 import com.d4rk.android.libs.apptoolkit.app.onboarding.domain.repository.OnboardingRepository
 import com.d4rk.android.libs.apptoolkit.app.onboarding.domain.usecases.CompleteOnboardingUseCase
 import com.d4rk.android.libs.apptoolkit.app.onboarding.domain.usecases.ObserveOnboardingCompletionUseCase
 import com.d4rk.android.libs.apptoolkit.app.onboarding.ui.contract.OnboardingEvent
 import com.d4rk.android.libs.apptoolkit.core.di.TestDispatchers
-import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
-import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Errors
 import com.d4rk.android.libs.apptoolkit.core.utils.FakeFirebaseController
 import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.UnconfinedDispatcherExtension
 import com.google.common.truth.Truth.assertThat
@@ -35,7 +29,6 @@ import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.flow
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
 import org.junit.jupiter.api.Test
@@ -187,22 +180,7 @@ class TestOnboardingViewModel {
         OnboardingViewModel(
             observeOnboardingCompletionUseCase = ObserveOnboardingCompletionUseCase(repository),
             completeOnboardingUseCase = CompleteOnboardingUseCase(repository),
-            requestConsentUseCase = RequestConsentUseCase(
-                FakeConsentRepository(),
-                firebaseController
-            ),
             dispatchers = TestDispatchers(testDispatcher = dispatcherExtension.testDispatcher),
             firebaseController = firebaseController,
         )
-}
-
-private class FakeConsentRepository : ConsentRepository {
-    override fun requestConsent(
-        host: ConsentHost,
-        showIfRequired: Boolean,
-    ): Flow<DataState<Unit, Errors.UseCase>> = flowOf(DataState.Success(Unit))
-
-    override suspend fun applyInitialConsent() = Unit
-
-    override suspend fun applyConsentSettings(settings: ConsentSettings) = Unit
 }

--- a/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/TestSettingsViewModel.kt
+++ b/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/TestSettingsViewModel.kt
@@ -17,7 +17,6 @@
 
 package com.d4rk.android.libs.apptoolkit.app.settings.settings.ui
 
-import android.content.Context
 import com.d4rk.android.libs.apptoolkit.app.settings.settings.domain.model.SettingsCategory
 import com.d4rk.android.libs.apptoolkit.app.settings.settings.domain.model.SettingsConfig
 import com.d4rk.android.libs.apptoolkit.app.settings.settings.ui.contract.SettingsEvent
@@ -52,7 +51,7 @@ class TestSettingsViewModel {
 
     private fun setup(config: SettingsConfig) {
         provider = mockk()
-        every { provider.provideSettingsConfig(any()) } returns config
+        every { provider.provideSettingsConfig() } returns config
         val dispatchers = TestDispatchers(dispatcherExtension.testDispatcher)
         viewModel = SettingsViewModel(provider, dispatchers, firebaseController)
     }
@@ -63,10 +62,9 @@ class TestSettingsViewModel {
             title = "Title",
             categories = listOf(SettingsCategory(title = "c", preferences = emptyList()))
         )
-        val context = mockk<Context>(relaxed = true)
         setup(config)
 
-        viewModel.onEvent(SettingsEvent.Load(context))
+        viewModel.onEvent(SettingsEvent.Load)
         advanceUntilIdle()
 
         assertThat(viewModel.uiState.value.data?.title).isEqualTo("Title")
@@ -76,10 +74,9 @@ class TestSettingsViewModel {
     @Test
     fun `load settings no data`() = runTest(dispatcherExtension.testDispatcher) {
         val config = SettingsConfig(title = "", categories = emptyList())
-        val context = mockk<Context>(relaxed = true)
         setup(config)
 
-        viewModel.onEvent(SettingsEvent.Load(context))
+        viewModel.onEvent(SettingsEvent.Load)
         advanceUntilIdle()
 
         assertThat(viewModel.uiState.value.screenState).isInstanceOf(ScreenState.NoData::class.java)
@@ -93,18 +90,17 @@ class TestSettingsViewModel {
                 title = "Title",
                 categories = listOf(SettingsCategory(title = "c", preferences = emptyList()))
             )
-            val context = mockk<Context>(relaxed = true)
             provider = mockk()
-            every { provider.provideSettingsConfig(any()) } returnsMany listOf(empty, valid)
+            every { provider.provideSettingsConfig() } returnsMany listOf(empty, valid)
             val dispatchers = TestDispatchers(dispatcherExtension.testDispatcher)
             viewModel = SettingsViewModel(provider, dispatchers, firebaseController)
 
-            viewModel.onEvent(SettingsEvent.Load(context))
+            viewModel.onEvent(SettingsEvent.Load)
             advanceUntilIdle()
             assertThat(viewModel.uiState.value.screenState).isInstanceOf(ScreenState.NoData::class.java)
             assertThat(viewModel.uiState.value.errors).isNotEmpty()
 
-            viewModel.onEvent(SettingsEvent.Load(context))
+            viewModel.onEvent(SettingsEvent.Load)
             advanceUntilIdle()
             assertThat(viewModel.uiState.value.screenState).isInstanceOf(ScreenState.Success::class.java)
             assertThat(viewModel.uiState.value.errors).isEmpty()
@@ -116,15 +112,14 @@ class TestSettingsViewModel {
             title = "Title",
             categories = listOf(SettingsCategory(title = "c", preferences = emptyList()))
         )
-        val context = mockk<Context>(relaxed = true)
         provider = mockk()
-        every { provider.provideSettingsConfig(any()) } returns config
+        every { provider.provideSettingsConfig() } returns config
         val dispatchers = TestDispatchers(dispatcherExtension.testDispatcher)
         viewModel = SettingsViewModel(provider, dispatchers, firebaseController)
 
-        viewModel.onEvent(SettingsEvent.Load(context))
+        viewModel.onEvent(SettingsEvent.Load)
         advanceUntilIdle()
 
-        verify(exactly = 1) { provider.provideSettingsConfig(context) }
+        verify(exactly = 1) { provider.provideSettingsConfig() }
     }
 }

--- a/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupViewModelTest.kt
+++ b/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/app/startup/ui/StartupViewModelTest.kt
@@ -17,23 +17,13 @@
 
 package com.d4rk.android.libs.apptoolkit.app.startup.ui
 
-import com.d4rk.android.libs.apptoolkit.app.consent.domain.model.ConsentHost
-import com.d4rk.android.libs.apptoolkit.app.consent.domain.model.ConsentSettings
-import com.d4rk.android.libs.apptoolkit.app.consent.domain.repository.ConsentRepository
-import com.d4rk.android.libs.apptoolkit.app.consent.domain.usecases.RequestConsentUseCase
 import com.d4rk.android.libs.apptoolkit.app.startup.ui.contract.StartupAction
 import com.d4rk.android.libs.apptoolkit.app.startup.ui.contract.StartupEvent
-import com.d4rk.android.libs.apptoolkit.core.coroutines.dispatchers.DispatcherProvider
-import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
-import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Errors
 import com.d4rk.android.libs.apptoolkit.core.ui.state.ScreenState
 import com.d4rk.android.libs.apptoolkit.core.utils.FakeFirebaseController
 import com.d4rk.android.libs.apptoolkit.core.utils.dispatchers.UnconfinedDispatcherExtension
 import com.google.common.truth.Truth.assertThat
-import io.mockk.mockk
 import kotlinx.coroutines.ExperimentalCoroutinesApi
-import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.advanceUntilIdle
 import kotlinx.coroutines.test.runTest
@@ -51,16 +41,10 @@ class StartupViewModelTest {
 
     @Test
     fun `consent event updates state`() = runTest(dispatcherExtension.testDispatcher) {
-        val firebaseController = FakeFirebaseController()
-        val viewModel = StartupViewModel(
-            requestConsentUseCase = RequestConsentUseCase(
-                FakeConsentRepository(),
-                firebaseController
-            ),
-            dispatchers = testDispatcherProvider(),
-            firebaseController = firebaseController,
-        )
+        val viewModel = StartupViewModel(firebaseController = FakeFirebaseController())
+
         viewModel.onEvent(StartupEvent.ConsentFormLoaded)
+
         val state = viewModel.uiState.value
         assertThat(state.screenState).isInstanceOf(ScreenState.Success::class.java)
         assertThat(state.data?.consentFormLoaded).isTrue()
@@ -68,65 +52,27 @@ class StartupViewModelTest {
 
     @Test
     fun `continue event emits navigation action`() = runTest(dispatcherExtension.testDispatcher) {
-        val firebaseController = FakeFirebaseController()
-        val viewModel = StartupViewModel(
-            requestConsentUseCase = RequestConsentUseCase(
-                FakeConsentRepository(),
-                firebaseController
-            ),
-            dispatchers = testDispatcherProvider(),
-            firebaseController = firebaseController,
-        )
+        val viewModel = StartupViewModel(firebaseController = FakeFirebaseController())
         val actions = mutableListOf<StartupAction>()
         val job = launch { viewModel.actionEvent.collect { actions.add(it) } }
+
         viewModel.onEvent(StartupEvent.Continue)
         advanceUntilIdle()
+
         assertThat(actions).containsExactly(StartupAction.NavigateNext)
         job.cancel()
     }
 
     @Test
-    fun `request consent event completes startup state`() =
-        runTest(dispatcherExtension.testDispatcher) {
-            val firebaseController = FakeFirebaseController()
-            val viewModel = StartupViewModel(
-                requestConsentUseCase = RequestConsentUseCase(
-                    FakeConsentRepository(),
-                    firebaseController
-                ),
-                dispatchers = testDispatcherProvider(),
-                firebaseController = firebaseController,
-            )
+    fun `request consent emits ui action`() = runTest(dispatcherExtension.testDispatcher) {
+        val viewModel = StartupViewModel(firebaseController = FakeFirebaseController())
+        val actions = mutableListOf<StartupAction>()
+        val job = launch { viewModel.actionEvent.collect { actions.add(it) } }
 
-            viewModel.onEvent(StartupEvent.RequestConsent(host = FakeConsentHost()))
-            advanceUntilIdle()
+        viewModel.onEvent(StartupEvent.RequestConsent)
+        advanceUntilIdle()
 
-            val state = viewModel.uiState.value
-            assertThat(state.data?.consentFormLoaded).isTrue()
-        }
-
-    private fun testDispatcherProvider(): DispatcherProvider = object : DispatcherProvider {
-        override val main = dispatcherExtension.testDispatcher
-        override val io = dispatcherExtension.testDispatcher
-        override val default = dispatcherExtension.testDispatcher
-        override val unconfined = dispatcherExtension.testDispatcher
+        assertThat(actions).containsExactly(StartupAction.RequestConsentUi)
+        job.cancel()
     }
-}
-
-private class FakeConsentRepository : ConsentRepository {
-    override fun requestConsent(
-        host: ConsentHost,
-        showIfRequired: Boolean,
-    ): Flow<DataState<Unit, Errors.UseCase>> = flowOf(
-        DataState.Loading(),
-        DataState.Success(Unit),
-    )
-
-    override suspend fun applyInitialConsent() = Unit
-
-    override suspend fun applyConsentSettings(settings: ConsentSettings) = Unit
-}
-
-private class FakeConsentHost : ConsentHost {
-    override val activity = mockk<android.app.Activity>(relaxed = true)
 }


### PR DESCRIPTION
### Motivation
- Reduce startup/main-thread blocking by removing synchronous DataStore reads and moving consent UI work out of ViewModels to avoid holding Activity references in business logic.
- Make settings provider API context-agnostic and simplify DI so settings can be provided without passing Activity contexts.
- Harden app surface by marking internal activities non-exported to reduce intent spoofing and clarify internal-only screens.
- Improve composables and lifecycle handling by moving consent requests to Activities and emitting UI actions from ViewModels.

### Description
- Replaced blocking palette resolution in `AppToolkit` with deterministic DI-provided initial palette and asynchronous reconciliation using an `appScope` coroutine; added `applyColorPalette` helper and cancel `appScope` on `onTerminate`.
- Removed `requestConsentUseCase` and Activity `host` coupling from `StartupViewModel` and `OnboardingViewModel`; ViewModels now emit `RequestConsentUi` actions and only manage state, while `StartupActivity` and `OnboardingActivity` perform the actual `RequestConsentUseCase` calls using an Activity-bound `ConsentHost` and collect results.
- Updated contracts to remove `ConsentHost` parameters: `StartupEvent.RequestConsent` and `OnboardingEvent.RequestConsent` are now parameterless, and new action `RequestConsentUi` was added to both `StartupAction` and `OnboardingAction`.
- Converted `SettingsProvider` API to `provideSettingsConfig(): SettingsConfig` (no `Context`) and changed `AppSettingsProvider` to accept an application `Context` in its constructor and use `context.applicationContext` internally; DI module updated to provide the context when registering the provider.
- Tightened Android manifest by setting many internal activities from `android:exported="true"` to `android:exported="false"` and added comments clarifying internal-only screens.
- Minor UI and coroutine improvements: avoid unnecessary `runBlocking`/`withContext`, optimize `SelectLanguageAlertDialog` `remember` keys, and update multiple DI modules to remove the removed consent dependency.
- Updated unit tests to match the new provider and consent flow: `TestSettingsViewModel` and `StartupViewModelTest` were adjusted to the new signatures and behavior.

### Testing
- Updated and ran unit tests for settings and startup modules; `TestSettingsViewModel` and `StartupViewModelTest` were modified and executed successfully.
- Ran the test suite with `./gradlew :apptoolkit:test` and `./gradlew test`; automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b83859bc00832d9ef3b6a296cee3a2)