### PR TITLE
Improve typography scaling and remove bold-weight usage in shared UI

### DIFF
--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/theme/ui/style/typography/Type.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/theme/ui/style/typography/Type.kt
@@ -1,8 +1,10 @@
 package com.d4rk.android.libs.apptoolkit.app.theme.ui.style.typography
 
 import androidx.compose.material3.Typography
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.Font
 import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
 import com.d4rk.android.libs.apptoolkit.R
 
 private val baseline = Typography()
@@ -11,20 +13,34 @@ private val appFontFamily = FontFamily(
     Font(R.font.google_sans_flex_variable)
 )
 
+private fun TextStyle.withAppTypographyDefaults(): TextStyle {
+    val normalizedWeight: FontWeight? = when (fontWeight) {
+        FontWeight.Bold,
+        FontWeight.ExtraBold,
+        FontWeight.Black -> FontWeight.SemiBold
+
+        else -> fontWeight
+    }
+    return copy(
+        fontFamily = appFontFamily,
+        fontWeight = normalizedWeight
+    )
+}
+
 val AppTypography: Typography = Typography(
-    displayLarge = baseline.displayLarge.copy(fontFamily = appFontFamily),
-    displayMedium = baseline.displayMedium.copy(fontFamily = appFontFamily),
-    displaySmall = baseline.displaySmall.copy(fontFamily = appFontFamily),
-    headlineLarge = baseline.headlineLarge.copy(fontFamily = appFontFamily),
-    headlineMedium = baseline.headlineMedium.copy(fontFamily = appFontFamily),
-    headlineSmall = baseline.headlineSmall.copy(fontFamily = appFontFamily),
-    titleLarge = baseline.titleLarge.copy(fontFamily = appFontFamily),
-    titleMedium = baseline.titleMedium.copy(fontFamily = appFontFamily),
-    titleSmall = baseline.titleSmall.copy(fontFamily = appFontFamily),
-    bodyLarge = baseline.bodyLarge.copy(fontFamily = appFontFamily),
-    bodyMedium = baseline.bodyMedium.copy(fontFamily = appFontFamily),
-    bodySmall = baseline.bodySmall.copy(fontFamily = appFontFamily),
-    labelLarge = baseline.labelLarge.copy(fontFamily = appFontFamily),
-    labelMedium = baseline.labelMedium.copy(fontFamily = appFontFamily),
-    labelSmall = baseline.labelSmall.copy(fontFamily = appFontFamily),
+    displayLarge = baseline.displayLarge.withAppTypographyDefaults(),
+    displayMedium = baseline.displayMedium.withAppTypographyDefaults(),
+    displaySmall = baseline.displaySmall.withAppTypographyDefaults(),
+    headlineLarge = baseline.headlineLarge.withAppTypographyDefaults(),
+    headlineMedium = baseline.headlineMedium.withAppTypographyDefaults(),
+    headlineSmall = baseline.headlineSmall.withAppTypographyDefaults(),
+    titleLarge = baseline.titleLarge.withAppTypographyDefaults(),
+    titleMedium = baseline.titleMedium.withAppTypographyDefaults(),
+    titleSmall = baseline.titleSmall.withAppTypographyDefaults(),
+    bodyLarge = baseline.bodyLarge.withAppTypographyDefaults(),
+    bodyMedium = baseline.bodyMedium.withAppTypographyDefaults(),
+    bodySmall = baseline.bodySmall.withAppTypographyDefaults(),
+    labelLarge = baseline.labelLarge.withAppTypographyDefaults(),
+    labelMedium = baseline.labelMedium.withAppTypographyDefaults(),
+    labelSmall = baseline.labelSmall.withAppTypographyDefaults(),
 )

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/dialogs/BasicAlertDialog.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/dialogs/BasicAlertDialog.kt
@@ -22,6 +22,7 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import com.d4rk.android.libs.apptoolkit.core.ui.views.modifiers.bounceClick
 
 @Composable
@@ -51,7 +52,11 @@ fun BasicAlertDialog(
         }
     }, title = {
         if (!title.isNullOrEmpty()) {
-            Text(text = title)
+            Text(
+                text = title,
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis
+            )
         }
     }, text = {
         AnimatedContent(
@@ -71,7 +76,11 @@ fun BasicAlertDialog(
             hapticFeedback.performHapticFeedback(hapticFeedbackType = HapticFeedbackType.ContextClick)
             onConfirm()
         }, enabled = confirmEnabled) {
-            Text(text = confirmButtonText ?: stringResource(id = android.R.string.ok))
+            Text(
+                text = confirmButtonText ?: stringResource(id = android.R.string.ok),
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
+            )
         }
     }, dismissButton = {
         if (showDismissButton) {
@@ -80,7 +89,11 @@ fun BasicAlertDialog(
                 hapticFeedback.performHapticFeedback(hapticFeedbackType = HapticFeedbackType.ContextClick)
                 onCancel()
             }, enabled = dismissEnabled) {
-                Text(text = dismissButtonText ?: stringResource(id = android.R.string.cancel))
+                Text(
+                    text = dismissButtonText ?: stringResource(id = android.R.string.cancel),
+                    maxLines = 1,
+                    overflow = TextOverflow.Ellipsis
+                )
             }
         }
     })

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/dialogs/BasicFullScreenDialog.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/dialogs/BasicFullScreenDialog.kt
@@ -25,6 +25,7 @@ import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalView
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.window.Dialog
 import androidx.compose.ui.window.DialogProperties
 import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.IconButton
