### PR TITLE
Replace unstable analytics params in SmallFloatingActionButton with onLogClick callback

### DIFF
--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/components/ui/views/ComponentsScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/components/ui/views/ComponentsScreen.kt
@@ -59,6 +59,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.GeneralButton
 import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.GeneralOutlinedButton
 import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.GeneralTextButton
 import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.GeneralTonalButton
+import com.d4rk.android.libs.apptoolkit.core.ui.views.analytics.logGa4Event
 import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.fab.AnimatedExtendedFloatingActionButton
 import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.fab.AnimatedFloatingActionButton
 import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.fab.SmallFloatingActionButton
@@ -334,8 +335,11 @@ fun ComponentsScreen(
                         icon = Icons.Filled.Add,
                         contentDescription = iconContentDescription,
                         onClick = {},
-                        firebaseController = firebaseController,
-                        ga4Event = ga4Event(component = "fab", variant = "small"),
+                        onLogClick = {
+                            firebaseController.logGa4Event(
+                                ga4Event(component = "fab", variant = "small")
+                            )
+                        },
                     )
                 }
                 SmallVerticalSpacer()

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/buttons/fab/SmallFloatingActionButton.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/buttons/fab/SmallFloatingActionButton.kt
@@ -29,9 +29,6 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalView
-import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
-import com.d4rk.android.libs.apptoolkit.core.ui.model.analytics.Ga4EventData
-import com.d4rk.android.libs.apptoolkit.core.ui.views.analytics.logGa4Event
 import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.ButtonFeedback
 import com.d4rk.android.libs.apptoolkit.core.ui.views.modifiers.bounceClick
 
@@ -55,8 +52,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.views.modifiers.bounceClick
  * @param contentDescription Optional description of the icon for accessibility.
  * @param onClick The action to be performed when the button is clicked.
  * @param feedback The feedback configuration for sound and haptics.
- * @param firebaseController Optional Firebase controller used to log GA4 events.
- * @param ga4Event Optional GA4 event data to log on click.
+ * @param onLogClick Optional analytics hook invoked before [onClick].
  */
 @Composable
 fun SmallFloatingActionButton(
@@ -67,8 +63,7 @@ fun SmallFloatingActionButton(
     contentDescription: String? = null,
     onClick: () -> Unit,
     feedback: ButtonFeedback = ButtonFeedback(),
-    firebaseController: FirebaseController? = null, // FIXME: Parameter 'firebaseController' has runtime-determined stability
-    ga4Event: Ga4EventData? = null, // FIXME: Parameter 'ga4Event' has runtime-determined stability
+    onLogClick: (() -> Unit)? = null,
 ) {
     val hapticFeedback: HapticFeedback = LocalHapticFeedback.current
     val view: View = LocalView.current
@@ -80,7 +75,7 @@ fun SmallFloatingActionButton(
     ) {
         SmallFloatingActionButton(onClick = {
             feedback.performClick(view = view, hapticFeedback = hapticFeedback)
-            firebaseController.logGa4Event(ga4Event)
+            onLogClick?.invoke()
             onClick()
         }, modifier = modifier.bounceClick()) {
             Icon(imageVector = icon, contentDescription = contentDescription)


### PR DESCRIPTION
### Motivation
- Remove runtime-stability-sensitive composable parameters (`FirebaseController`, `Ga4EventData`) and keep analytics wiring out of a reusable UI primitive to improve composability and stability.
- Keep existing click behavior and ordering while simplifying the composable API and resolving `FIXME` markers.

### Description
- Updated `SmallFloatingActionButton` to remove `firebaseController` and `ga4Event` parameters and add a nullable `onLogClick: (() -> Unit)?` callback, and updated the KDoc to document the new analytics hook contract.
- Preserved click side-effect ordering by invoking `feedback.performClick` then `onLogClick?.invoke()` then the provided `onClick` handler inside the composable.
- Updated `ComponentsScreen` to call analytics through the new `onLogClick` callback by invoking `firebaseController.logGa4Event(ga4Event(...))` at the call site and added the required `logGa4Event` import.
- Removed the `FIXME` notes related to runtime-determined stability for the small FAB parameters by moving analytics out of the composable API.

### Testing
- Ran `rg -n "TODO|FIXME" app apptoolkit --glob '*.kt'` and confirmed no remaining `TODO`/`FIXME` instances in the inspected modules.
- Attempted `./gradlew :app:compileDebugKotlin :apptoolkit:compileDebugKotlin`, but build could not complete in this environment due to missing Android SDK configuration (`ANDROID_HOME` / `local.properties sdk.dir`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69bf2647d8e0832daf2151ce970167f3)