### PR TITLE
Add detailed KDoc and usage/guardrails to carousel, indicator, app bar and HTML text components

### DIFF
--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/carousel/CustomCarousel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/carousel/CustomCarousel.kt
@@ -36,6 +36,36 @@ import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import kotlinx.collections.immutable.toImmutableList
 import kotlin.math.absoluteValue
 
+/**
+ * Displays a horizontally swipeable carousel with a synchronized animated dot indicator.
+ *
+ * State ownership:
+ * - Callers own [items], [sidePadding], and [pagerState].
+ * - This composable derives page offset animations and the selected dot from [pagerState].
+ *
+ * Guardrails:
+ * - Keep [items] stable across recompositions for predictable paging and animation behavior.
+ * - Provide a [pagerState] whose page count matches [items] to avoid invalid page access.
+ * - Use non-negative [sidePadding] so content remains readable.
+ *
+ * Example:
+ * ```
+ * val items = remember { listOf("One", "Two", "Three") }
+ * val pagerState = rememberPagerState(pageCount = { items.size })
+ * CustomCarousel(
+ *     items = items,
+ *     sidePadding = 16.dp,
+ *     pagerState = pagerState,
+ * ) { item ->
+ *     Text(text = item)
+ * }
+ * ```
+ *
+ * @param items Ordered list of models rendered page-by-page.
+ * @param sidePadding Horizontal inset applied on both sides of the pager content.
+ * @param pagerState Shared pager state that controls and reports current page selection.
+ * @param itemContent Composable renderer for each carousel item.
+ */
 @Composable
 fun <T> CustomCarousel(
     items: List<T>,

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/carousel/DotsIndicator.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/carousel/DotsIndicator.kt
@@ -34,6 +34,26 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.ExtraTinyHorizontalSpacer
 
+/**
+ * Renders an animated row of dots that reflects the currently selected carousel page.
+ *
+ * State ownership:
+ * - Callers own [totalDots], [selectedIndex], sizing, colors, and animation timing.
+ * - This composable derives the visual selected/unselected state for each dot.
+ *
+ * Guardrails:
+ * - Keep [selectedIndex] in `0 until totalDots` to ensure a valid selected item.
+ * - Use [dotSize] values greater than `0.dp`.
+ * - Keep [animationDuration] non-negative.
+ *
+ * @param modifier Modifier applied to the indicator row.
+ * @param totalDots Total number of dots to render.
+ * @param selectedIndex Currently selected dot index.
+ * @param selectedColor Color used for the selected dot.
+ * @param unSelectedColor Color used for unselected dots.
+ * @param dotSize Base size of each dot before the selection animation is applied.
+ * @param animationDuration Duration (in milliseconds) of the dot size transition.
+ */
 @Composable
 fun DotsIndicator(
     modifier: Modifier = Modifier,

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/carousel/IndicatorDot.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/carousel/IndicatorDot.kt
@@ -27,6 +27,20 @@ import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.Dp
 
+/**
+ * Draws a circular dot used by pagination indicators.
+ *
+ * State ownership:
+ * - Callers own [size], [color], and optional [modifier].
+ * - This composable is render-only and emits no side effects.
+ *
+ * Guardrails:
+ * - Provide a [size] greater than `0.dp` so the dot remains visible.
+ *
+ * @param modifier Modifier applied to the dot container.
+ * @param size Diameter of the dot.
+ * @param color Fill color of the dot.
+ */
 @Composable
 fun IndicatorDot(
     modifier: Modifier = Modifier,

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/navigation/TopAppBar.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/navigation/TopAppBar.kt
@@ -39,30 +39,28 @@ import androidx.compose.ui.res.stringResource
 import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.AnimatedIconButtonDirection
 
 /**
- * A composable function that creates a screen layout with a large top app bar and a scaffold.
+ * Provides a scaffold with a Material 3 large top app bar, back navigation, and optional actions.
  *
- * This function provides a convenient way to structure a screen with a collapsing large top app bar,
- * optional floating action button, and custom content area.
+ * State ownership:
+ * - Callers own the title text, navigation callback, top-bar actions, and body content.
+ * - Callers can provide [snackbarHostState] and [scrollBehavior] to integrate with screen-level state.
  *
- * @param title The title to display in the large top app bar.
- * @param onBackClicked The callback to be invoked when the back navigation icon is clicked.
- * @param actions The actions to display in the large top app bar's action area. This is a composable
- *                lambda that receives a [RowScope] to lay out the actions horizontally. Defaults to an
- *                empty lambda, meaning no actions.
- * @param floatingActionButton An optional composable lambda that creates a floating action button. If
- *                             null, no floating action button is displayed. Defaults to null.
- * @param scrollBehavior The [TopAppBarScrollBehavior] to control how the large top app bar collapses
- *                       and expands with scrolling. Defaults to `TopAppBarDefaults.exitUntilCollapsedScrollBehavior()`.
- * @param content The composable lambda for the main content of the screen. It receives [PaddingValues]
- *                representing the padding applied by the scaffold to accommodate the top app bar and
- *                floating action button.
+ * Behavior:
+ * - The default [scrollBehavior] is [TopAppBarDefaults.exitUntilCollapsedScrollBehavior], so the
+ *   top app bar collapses as content scrolls.
+ * - A default empty lambda is used when [floatingActionButton] is not provided.
  *
- * Example usage:
- * ```
- * LargeTopAppBarWithScaffold(
- *     title = "My Screen",
- *     onBackClicked = { navController.popBackStack() },
- *     actions = */
+ * Usage note:
+ * - Pass [content] that applies the provided [PaddingValues] to avoid overlap with the top app bar.
+ *
+ * @param title Title rendered in the large top app bar.
+ * @param onBackClicked Callback invoked when the back button is pressed.
+ * @param actions Optional action-slot composables displayed on the top app bar.
+ * @param floatingActionButton Optional floating action button content for the scaffold.
+ * @param snackbarHostState Snackbar host state used by the scaffold.
+ * @param scrollBehavior Scroll behavior applied to the top app bar.
+ * @param content Main screen content receiving scaffold paddings.
+ */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun LargeTopAppBarWithScaffold(
@@ -97,31 +95,19 @@ fun LargeTopAppBarWithScaffold(
 }
 
 /**
- * A composable function that provides a scaffold with a large top app bar that supports scrolling behavior.
+ * Provides a scaffold with a scroll-aware large top app bar and optional floating action button.
  *
- * This function simplifies the creation of a common UI pattern where a large top app bar is used
- * and the content scrolls under it, collapsing the app bar as the user scrolls down.
+ * State ownership:
+ * - Callers own [title], optional [floatingActionButton], and body [content].
+ * - This composable owns an internal enter-always [TopAppBarScrollBehavior].
  *
- * @param title The text to be displayed in the large top app bar.
- * @param content The composable content to be displayed within the scaffold's body.
- *                This content will receive [PaddingValues] that account for the top app bar's height.
- *                Use this padding to correctly position your content.
+ * Usage note:
+ * - Apply the provided [PaddingValues] inside [content] so list and screen content does not draw
+ *   under the app bar.
  *
- * Example Usage:
- * ```
- * TopAppBarScaffold(title = "My App") { paddingValues ->
- *     LazyColumn(modifier = Modifier.padding(paddingValues)) {
- *         items(100) { index ->
- *             Text(text = "Item $index")
- *         }
- *     }
- * }
- * ```
- *
- * In this example, the `LazyColumn` is padded appropriately to ensure the content starts
- * below the LargeTopAppBar.
- *
- * @OptIn ExperimentalMaterial3Api is used because [LargeTopAppBar] and [TopAppBarScrollBehavior] are experimental.
+ * @param title Title rendered in the large top app bar.
+ * @param content Main scaffold content that receives top app bar paddings.
+ * @param floatingActionButton Optional floating action button content.
  */
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/text/HtmlText.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/text/HtmlText.kt
@@ -30,6 +30,27 @@ import androidx.compose.ui.unit.isSpecified
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.text.HtmlCompat
 
+/**
+ * Renders trusted HTML content inside Compose using an Android [TextView] host.
+ *
+ * The HTML is parsed with [HtmlCompat.FROM_HTML_MODE_COMPACT], which supports common inline and
+ * block formatting while collapsing unnecessary whitespace. Links are interactive because the
+ * embedded [TextView] uses [LinkMovementMethod].
+ *
+ * Styling behavior:
+ * - Text color follows `MaterialTheme.colorScheme.onSurface`.
+ * - Font size uses [style] when specified, otherwise falls back to
+ *   `MaterialTheme.typography.bodyMedium.fontSize`.
+ *
+ * Prefer this component when the content source is already HTML and you need clickable links.
+ * Prefer Compose `Text` for plain strings or rich text produced fully in Compose.
+ *
+ * Security note: pass trusted or sanitized HTML input only.
+ *
+ * @param text HTML string to parse and display.
+ * @param modifier Modifier applied to the host view.
+ * @param style Base text style used to derive visual typography.
+ */
 @Composable
 fun HtmlText(
     text: String,


### PR DESCRIPTION
### Motivation
- Improve developer ergonomics by documenting ownership, expected inputs, and usage examples for several Compose UI components. 
- Make guardrails explicit to reduce incorrect usage (invalid pager state, zero-sized dots, unsanitized HTML, etc.).
- Provide clear guidance on styling and integration points for the top app bar scaffolds and HTML host view.

### Description
- Added detailed KDoc to `CustomCarousel` describing state ownership, guardrails, and an example usage for `items`, `sidePadding`, and `pagerState`.
- Documented `DotsIndicator` with animation parameters, expected `selectedIndex` range, and animation timing notes, and retained the animated dot sizing logic.
- Added KDoc to `IndicatorDot` describing rendering-only behavior and a guardrail for `size` values.
- Expanded `TopAppBar` documentation for `LargeTopAppBarWithScaffold` and `TopAppBarScaffold` describing state ownership, behavior, and usage notes while keeping existing APIs and behavior unchanged.
- Documented `HtmlText` with parsing mode, link behavior, styling fallbacks, and a security note to pass trusted or sanitized HTML only.

### Testing
- Ran project static checks and build for the module using `./gradlew :apptoolkit:check` which completed successfully.
- Assembled the module with `./gradlew :apptoolkit:assembleDebug` and the build succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf1ed8bd94832d8e52ebecc95c4a9a)