@@ -61,13 +62,23 @@ fun BasicFullScreenDialog(
                         icon = Icons.Filled.Close,
                         iconContentDescription = null
                     )
-                }, title = { Text(text = title) }, actions = {
+                }, title = {
+                    Text(
+                        text = title,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                }, actions = {
                     TextButton(modifier = Modifier.bounceClick(), onClick = {
                         view.playSoundEffect(SoundEffectConstants.CLICK)
                         hapticFeedback.performHapticFeedback(hapticFeedbackType = HapticFeedbackType.ContextClick)
                         onConfirm()
                     }, enabled = confirmEnabled) {
-                        Text(confirmButtonText)
+                        Text(
+                            text = confirmButtonText,
+                            maxLines = 1,
+                            overflow = TextOverflow.Ellipsis
+                        )
                     }
                 })
             }) { innerPadding: PaddingValues ->

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/layouts/LoadingScreen.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/layouts/LoadingScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.Dp
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.MediumVerticalSpacer
@@ -53,7 +54,9 @@ fun LoadingScreen(
             MediumVerticalSpacer()
             Text(
                 text = stringResource(R.string.loading),
-                style = MaterialTheme.typography.bodyMedium
+                style = MaterialTheme.typography.bodyMedium,
+                maxLines = 1,
+                overflow = TextOverflow.Ellipsis
             )
         }
     }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/layouts/NoDataScreen.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/layouts/NoDataScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.text.style.TextOverflow
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.core.ui.model.ads.AdsConfig
 import com.d4rk.android.libs.apptoolkit.core.ui.views.ads.NoDataNativeAdCard
