### PR TITLE
Constrain buildscript classpath versions to mitigate multiple CVEs

### DIFF
--- a/apptoolkit/build.gradle.kts
+++ b/apptoolkit/build.gradle.kts
@@ -88,7 +88,6 @@ android {
 }
 
 dependencies {
-
     // AndroidX (Core / platform)
     api(dependencyNotation = libs.bundles.androidx.core)
     api(dependencyNotation = libs.androidx.window)

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,3 +26,28 @@ plugins {
     alias(notation = libs.plugins.about.libraries) apply true
     alias(notation = libs.plugins.mannodermaus.android.junit5) apply false
 }
+
+buildscript {
+    dependencies {
+        constraints {
+            classpath("org.jdom:jdom2:2.0.6.1") {
+                because("Mitigates CVE-2021-33813 (XXE) from AGP transitive dependency chain")
+            }
+            classpath("io.netty:netty-handler:4.1.129.Final") {
+                because("Mitigates known Netty handler vulnerabilities (native crash and SNI allocation DoS)")
+            }
+            classpath("io.netty:netty-codec-http2:4.1.129.Final") {
+                because("Mitigates known HTTP/2 vulnerabilities, including Rapid Reset and MadeYouReset")
+            }
+            classpath("io.netty:netty-codec:4.1.129.Final") {
+                because("Mitigates Netty decoder DoS vulnerabilities (including CVE-2025-58057)")
+            }
+            classpath("io.netty:netty-codec-http:4.1.129.Final") {
+                because("Mitigates CRLF injection/request smuggling vulnerability (CVE-2025-67735)")
+            }
+            classpath("org.bitbucket.b_c:jose4j:0.9.6") {
+                because("Mitigates DoS via compressed JWE content (CVE-2024-29371)")
+            }
+        }
+    }
+}


### PR DESCRIPTION
### Motivation
- Mitigate several transitive security vulnerabilities in the Android Gradle Plugin and buildscript classpath by pinning safer versions of affected libraries such as `org.jdom`, `io.netty` and `jose4j`.
- Clean up minor formatting in `apptoolkit/build.gradle.kts` to keep the Gradle file tidy.

### Description
- Added a `buildscript` block with `dependencies { constraints { classpath(...) } }` to the root `build.gradle.kts` that constrains specific classpath artifacts to known-safe versions with explanatory `because(...)` comments. 
- Constrained artifacts include `org.jdom:jdom2:2.0.6.1`, `io.netty:netty-handler:4.1.129.Final`, `io.netty:netty-codec-http2:4.1.129.Final`, `io.netty:netty-codec:4.1.129.Final`, `io.netty:netty-codec-http:4.1.129.Final`, and `org.bitbucket.b_c:jose4j:0.9.6` to mitigate XXE, Netty decoder/HTTP2/handler issues, CRLF injection, and JWE compression DoS respectively. 
- Minor whitespace/newline cleanup was applied to `apptoolkit/build.gradle.kts` and the root `build.gradle.kts` end-of-file formatting.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c023731aa0832dadf21f960b85c9a3)