@@ -92,7 +93,9 @@ fun NoDataScreen(
         Text(
             text = stringResource(id = textMessage),
             style = MaterialTheme.typography.displaySmall.copy(textAlign = TextAlign.Center),
-            color = if (isError) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onBackground
+            color = if (isError) MaterialTheme.colorScheme.error else MaterialTheme.colorScheme.onBackground,
+            maxLines = 3,
+            overflow = TextOverflow.Ellipsis
         )
         if (showRetry) {
             LargeVerticalSpacer()

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/layouts/sections/TopListFilters.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/layouts/sections/TopListFilters.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextOverflow
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.chip.CommonFilterChip
 import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.LargeHorizontalSpacer
@@ -36,7 +37,9 @@ fun TopListFilters(
         Text(
             text = label,
             style = MaterialTheme.typography.bodyMedium,
-            fontWeight = FontWeight.SemiBold
+            fontWeight = FontWeight.SemiBold,
+            maxLines = 1,
+            overflow = TextOverflow.Ellipsis
         )
         LargeHorizontalSpacer()
         LazyRow(

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/navigation/TopAppBar.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/navigation/TopAppBar.kt
@@ -18,6 +18,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
 import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.AnimatedIconButtonDirection
 
 /**
@@ -60,7 +61,14 @@ fun LargeTopAppBarWithScaffold(
         modifier = Modifier.nestedScroll(scrollBehavior.nestedScrollConnection),
         topBar = {
             LargeTopAppBar(
-                title = { Text(modifier = Modifier.animateContentSize(), text = title) },
+                title = {
+                    Text(
+                        modifier = Modifier.animateContentSize(),
+                        text = title,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                },
                 navigationIcon = {
                     AnimatedIconButtonDirection(
                         icon = Icons.AutoMirrored.Filled.ArrowBack,
@@ -119,7 +127,14 @@ fun TopAppBarScaffold(
         modifier = Modifier.nestedScroll(connection = scrollBehaviorState.nestedScrollConnection),
         topBar = {
             LargeTopAppBar(
-                title = { Text(modifier = Modifier.animateContentSize(), text = title) },
+                title = {
+                    Text(
+                        modifier = Modifier.animateContentSize(),
+                        text = title,
+                        maxLines = 2,
+                        overflow = TextOverflow.Ellipsis
+                    )
+                },
                 scrollBehavior = scrollBehaviorState
             )
         },

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/preferences/CheckBoxPreferenceItem.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/preferences/CheckBoxPreferenceItem.kt
@@ -77,7 +77,12 @@ fun CheckBoxPreferenceItem(
                 fontWeight = FontWeight.SemiBold
             )
             summary?.let {
-                Text(text = it, style = MaterialTheme.typography.bodyMedium)
+                Text(
+                    text = it,
+                    style = MaterialTheme.typography.bodyMedium,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis
+                )
             }
         }
         Checkbox(checked = checked, onCheckedChange = { isChecked: Boolean ->

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/preferences/PreferenceItem.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/preferences/PreferenceItem.kt
@@ -80,7 +80,9 @@ fun PreferenceItem(
                 Text(
                     text = it,
                     style = MaterialTheme.typography.bodyMedium,
-                    color = if (!enabled) LocalContentColor.current.copy(alpha = 0.38f) else LocalContentColor.current
+                    color = if (!enabled) LocalContentColor.current.copy(alpha = 0.38f) else LocalContentColor.current,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis
                 )
             }
         }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/preferences/RadioButtonPreferenceItem.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/preferences/RadioButtonPreferenceItem.kt
@@ -16,6 +16,7 @@ import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.text.style.TextOverflow
 import com.d4rk.android.libs.apptoolkit.core.ui.views.modifiers.bounceClick
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 
@@ -61,9 +62,13 @@ fun RadioButtonPreferenceItem(
                 onCheckedChange(!isChecked)
             })
         Text(
-            text = text, style = MaterialTheme.typography.bodyMedium, modifier = Modifier
+            text = text,
+            style = MaterialTheme.typography.bodyMedium,
+            modifier = Modifier
                 .weight(weight = 1f)
-                .padding(end = SizeConstants.LargeSize, start = SizeConstants.LargeSize)
+                .padding(end = SizeConstants.LargeSize, start = SizeConstants.LargeSize),
+            maxLines = 2,
+            overflow = TextOverflow.Ellipsis
         )
     }
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/preferences/SwitchPreferenceItem.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/preferences/SwitchPreferenceItem.kt
@@ -83,7 +83,12 @@ fun SwitchPreferenceItem(
                     overflow = TextOverflow.Ellipsis
                 )
                 summary?.let {
-                    Text(text = it, style = MaterialTheme.typography.bodyMedium)
+                    Text(
+                        text = it,
+                        style = MaterialTheme.typography.bodyMedium,
+                        maxLines = 3,
+                        overflow = TextOverflow.Ellipsis
+                    )
                 }
             }
             CustomSwitch(

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/preferences/SwitchPreferenceItemWithDivider.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/preferences/SwitchPreferenceItemWithDivider.kt
@@ -93,7 +93,12 @@ fun SwitchPreferenceItemWithDivider(
                     maxLines = 1,
                     overflow = TextOverflow.Ellipsis
                 )
-                Text(text = summary, style = MaterialTheme.typography.bodyMedium)
+                Text(
+                    text = summary,
+                    style = MaterialTheme.typography.bodyMedium,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis
+                )
             }
             ExtraSmallHorizontalSpacer()
             Icon(

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/snackbar/DefaultSnackbarHost.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/snackbar/DefaultSnackbarHost.kt
@@ -23,6 +23,7 @@ import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalView
+import androidx.compose.ui.text.style.TextOverflow
 import com.d4rk.android.libs.apptoolkit.core.ui.model.CustomSnackbarVisuals
 import com.d4rk.android.libs.apptoolkit.core.ui.views.modifiers.bounceClick
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
@@ -62,7 +63,11 @@ fun DefaultSnackbarHost(snackbarState: SnackbarHostState, modifier: Modifier = M
                         )
                     }
                 }) {
-                Text(text = visuals.message)
+                Text(
+                    text = visuals.message,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis
+                )
             }
         }
     }


### PR DESCRIPTION
## Summary
- normalized the app typography setup so any Bold/ExtraBold/Black text styles are automatically downgraded to `SemiBold` while keeping Google Sans Flex as the global font family
- improved shared text components to better handle font scaling by adding `maxLines` + `TextOverflow.Ellipsis` in commonly reused UI surfaces
- updated top app bars, dialogs, snackbars, loading/no-data, and shared preference items to reduce clipping/truncation issues on small screens and at larger font sizes

## Change rationale
Previously, some shared surfaces could render unrestricted text and potentially overflow under larger accessibility font settings, and typography setup did not explicitly guard against heavy bold weights. This change introduces consistent truncation behavior in reusable components and enforces a semibold ceiling for weight-heavy styles, which aligns with the custom Google Sans Flex rendering constraints and improves readability stability across UI sizes.

## Files touched
- `app/theme/ui/style/typography/Type.kt`
- `core/ui/views/navigation/TopAppBar.kt`
- `core/ui/views/dialogs/BasicAlertDialog.kt`
- `core/ui/views/dialogs/BasicFullScreenDialog.kt`
- `core/ui/views/preferences/PreferenceItem.kt`
- `core/ui/views/preferences/SwitchPreferenceItem.kt`
- `core/ui/views/preferences/SwitchPreferenceItemWithDivider.kt`
- `core/ui/views/preferences/CheckBoxPreferenceItem.kt`
- `core/ui/views/preferences/RadioButtonPreferenceItem.kt`
- `core/ui/views/snackbar/DefaultSnackbarHost.kt`
- `core/ui/views/layouts/LoadingScreen.kt`
- `core/ui/views/layouts/NoDataScreen.kt`
- `core/ui/views/layouts/sections/TopListFilters.kt`

## Testing
- Not run (no build/test execution requested).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c0fa367638832da2749b99b9548f08)