### PR TITLE
Migrate ad implementation to GMA Next‑Gen SDK and adapt ad APIs

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -41,6 +41,14 @@ if (hasGoogleServicesConfig) {
     apply(plugin = libs.plugins.firebase.performance.get().pluginId)
 }
 
+configurations.configureEach {
+    exclude(group = "org.chromium.net", module = "cronet-fallback")
+    exclude(group = "org.chromium.net", module = "httpengine-native-provider")
+    exclude(group = "org.chromium.net", module = "cronet-common")
+    exclude(group = "org.chromium.net", module = "cronet-api")
+    exclude(group = "org.chromium.net", module = "cronet-shared")
+}
+
 android {
     namespace = "com.d4rk.android.apps.apptoolkit"
     compileSdk {

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainActivity.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainActivity.kt
@@ -30,7 +30,6 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.d4rk.android.apps.apptoolkit.app.main.ui.contract.MainAction
 import com.d4rk.android.apps.apptoolkit.app.main.ui.contract.MainEvent
-import com.d4rk.android.apps.apptoolkit.R
 import com.d4rk.android.apps.apptoolkit.core.data.local.DataStore
 import com.d4rk.android.libs.apptoolkit.app.consent.domain.usecases.ApplyInitialConsentUseCase
 import com.d4rk.android.libs.apptoolkit.app.main.ui.factory.GmsHostFactory
@@ -82,7 +81,8 @@ class MainActivity : AppCompatActivity() {
                     async(dispatchers.default) {
                         MobileAds.initialize(
                             this@MainActivity,
-                            InitializationConfig.Builder(getString(R.string.ad_mob_app_id)).build()
+                            InitializationConfig.Builder(getString(com.d4rk.android.libs.apptoolkit.R.string.ad_mob_app_id))
+                                .build()
                         ) {}
                     }
                 val consentInitialization =

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainActivity.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainActivity.kt
@@ -30,6 +30,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import com.d4rk.android.apps.apptoolkit.app.main.ui.contract.MainAction
 import com.d4rk.android.apps.apptoolkit.app.main.ui.contract.MainEvent
+import com.d4rk.android.apps.apptoolkit.R
 import com.d4rk.android.apps.apptoolkit.core.data.local.DataStore
 import com.d4rk.android.libs.apptoolkit.app.consent.domain.usecases.ApplyInitialConsentUseCase
 import com.d4rk.android.libs.apptoolkit.app.main.ui.factory.GmsHostFactory
@@ -37,7 +38,8 @@ import com.d4rk.android.libs.apptoolkit.app.startup.ui.StartupActivity
 import com.d4rk.android.libs.apptoolkit.app.theme.ui.style.AppTheme
 import com.d4rk.android.libs.apptoolkit.core.coroutines.dispatchers.DispatcherProvider
 import com.d4rk.android.libs.apptoolkit.core.utils.extensions.context.openActivity
-import com.google.android.gms.ads.MobileAds
+import com.google.android.libraries.ads.mobile.sdk.MobileAds
+import com.google.android.libraries.ads.mobile.sdk.initialization.InitializationConfig
 import kotlinx.coroutines.async
 import kotlinx.coroutines.awaitAll
 import kotlinx.coroutines.coroutineScope
@@ -77,7 +79,12 @@ class MainActivity : AppCompatActivity() {
         lifecycleScope.launch {
             coroutineScope {
                 val adsInitialization =
-                    async(dispatchers.default) { MobileAds.initialize(this@MainActivity) {} }
+                    async(dispatchers.default) {
+                        MobileAds.initialize(
+                            this@MainActivity,
+                            InitializationConfig.Builder(getString(R.string.ad_mob_app_id)).build()
+                        ) {}
+                    }
                 val consentInitialization =
                     async(dispatchers.io) { applyInitialConsentUseCase.invoke() }
                 awaitAll(adsInitialization, consentInitialization)

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/widgets/apps/AppIconsWidget.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/widgets/apps/AppIconsWidget.kt
@@ -24,6 +24,7 @@ import android.graphics.drawable.Drawable
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.unit.DpSize
 import androidx.compose.ui.unit.dp
+import androidx.core.graphics.createBitmap
 import androidx.glance.GlanceId
 import androidx.glance.GlanceModifier
 import androidx.glance.Image
@@ -74,7 +75,8 @@ class AppIconsWidget : GlanceAppWidget() {
             is DataState.Loading -> emptyList()
         }
 
-        val source = if (apps.isNotEmpty()) apps else listOf(createFallbackEntry(context))
+        val source =
+            if (apps.isNotEmpty()) apps else listOf(createFallbackEntry(context)) // FIXME: Replace with 'ifEmpty {...}'
         return source.map { app ->
             WidgetAppEntry(
                 app = app,
@@ -107,7 +109,9 @@ class AppIconsWidget : GlanceAppWidget() {
 }
 
 @Composable
-private fun AppIconsWidgetContent(apps: List<WidgetAppEntry>) {
+private fun AppIconsWidgetContent(
+    apps: List<WidgetAppEntry> // FIXME: Unstable parameter 'apps' prevents composable from being skippable
+) {
     LazyColumn(
         modifier = GlanceModifier
             .fillMaxSize()
@@ -152,7 +156,7 @@ private fun GlanceModifier.appWidgetClickAction(packageName: String): GlanceModi
 private fun Drawable.toBitmap(sizePx: Int): Bitmap {
     val width = intrinsicWidth.takeIf { it > 0 } ?: sizePx
     val height = intrinsicHeight.takeIf { it > 0 } ?: sizePx
-    return Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888).also { bitmap ->
+    return createBitmap(width, height).also { bitmap ->
         val canvas = Canvas(bitmap)
         setBounds(0, 0, canvas.width, canvas.height)
         draw(canvas)

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/app/modules/AdsModule.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/app/modules/AdsModule.kt
@@ -25,7 +25,7 @@ import com.d4rk.android.libs.apptoolkit.app.ads.domain.usecases.SetAdsEnabledUse
 import com.d4rk.android.libs.apptoolkit.app.ads.ui.AdsSettingsViewModel
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoProvider
 import com.d4rk.android.libs.apptoolkit.core.ui.model.ads.AdsConfig
-import com.google.android.gms.ads.AdSize
+import com.google.android.libraries.ads.mobile.sdk.banner.AdSize
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.viewModel
 import org.koin.core.qualifier.named

--- a/app/src/main/res/xml/app_icons_widget_info.xml
+++ b/app/src/main/res/xml/app_icons_widget_info.xml
@@ -17,6 +17,7 @@
   -->
 
 <appwidget-provider xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:description="@string/app_short_description"
     android:initialLayout="@layout/widget_app_icons_loading"
     android:minHeight="120dp"
@@ -26,4 +27,5 @@
     android:targetCellHeight="2"
     android:targetCellWidth="2"
     android:updatePeriodMillis="0"
-    android:widgetCategory="home_screen" />
+    android:widgetCategory="home_screen"
+    tools:targetApi="31" />

--- a/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/usecases/FetchDeveloperAppsUseCaseTest.kt
+++ b/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/domain/usecases/FetchDeveloperAppsUseCaseTest.kt
@@ -62,7 +62,7 @@ class FetchDeveloperAppsUseCaseTest {
         val result = useCase().toList()
 
         assertEquals(repositoryEmissions, result)
-        verify(exactly = 1) { repository.fetchDeveloperApps() }
+        verify(exactly = 1) { repository.fetchDeveloperApps() } // FIXME: Flow is constructed but not used
     }
 
     @Test
@@ -78,6 +78,6 @@ class FetchDeveloperAppsUseCaseTest {
         }
 
         assertSame(exception, thrown)
-        verify(exactly = 1) { repository.fetchDeveloperApps() }
+        verify(exactly = 1) { repository.fetchDeveloperApps() } // FIXME: Flow is constructed but not used
     }
 }

--- a/apptoolkit/build.gradle.kts
+++ b/apptoolkit/build.gradle.kts
@@ -33,6 +33,11 @@ plugins {
     `maven-publish`
 }
 
+configurations.configureEach {
+    exclude(group = "com.google.android.gms", module = "play-services-ads")
+    exclude(group = "com.google.android.gms", module = "play-services-ads-lite")
+}
+
 android {
 
     namespace = "com.d4rk.android.libs.apptoolkit"

--- a/apptoolkit/build.gradle.kts
+++ b/apptoolkit/build.gradle.kts
@@ -36,6 +36,11 @@ plugins {
 configurations.configureEach {
     exclude(group = "com.google.android.gms", module = "play-services-ads")
     exclude(group = "com.google.android.gms", module = "play-services-ads-lite")
+    exclude(group = "org.chromium.net", module = "cronet-fallback")
+    exclude(group = "org.chromium.net", module = "httpengine-native-provider")
+    exclude(group = "org.chromium.net", module = "cronet-common")
+    exclude(group = "org.chromium.net", module = "cronet-api")
+    exclude(group = "org.chromium.net", module = "cronet-shared")
 }
 
 android {

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/issuereporter/domain/model/DeviceInfo.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/issuereporter/domain/model/DeviceInfo.kt
@@ -22,7 +22,7 @@ import android.content.Context
 import android.os.Build
 import com.d4rk.android.libs.apptoolkit.core.utils.extensions.packagemanager.getVersionInfo
 
-class DeviceInfo() {
+class DeviceInfo {
     private var versionCode: Long = -1
     private var versionName: String? = null
     private val buildVersion: String = Build.VERSION.INCREMENTAL ?: Build.UNKNOWN

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/GeneralSettingsScreen.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/general/ui/GeneralSettingsScreen.kt
@@ -89,7 +89,7 @@ fun GeneralSettingsScreen(
 @Composable
 fun GeneralSettingsContent(
     screenState: UiStateScreen<GeneralSettingsUiState>,
-    contentProvider: GeneralSettingsContentProvider,
+    contentProvider: GeneralSettingsContentProvider, // FIXME: Parameter 'contentProvider' has runtime-determined stability
     paddingValues: PaddingValues,
     snackbarHostState: SnackbarHostState,
 ) {

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsScreen.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsScreen.kt
@@ -165,7 +165,7 @@ fun SettingsScreen() {
 fun SettingsScreenContent(
     paddingValues: PaddingValues,
     settingsConfig: SettingsConfig,
-    contentProvider: GeneralSettingsContentProvider,
+    contentProvider: GeneralSettingsContentProvider, // FIXME: Parameter 'contentProvider' has runtime-determined stability
     firebaseController: FirebaseController,
 ) {
     val windowWidthSizeClass: AppWindowWidthSizeClass = rememberWindowWidthSizeClass()
@@ -203,7 +203,7 @@ fun PhoneSettingsScreen(
 fun TabletSettingsScreen(
     paddingValues: PaddingValues,
     settingsConfig: SettingsConfig,
-    contentProvider: GeneralSettingsContentProvider,
+    contentProvider: GeneralSettingsContentProvider, // FIXME: Parameter 'contentProvider' has runtime-determined stability
     firebaseController: FirebaseController,
 ) {
     var selected: SettingsPreference? by remember { mutableStateOf(null) }
@@ -296,7 +296,7 @@ fun SettingsDetailPlaceholder(paddingValues: PaddingValues) {
 fun SettingsDetail(
     preference: SettingsPreference,
     paddingValues: PaddingValues,
-    contentProvider: GeneralSettingsContentProvider,
+    contentProvider: GeneralSettingsContentProvider, // FIXME: Parameter 'contentProvider' has runtime-determined stability
 ) {
     val viewModel: GeneralSettingsViewModel = koinViewModel()
     val snackbarHostState: SnackbarHostState = remember { SnackbarHostState() }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/data/remote/ads/AdsCoreManager.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/data/remote/ads/AdsCoreManager.kt
@@ -19,16 +19,19 @@ package com.d4rk.android.libs.apptoolkit.core.data.remote.ads
 
 import android.app.Activity
 import android.content.Context
+import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoProvider
 import com.d4rk.android.libs.apptoolkit.core.coroutines.dispatchers.DispatcherProvider
 import com.d4rk.android.libs.apptoolkit.core.data.local.datastore.CommonDataStore
 import com.d4rk.android.libs.apptoolkit.core.utils.interfaces.OnShowAdCompleteListener
-import com.google.android.gms.ads.AdError
-import com.google.android.gms.ads.AdRequest
-import com.google.android.gms.ads.FullScreenContentCallback
-import com.google.android.gms.ads.LoadAdError
-import com.google.android.gms.ads.MobileAds
-import com.google.android.gms.ads.appopen.AppOpenAd
+import com.google.android.libraries.ads.mobile.sdk.MobileAds
+import com.google.android.libraries.ads.mobile.sdk.appopen.AppOpenAd
+import com.google.android.libraries.ads.mobile.sdk.appopen.AppOpenAdEventCallback
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
+import com.google.android.libraries.ads.mobile.sdk.common.AdRequest
+import com.google.android.libraries.ads.mobile.sdk.common.FullScreenContentError
+import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
+import com.google.android.libraries.ads.mobile.sdk.initialization.InitializationConfig
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -58,7 +61,12 @@ open class AdsCoreManager(
             dataStore.ads(default = !buildInfoProvider.isDebugBuild).first()
         }
         if (isAdsChecked) {
-            withContext(dispatchers.io) { MobileAds.initialize(context) }
+            withContext(dispatchers.io) {
+                MobileAds.initialize(
+                    context,
+                    InitializationConfig.Builder(context.getString(R.string.ad_mob_app_id)).build()
+                ) {}
+            }
             appOpenAdManager = AppOpenAdManager(appOpenUnitId)
         }
     }
@@ -90,10 +98,9 @@ open class AdsCoreManager(
                 return
             }
             isLoadingAd = true
-            val request = AdRequest.Builder().build()
-            val appContext = context.applicationContext ?: context
+            val request = AdRequest.Builder(appOpenUnitId).build()
             AppOpenAd.load(
-                appContext, appOpenUnitId, request, object : AppOpenAd.AppOpenAdLoadCallback() {
+                request, object : AdLoadCallback<AppOpenAd>() {
                     override fun onAdLoaded(ad: AppOpenAd) {
                         appOpenAd = ad
                         isLoadingAd = false
@@ -143,7 +150,7 @@ open class AdsCoreManager(
                 return
             }
 
-            appOpenAd?.fullScreenContentCallback = object : FullScreenContentCallback() {
+            appOpenAd?.adEventCallback = object : AppOpenAdEventCallback {
                 override fun onAdDismissedFullScreenContent() {
                     appOpenAd = null
                     isShowingAd = false
@@ -151,7 +158,7 @@ open class AdsCoreManager(
                     loadAd(context = this@AdsCoreManager.context)
                 }
 
-                override fun onAdFailedToShowFullScreenContent(adError: AdError) {
+                override fun onAdFailedToShowFullScreenContent(fullScreenContentError: FullScreenContentError) {
                     appOpenAd = null
                     isShowingAd = false
                     onShowAdCompleteListener.onShowAdComplete()

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/data/remote/ads/AdsCoreManager.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/data/remote/ads/AdsCoreManager.kt
@@ -93,7 +93,7 @@ open class AdsCoreManager(
         private var loadTime: Long = 0
 
         /** Loads a new ad if none is available. */
-        fun loadAd(context: Context) {
+        fun loadAd(context: Context) { // FIXME: Parameter "context" is never used
             if (isLoadingAd || isAdAvailable()) {
                 return
             }
@@ -107,7 +107,7 @@ open class AdsCoreManager(
                         loadTime = Date().time
                     }
 
-                    override fun onAdFailedToLoad(loadAdError: LoadAdError) {
+                    override fun onAdFailedToLoad(adError: LoadAdError) {
                         isLoadingAd = false
                     }
                 })

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/data/remote/ads/AdsCoreManager.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/data/remote/ads/AdsCoreManager.kt
@@ -100,7 +100,7 @@ open class AdsCoreManager(
             isLoadingAd = true
             val request = AdRequest.Builder(appOpenUnitId).build()
             AppOpenAd.load(
-                request, object : AdLoadCallback<AppOpenAd>() {
+                request, object : AdLoadCallback<AppOpenAd> {
                     override fun onAdLoaded(ad: AppOpenAd) {
                         appOpenAd = ad
                         isLoadingAd = false

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/model/ads/AdsConfig.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/model/ads/AdsConfig.kt
@@ -18,7 +18,7 @@
 package com.d4rk.android.libs.apptoolkit.core.ui.model.ads
 
 import androidx.compose.runtime.Immutable
-import com.google.android.gms.ads.AdSize
+import com.google.android.libraries.ads.mobile.sdk.banner.AdSize
 
 /**
  * Data class representing the configuration for displaying ads.

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/ads/AdBanner.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/ads/AdBanner.kt
@@ -18,13 +18,14 @@
 package com.d4rk.android.libs.apptoolkit.core.ui.views.ads
 
 import android.content.Context
+import android.os.Handler
+import android.os.Looper
 import androidx.compose.animation.AnimatedVisibility
 import androidx.compose.animation.expandVertically
 import androidx.compose.animation.shrinkVertically
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -35,10 +36,12 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
-import androidx.lifecycle.compose.LifecycleResumeEffect
 import com.d4rk.android.libs.apptoolkit.core.ui.model.ads.AdsConfig
-import com.google.android.gms.ads.AdRequest
-import com.google.android.gms.ads.AdView
+import com.google.android.libraries.ads.mobile.sdk.banner.AdView
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAd
+import com.google.android.libraries.ads.mobile.sdk.banner.BannerAdRequest
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
+import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
 
 /**
  * A Composable function that displays a banner ad from Google AdMob.
@@ -68,38 +71,35 @@ fun AdBanner(
 
     var isAdLoaded by remember(adsConfig.bannerAdUnitId) { mutableStateOf(false) }
 
-    val adRequest = remember { AdRequest.Builder().build() }
+    val mainHandler: Handler = remember { Handler(Looper.getMainLooper()) }
 
     val adView = remember(adsConfig.bannerAdUnitId, adsConfig.adSize) {
-        AdView(context).apply {
-            this.adUnitId = adsConfig.bannerAdUnitId
-            setAdSize(adsConfig.adSize)
-        }
+        AdView(context)
     }
 
-    DisposableEffect(key1 = adView) {
-        onDispose {
-            adView.destroy()
-        }
-    }
-
-    LaunchedEffect(key1 = adView, key2 = adRequest, key3 = showAds) {
+    LaunchedEffect(key1 = adView, key2 = showAds, key3 = adsConfig.bannerAdUnitId, key4 = adsConfig.adSize) {
         if (!showAds) {
             isAdLoaded = false
             return@LaunchedEffect
         }
 
         isAdLoaded = false
-        adView.adListener = object : com.google.android.gms.ads.AdListener() {
-            override fun onAdLoaded() {
-                isAdLoaded = true
-            }
+        val adRequest = BannerAdRequest.Builder(
+            adsConfig.bannerAdUnitId,
+            adsConfig.adSize
+        ).build()
+        adView.loadAd(
+            adRequest,
+            object : AdLoadCallback<BannerAd>() {
+                override fun onAdLoaded(ad: BannerAd) {
+                    mainHandler.post { isAdLoaded = true }
+                }
 
-            override fun onAdFailedToLoad(loadAdError: com.google.android.gms.ads.LoadAdError) {
-                isAdLoaded = false
+                override fun onAdFailedToLoad(adError: LoadAdError) {
+                    mainHandler.post { isAdLoaded = false }
+                }
             }
-        }
-        adView.loadAd(adRequest)
+        )
     }
 
     AnimatedVisibility(
@@ -113,12 +113,5 @@ fun AdBanner(
                 .height(adsConfig.adSize.height.dp),
             factory = { adView }
         )
-
-        LifecycleResumeEffect(key1 = adView) {
-            adView.resume()
-            onPauseOrDispose {
-                adView.pause()
-            }
-        }
     }
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/ads/AdBanner.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/ads/AdBanner.kt
@@ -77,7 +77,7 @@ fun AdBanner(
         AdView(context)
     }
 
-    LaunchedEffect(key1 = adView, key2 = showAds, key3 = adsConfig.bannerAdUnitId, key4 = adsConfig.adSize) {
+    LaunchedEffect(adView, showAds, adsConfig.bannerAdUnitId, adsConfig.adSize) {
         if (!showAds) {
             isAdLoaded = false
             return@LaunchedEffect
@@ -90,7 +90,7 @@ fun AdBanner(
         ).build()
         adView.loadAd(
             adRequest,
-            object : AdLoadCallback<BannerAd>() {
+            object : AdLoadCallback<BannerAd> {
                 override fun onAdLoaded(ad: BannerAd) {
                     mainHandler.post { isAdLoaded = true }
                 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/ads/AppDetailsNativeAd.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/ads/AppDetailsNativeAd.kt
@@ -18,6 +18,8 @@
 package com.d4rk.android.libs.apptoolkit.core.ui.views.ads
 
 import android.annotation.SuppressLint
+import android.os.Handler
+import android.os.Looper
 import android.view.LayoutInflater
 import android.widget.ImageView
 import android.widget.TextView
@@ -34,19 +36,17 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.view.isVisible
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.core.ui.model.ads.AdsConfig
-import com.google.android.gms.ads.AdListener
-import com.google.android.gms.ads.AdLoader
-import com.google.android.gms.ads.AdRequest
-import com.google.android.gms.ads.LoadAdError
-import com.google.android.gms.ads.nativead.NativeAd
-import com.google.android.gms.ads.nativead.NativeAdOptions
-import com.google.android.gms.ads.nativead.NativeAdView
+import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAd
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoader
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoaderCallback
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdRequest
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdView
 import com.google.android.material.button.MaterialButton
 
 /**
@@ -76,7 +76,6 @@ fun AppDetailsNativeAd(
     modifier: Modifier = Modifier,
     adsConfig: AdsConfig
 ) {
-    val context = LocalContext.current
     val inspectionMode = LocalInspectionMode.current
     val showAds: Boolean = rememberAdsEnabled()
 
@@ -89,7 +88,7 @@ fun AppDetailsNativeAd(
         return
     }
 
-    val adRequest: AdRequest = remember { AdRequest.Builder().build() }
+    val mainHandler: Handler = remember { Handler(Looper.getMainLooper()) }
 
     var nativeAdView by remember { mutableStateOf<NativeAdView?>(null) }
     var currentNativeAd by remember { mutableStateOf<NativeAd?>(null) }
@@ -114,30 +113,32 @@ fun AppDetailsNativeAd(
         }
     )
 
-    LaunchedEffect(nativeAdView, adsConfig.bannerAdUnitId, adRequest) {
+    LaunchedEffect(nativeAdView, adsConfig.bannerAdUnitId) {
         val view: NativeAdView = nativeAdView ?: return@LaunchedEffect
 
-        val adLoader: AdLoader = AdLoader.Builder(context, adsConfig.bannerAdUnitId)
-            .forNativeAd { nativeAd ->
-                currentNativeAd?.destroy()
-                currentNativeAd = nativeAd
-                bindAppDetailsNativeAd(adView = view, nativeAd = nativeAd)
-                view.isVisible = true
-            }
-            .withNativeAdOptions(
-                NativeAdOptions.Builder()
-                    .setAdChoicesPlacement(NativeAdOptions.ADCHOICES_TOP_RIGHT)
-                    .build()
-            )
-            .withAdListener(object : AdListener() {
-                override fun onAdFailedToLoad(adError: LoadAdError) {
-                    view.isVisible = false
+        val adRequest: NativeAdRequest = NativeAdRequest.Builder(
+            adsConfig.bannerAdUnitId,
+            listOf(NativeAd.NativeAdType.NATIVE)
+        ).build()
+        NativeAdLoader.load(
+            adRequest,
+            object : NativeAdLoaderCallback {
+                override fun onNativeAdLoaded(nativeAd: NativeAd) {
+                    mainHandler.post {
+                        currentNativeAd?.destroy()
+                        currentNativeAd = nativeAd
+                        bindAppDetailsNativeAd(adView = view, nativeAd = nativeAd)
+                        view.isVisible = true
+                    }
                 }
-            })
-            .build()
+
+                override fun onAdFailedToLoad(adError: LoadAdError) {
+                    mainHandler.post { view.isVisible = false }
+                }
+            }
+        )
 
         view.isVisible = false
-        adLoader.loadAd(adRequest)
     }
 }
 
@@ -201,5 +202,5 @@ private fun bindAppDetailsNativeAd(adView: NativeAdView, nativeAd: NativeAd) {
         callToActionView.isVisible = true
     }
 
-    adView.setNativeAd(nativeAd)
+    adView.registerNativeAd(nativeAd, null)
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/ads/AppsListNativeAdCard.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/ads/AppsListNativeAdCard.kt
@@ -18,6 +18,8 @@
 package com.d4rk.android.libs.apptoolkit.core.ui.views.ads
 
 import android.annotation.SuppressLint
+import android.os.Handler
+import android.os.Looper
 import android.widget.ImageView
 import android.widget.TextView
 import androidx.compose.foundation.layout.Box
@@ -37,18 +39,16 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.core.view.isVisible
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
-import com.google.android.gms.ads.AdListener
-import com.google.android.gms.ads.AdLoader
-import com.google.android.gms.ads.AdRequest
-import com.google.android.gms.ads.LoadAdError
-import com.google.android.gms.ads.nativead.NativeAd
-import com.google.android.gms.ads.nativead.NativeAdOptions
-import com.google.android.gms.ads.nativead.NativeAdView
+import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAd
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoader
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoaderCallback
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdRequest
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdView
 
 @SuppressLint("InflateParams")
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
@@ -57,7 +57,6 @@ fun AppsListNativeAdCard(
     modifier: Modifier = Modifier,
     adUnitId: String
 ) {
-    val context = LocalContext.current
     val inspectionMode = LocalInspectionMode.current
     val showAds: Boolean = rememberAdsEnabled()
 
@@ -66,7 +65,7 @@ fun AppsListNativeAdCard(
         return
     }
 
-    val adRequest: AdRequest = remember { AdRequest.Builder().build() }
+    val mainHandler: Handler = remember { Handler(Looper.getMainLooper()) }
 
     var isAdLoaded by remember(adUnitId) { mutableStateOf(false) }
     var nativeAdView by remember { mutableStateOf<NativeAdView?>(null) }
@@ -79,7 +78,7 @@ fun AppsListNativeAdCard(
         }
     }
 
-    LaunchedEffect(adUnitId, adRequest, showAds) {
+    LaunchedEffect(adUnitId, showAds) {
         if (!showAds || adUnitId.isBlank()) {
             nativeAdView?.isVisible = false
             currentNativeAd?.destroy()
@@ -89,31 +88,35 @@ fun AppsListNativeAdCard(
         }
 
         isAdLoaded = false
-        val adLoader: AdLoader = AdLoader.Builder(context, adUnitId)
-            .forNativeAd { nativeAd ->
-                currentNativeAd?.destroy()
-                currentNativeAd = nativeAd
-                nativeAdView?.let { view ->
-                    bindAppsListNativeAd(adView = view, nativeAd = nativeAd)
-                    view.isVisible = true
-                }
-                isAdLoaded = true
-            }
-            .withNativeAdOptions(
-                NativeAdOptions.Builder()
-                    .setAdChoicesPlacement(NativeAdOptions.ADCHOICES_TOP_RIGHT)
-                    .build()
-            )
-            .withAdListener(object : AdListener() {
-                override fun onAdFailedToLoad(adError: LoadAdError) {
-                    nativeAdView?.isVisible = false
-                    isAdLoaded = false
-                }
-            })
-            .build()
+        val adRequest: NativeAdRequest = NativeAdRequest.Builder(
+            adUnitId,
+            listOf(NativeAd.NativeAdType.NATIVE)
+        ).build()
 
         nativeAdView?.isVisible = false
-        adLoader.loadAd(adRequest)
+        NativeAdLoader.load(
+            adRequest,
+            object : NativeAdLoaderCallback {
+                override fun onNativeAdLoaded(nativeAd: NativeAd) {
+                    mainHandler.post {
+                        currentNativeAd?.destroy()
+                        currentNativeAd = nativeAd
+                        nativeAdView?.let { view ->
+                            bindAppsListNativeAd(adView = view, nativeAd = nativeAd)
+                            view.isVisible = true
+                        }
+                        isAdLoaded = true
+                    }
+                }
+
+                override fun onAdFailedToLoad(adError: LoadAdError) {
+                    mainHandler.post {
+                        nativeAdView?.isVisible = false
+                        isAdLoaded = false
+                    }
+                }
+            }
+        )
     }
 
     if (isAdLoaded) {
@@ -200,5 +203,5 @@ private fun bindAppsListNativeAd(adView: NativeAdView, nativeAd: NativeAd) {
         iconView.isVisible = true
     }
 
-    adView.setNativeAd(nativeAd)
+    adView.registerNativeAd(nativeAd, null)
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/ads/BottomAppBarNativeAdBanner.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/ads/BottomAppBarNativeAdBanner.kt
@@ -18,6 +18,8 @@
 package com.d4rk.android.libs.apptoolkit.core.ui.views.ads
 
 import android.annotation.SuppressLint
+import android.os.Handler
+import android.os.Looper
 import android.view.LayoutInflater
 import android.widget.Button
 import android.widget.ImageView
@@ -37,19 +39,17 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.view.isVisible
 import com.d4rk.android.libs.apptoolkit.R
-import com.google.android.gms.ads.AdListener
-import com.google.android.gms.ads.AdLoader
-import com.google.android.gms.ads.AdRequest
-import com.google.android.gms.ads.LoadAdError
-import com.google.android.gms.ads.nativead.NativeAd
-import com.google.android.gms.ads.nativead.NativeAdOptions
-import com.google.android.gms.ads.nativead.NativeAdView
+import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAd
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoader
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoaderCallback
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdRequest
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdView
 
 private const val PREVIEW_NATIVE_AD_HEIGHT = 120
 
@@ -76,7 +76,6 @@ fun BottomAppBarNativeAdBanner(
     modifier: Modifier = Modifier,
     adUnitId: String
 ) {
-    val context = LocalContext.current
     val inspectionMode = LocalInspectionMode.current
     val showAds: Boolean = rememberAdsEnabled()
 
@@ -89,7 +88,7 @@ fun BottomAppBarNativeAdBanner(
         return
     }
 
-    val adRequest: AdRequest = remember { AdRequest.Builder().build() }
+    val mainHandler: Handler = remember { Handler(Looper.getMainLooper()) }
 
     var nativeAdView by remember { mutableStateOf<NativeAdView?>(null) }
     var currentNativeAd by remember { mutableStateOf<NativeAd?>(null) }
@@ -114,30 +113,32 @@ fun BottomAppBarNativeAdBanner(
         }
     )
 
-    LaunchedEffect(nativeAdView, adUnitId, adRequest) {
+    LaunchedEffect(nativeAdView, adUnitId) {
         val view: NativeAdView = nativeAdView ?: return@LaunchedEffect
 
-        val adLoader: AdLoader = AdLoader.Builder(context, adUnitId)
-            .forNativeAd { nativeAd ->
-                currentNativeAd?.destroy()
-                currentNativeAd = nativeAd
-                bindBottomAppBarNativeAd(adView = view, nativeAd = nativeAd)
-                view.isVisible = true
-            }
-            .withNativeAdOptions(
-                NativeAdOptions.Builder()
-                    .setAdChoicesPlacement(NativeAdOptions.ADCHOICES_TOP_RIGHT)
-                    .build()
-            )
-            .withAdListener(object : AdListener() {
-                override fun onAdFailedToLoad(adError: LoadAdError) {
-                    view.isVisible = false
-                }
-            })
-            .build()
+        val adRequest: NativeAdRequest = NativeAdRequest.Builder(
+            adUnitId,
+            listOf(NativeAd.NativeAdType.NATIVE)
+        ).build()
 
         view.isVisible = false
-        adLoader.loadAd(adRequest)
+        NativeAdLoader.load(
+            adRequest,
+            object : NativeAdLoaderCallback {
+                override fun onNativeAdLoaded(nativeAd: NativeAd) {
+                    mainHandler.post {
+                        currentNativeAd?.destroy()
+                        currentNativeAd = nativeAd
+                        bindBottomAppBarNativeAd(adView = view, nativeAd = nativeAd)
+                        view.isVisible = true
+                    }
+                }
+
+                override fun onAdFailedToLoad(adError: LoadAdError) {
+                    mainHandler.post { view.isVisible = false }
+                }
+            }
+        )
     }
 }
 
@@ -203,5 +204,5 @@ private fun bindBottomAppBarNativeAd(adView: NativeAdView, nativeAd: NativeAd) {
         callToActionView.isVisible = true
     }
 
-    adView.setNativeAd(nativeAd)
+    adView.registerNativeAd(nativeAd, null)
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/ads/HelpNativeAdCard.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/ads/HelpNativeAdCard.kt
@@ -18,6 +18,8 @@
 package com.d4rk.android.libs.apptoolkit.core.ui.views.ads
 
 import android.annotation.SuppressLint
+import android.os.Handler
+import android.os.Looper
 import android.view.View
 import android.widget.Button
 import android.widget.ImageView
@@ -50,19 +52,17 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.text.font.FontWeight
 import androidx.core.view.isVisible
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
-import com.google.android.gms.ads.AdListener
-import com.google.android.gms.ads.AdLoader
-import com.google.android.gms.ads.AdRequest
-import com.google.android.gms.ads.LoadAdError
-import com.google.android.gms.ads.nativead.NativeAd
-import com.google.android.gms.ads.nativead.NativeAdOptions
-import com.google.android.gms.ads.nativead.NativeAdView
+import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAd
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoader
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoaderCallback
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdRequest
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdView
 
 /**
  * A Composable that displays a native ad in a card format, specifically styled for a "help" or "discovery" context.
@@ -93,7 +93,6 @@ fun HelpNativeAdCard(
     modifier: Modifier = Modifier,
     adUnitId: String
 ) {
-    val context = LocalContext.current
     val inspectionMode = LocalInspectionMode.current
     val showAds: Boolean = rememberAdsEnabled()
 
@@ -106,7 +105,7 @@ fun HelpNativeAdCard(
         return
     }
 
-    val adRequest: AdRequest = remember { AdRequest.Builder().build() }
+    val mainHandler: Handler = remember { Handler(Looper.getMainLooper()) }
 
     var nativeAdView by remember { mutableStateOf<NativeAdView?>(null) }
     var currentNativeAd by remember { mutableStateOf<NativeAd?>(null) }
@@ -133,30 +132,32 @@ fun HelpNativeAdCard(
         )
     }
 
-    LaunchedEffect(nativeAdView, adUnitId, adRequest) {
+    LaunchedEffect(nativeAdView, adUnitId) {
         val view: NativeAdView = nativeAdView ?: return@LaunchedEffect
 
-        val adLoader: AdLoader = AdLoader.Builder(context, adUnitId)
-            .forNativeAd { nativeAd ->
-                currentNativeAd?.destroy()
-                currentNativeAd = nativeAd
-                bindHelpNativeAd(adView = view, nativeAd = nativeAd)
-                view.isVisible = true
-            }
-            .withNativeAdOptions(
-                NativeAdOptions.Builder()
-                    .setAdChoicesPlacement(NativeAdOptions.ADCHOICES_TOP_RIGHT)
-                    .build()
-            )
-            .withAdListener(object : AdListener() {
-                override fun onAdFailedToLoad(adError: LoadAdError) {
-                    view.isVisible = false
-                }
-            })
-            .build()
+        val adRequest: NativeAdRequest = NativeAdRequest.Builder(
+            adUnitId,
+            listOf(NativeAd.NativeAdType.NATIVE)
+        ).build()
 
         view.isVisible = false
-        adLoader.loadAd(adRequest)
+        NativeAdLoader.load(
+            adRequest,
+            object : NativeAdLoaderCallback {
+                override fun onNativeAdLoaded(nativeAd: NativeAd) {
+                    mainHandler.post {
+                        currentNativeAd?.destroy()
+                        currentNativeAd = nativeAd
+                        bindHelpNativeAd(adView = view, nativeAd = nativeAd)
+                        view.isVisible = true
+                    }
+                }
+
+                override fun onAdFailedToLoad(adError: LoadAdError) {
+                    mainHandler.post { view.isVisible = false }
+                }
+            }
+        )
     }
 }
 
@@ -264,5 +265,5 @@ private fun bindHelpNativeAd(adView: NativeAdView, nativeAd: NativeAd) {
         callToActionView.isVisible = true
     }
 
-    adView.setNativeAd(nativeAd)
+    adView.registerNativeAd(nativeAd, null)
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/ads/NativeAdViewHost.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/ads/NativeAdViewHost.kt
@@ -22,7 +22,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.UiComposable
 import androidx.compose.ui.viewinterop.AndroidView
-import com.google.android.gms.ads.nativead.NativeAdView
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdView
 
 /**
  * A small helper to inflate and remember a [NativeAdView] inside Compose.

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/ads/NoDataNativeAdCard.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/ads/NoDataNativeAdCard.kt
@@ -18,6 +18,8 @@
 package com.d4rk.android.libs.apptoolkit.core.ui.views.ads
 
 import android.annotation.SuppressLint
+import android.os.Handler
+import android.os.Looper
 import android.widget.Button
 import android.widget.ImageView
 import android.widget.TextView
@@ -36,19 +38,17 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.core.view.isVisible
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
-import com.google.android.gms.ads.AdListener
-import com.google.android.gms.ads.AdLoader
-import com.google.android.gms.ads.AdRequest
-import com.google.android.gms.ads.LoadAdError
-import com.google.android.gms.ads.nativead.MediaView
-import com.google.android.gms.ads.nativead.NativeAd
-import com.google.android.gms.ads.nativead.NativeAdOptions
-import com.google.android.gms.ads.nativead.NativeAdView
+import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
+import com.google.android.libraries.ads.mobile.sdk.nativead.MediaView
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAd
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoader
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoaderCallback
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdRequest
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdView
 
 /**
  * A Composable that displays a native ad in a card format, specifically designed for "no data" or empty states.
@@ -73,14 +73,13 @@ fun NoDataNativeAdCard(
     modifier: Modifier = Modifier,
     adUnitId: String
 ) {
-    val context = LocalContext.current
     val inspectionMode = LocalInspectionMode.current
     val showAds: Boolean = rememberAdsEnabled()
 
     if (inspectionMode) return
     if (!showAds || adUnitId.isBlank()) return
 
-    val adRequest: AdRequest = remember { AdRequest.Builder().build() }
+    val mainHandler: Handler = remember { Handler(Looper.getMainLooper()) }
 
     var nativeAdView by remember { mutableStateOf<NativeAdView?>(null) }
     var currentNativeAd by remember { mutableStateOf<NativeAd?>(null) }
@@ -110,36 +109,37 @@ fun NoDataNativeAdCard(
         )
     }
 
-    LaunchedEffect(nativeAdView, adUnitId, adRequest) {
+    LaunchedEffect(nativeAdView, adUnitId) {
         val view: NativeAdView = nativeAdView ?: return@LaunchedEffect
 
-        val adLoader: AdLoader = AdLoader.Builder(context, adUnitId)
-            .forNativeAd { nativeAd ->
-                currentNativeAd?.destroy()
-                currentNativeAd = nativeAd
-                bindNoDataNativeAd(adView = view, nativeAd = nativeAd)
-                view.isVisible = true
-            }
-            .withNativeAdOptions(
-                NativeAdOptions.Builder()
-                    .setAdChoicesPlacement(NativeAdOptions.ADCHOICES_TOP_RIGHT)
-                    .build()
-            )
-            .withAdListener(object : AdListener() {
-                override fun onAdFailedToLoad(adError: LoadAdError) {
-                    view.isVisible = false
-                }
-            })
-            .build()
+        val adRequest: NativeAdRequest = NativeAdRequest.Builder(
+            adUnitId,
+            listOf(NativeAd.NativeAdType.NATIVE)
+        ).build()
 
         view.isVisible = false
-        adLoader.loadAd(adRequest)
+        NativeAdLoader.load(
+            adRequest,
+            object : NativeAdLoaderCallback {
+                override fun onNativeAdLoaded(nativeAd: NativeAd) {
+                    mainHandler.post {
+                        currentNativeAd?.destroy()
+                        currentNativeAd = nativeAd
+                        bindNoDataNativeAd(adView = view, nativeAd = nativeAd)
+                        view.isVisible = true
+                    }
+                }
+
+                override fun onAdFailedToLoad(adError: LoadAdError) {
+                    mainHandler.post { view.isVisible = false }
+                }
+            }
+        )
     }
 }
 
 private fun bindNoDataNativeAd(adView: NativeAdView, nativeAd: NativeAd) {
     val mediaView: MediaView = adView.findViewById(R.id.native_ad_media)
-    adView.mediaView = mediaView
     val mediaContent = nativeAd.mediaContent
     if (mediaContent == null) {
         mediaView.isVisible = false
@@ -192,5 +192,5 @@ private fun bindNoDataNativeAd(adView: NativeAdView, nativeAd: NativeAd) {
         callToActionView.isVisible = true
     }
 
-    adView.setNativeAd(nativeAd)
+    adView.registerNativeAd(nativeAd, mediaView)
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/ads/SupportNativeAdCard.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/ads/SupportNativeAdCard.kt
@@ -18,6 +18,8 @@
 package com.d4rk.android.libs.apptoolkit.core.ui.views.ads
 
 import android.annotation.SuppressLint
+import android.os.Handler
+import android.os.Looper
 import android.view.LayoutInflater
 import android.widget.Button
 import android.widget.ImageView
@@ -34,7 +36,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.core.view.isVisible
@@ -43,14 +44,13 @@ import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.core.data.local.datastore.CommonDataStore
 import com.d4rk.android.libs.apptoolkit.core.data.local.datastore.rememberCommonDataStore
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
-import com.google.android.gms.ads.AdListener
-import com.google.android.gms.ads.AdLoader
-import com.google.android.gms.ads.AdRequest
-import com.google.android.gms.ads.LoadAdError
-import com.google.android.gms.ads.nativead.MediaView
-import com.google.android.gms.ads.nativead.NativeAd
-import com.google.android.gms.ads.nativead.NativeAdOptions
-import com.google.android.gms.ads.nativead.NativeAdView
+import com.google.android.libraries.ads.mobile.sdk.common.LoadAdError
+import com.google.android.libraries.ads.mobile.sdk.nativead.MediaView
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAd
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoader
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoaderCallback
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdRequest
+import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdView
 
 /**
  * A Composable that displays a native ad from Google AdMob within a card.
@@ -79,8 +79,6 @@ fun SupportNativeAdCard(
     modifier: Modifier = Modifier,
     adUnitId: String,
 ) {
-    val context = LocalContext.current
-    val appContext = remember(context) { context.applicationContext }
     val inspectionMode = LocalInspectionMode.current
 
     val dataStore: CommonDataStore = rememberCommonDataStore()
@@ -89,7 +87,7 @@ fun SupportNativeAdCard(
     if (inspectionMode) return
     if (!showAds || adUnitId.isBlank()) return
 
-    val adRequest: AdRequest = remember { AdRequest.Builder().build() }
+    val mainHandler: Handler = remember { Handler(Looper.getMainLooper()) }
 
     var nativeAdView by remember { mutableStateOf<NativeAdView?>(null) }
     var currentNativeAd by remember { mutableStateOf<NativeAd?>(null) }
@@ -121,34 +119,34 @@ fun SupportNativeAdCard(
     LaunchedEffect(nativeAdView, adUnitId) {
         val view: NativeAdView = nativeAdView ?: return@LaunchedEffect
 
-        val adLoader: AdLoader = AdLoader.Builder(appContext, adUnitId)
-            .forNativeAd { nativeAd ->
-                currentNativeAd?.destroy()
-                currentNativeAd = nativeAd
-
-                bindSupportNativeAd(adView = view, nativeAd = nativeAd)
-                view.isVisible = true
-            }
-            .withNativeAdOptions(
-                NativeAdOptions.Builder()
-                    .setAdChoicesPlacement(NativeAdOptions.ADCHOICES_TOP_RIGHT)
-                    .build()
-            )
-            .withAdListener(object : AdListener() {
-                override fun onAdFailedToLoad(adError: LoadAdError) {
-                    view.isVisible = false
-                }
-            })
-            .build()
+        val adRequest: NativeAdRequest = NativeAdRequest.Builder(
+            adUnitId,
+            listOf(NativeAd.NativeAdType.NATIVE)
+        ).build()
 
         view.isVisible = false
-        adLoader.loadAd(adRequest)
+        NativeAdLoader.load(
+            adRequest,
+            object : NativeAdLoaderCallback {
+                override fun onNativeAdLoaded(nativeAd: NativeAd) {
+                    mainHandler.post {
+                        currentNativeAd?.destroy()
+                        currentNativeAd = nativeAd
+                        bindSupportNativeAd(adView = view, nativeAd = nativeAd)
+                        view.isVisible = true
+                    }
+                }
+
+                override fun onAdFailedToLoad(adError: LoadAdError) {
+                    mainHandler.post { view.isVisible = false }
+                }
+            }
+        )
     }
 }
 
 private fun bindSupportNativeAd(adView: NativeAdView, nativeAd: NativeAd) {
     val mediaView: MediaView = adView.findViewById(R.id.native_ad_media)
-    adView.mediaView = mediaView
     val mediaContent = nativeAd.mediaContent
     if (mediaContent == null) {
         mediaView.isVisible = false
@@ -201,5 +199,5 @@ private fun bindSupportNativeAd(adView: NativeAdView, nativeAd: NativeAd) {
         callToActionView.isVisible = true
     }
 
-    adView.setNativeAd(nativeAd)
+    adView.registerNativeAd(nativeAd, mediaView)
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/theme/ThemePalettePager.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/theme/ThemePalettePager.kt
@@ -31,7 +31,7 @@ import androidx.compose.ui.Modifier
 @Composable
 fun ThemePalettePager(
     pagerState: PagerState,
-    pages: List<@Composable () -> Unit>,
+    pages: List<@Composable () -> Unit>, // FIXME: Parameter 'pages' has runtime-determined stability
     modifier: Modifier = Modifier,
 ) {
     HorizontalPager(

--- a/apptoolkit/src/main/res/layout/native_ad_app_details.xml
+++ b/apptoolkit/src/main/res/layout/native_ad_app_details.xml
@@ -15,7 +15,7 @@
   ~ along with this program. If not, see <https://www.gnu.org/licenses/>.
   -->
 
-<com.google.android.gms.ads.nativead.NativeAdView xmlns:android="http://schemas.android.com/apk/res/android"
+<com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -119,4 +119,4 @@
                 tools:text="Open" />
         </LinearLayout>
     </LinearLayout>
-</com.google.android.gms.ads.nativead.NativeAdView>
+</com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdView>

--- a/apptoolkit/src/main/res/layout/native_ad_apps_list_card.xml
+++ b/apptoolkit/src/main/res/layout/native_ad_apps_list_card.xml
@@ -15,7 +15,7 @@
   ~ along with this program. If not, see <https://www.gnu.org/licenses/>.
   -->
 
-<com.google.android.gms.ads.nativead.NativeAdView xmlns:android="http://schemas.android.com/apk/res/android"
+<com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -106,4 +106,4 @@
             app:layout_constraintTop_toBottomOf="@id/native_ad_advertiser"
             tools:text="Discover tools that keep you productive every day." />
     </androidx.constraintlayout.widget.ConstraintLayout>
-</com.google.android.gms.ads.nativead.NativeAdView>
+</com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdView>

--- a/apptoolkit/src/main/res/layout/native_ad_bottom_bar.xml
+++ b/apptoolkit/src/main/res/layout/native_ad_bottom_bar.xml
@@ -15,7 +15,7 @@
   ~ along with this program. If not, see <https://www.gnu.org/licenses/>.
   -->
 
-<com.google.android.gms.ads.nativead.NativeAdView xmlns:android="http://schemas.android.com/apk/res/android"
+<com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content">
@@ -106,4 +106,4 @@
                 android:textAllCaps="false" />
         </LinearLayout>
     </LinearLayout>
-</com.google.android.gms.ads.nativead.NativeAdView>
+</com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdView>

--- a/apptoolkit/src/main/res/layout/native_ad_help_card.xml
+++ b/apptoolkit/src/main/res/layout/native_ad_help_card.xml
@@ -15,7 +15,7 @@
   ~ along with this program. If not, see <https://www.gnu.org/licenses/>.
   -->
 
-<com.google.android.gms.ads.nativead.NativeAdView xmlns:android="http://schemas.android.com/apk/res/android"
+<com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -135,4 +135,4 @@
             tools:text="Install" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
-</com.google.android.gms.ads.nativead.NativeAdView>
+</com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdView>

--- a/apptoolkit/src/main/res/layout/native_ad_no_data_card.xml
+++ b/apptoolkit/src/main/res/layout/native_ad_no_data_card.xml
@@ -15,7 +15,7 @@
   ~ along with this program. If not, see <https://www.gnu.org/licenses/>.
   -->
 
-<com.google.android.gms.ads.nativead.NativeAdView xmlns:android="http://schemas.android.com/apk/res/android"
+<com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -43,7 +43,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <com.google.android.gms.ads.nativead.MediaView
+        <com.google.android.libraries.ads.mobile.sdk.nativead.MediaView
             android:id="@+id/native_ad_media"
             android:layout_width="0dp"
             android:layout_height="0dp"
@@ -138,4 +138,4 @@
             tools:text="Install" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
-</com.google.android.gms.ads.nativead.NativeAdView>
+</com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdView>

--- a/apptoolkit/src/main/res/layout/native_ad_support_card.xml
+++ b/apptoolkit/src/main/res/layout/native_ad_support_card.xml
@@ -15,7 +15,7 @@
   ~ along with this program. If not, see <https://www.gnu.org/licenses/>.
   -->
 
-<com.google.android.gms.ads.nativead.NativeAdView xmlns:android="http://schemas.android.com/apk/res/android"
+<com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
@@ -43,7 +43,7 @@
             app:layout_constraintStart_toStartOf="parent"
             app:layout_constraintTop_toTopOf="parent" />
 
-        <com.google.android.gms.ads.nativead.MediaView
+        <com.google.android.libraries.ads.mobile.sdk.nativead.MediaView
             android:id="@+id/native_ad_media"
             android:layout_width="0dp"
             android:layout_height="0dp"
@@ -138,4 +138,4 @@
             tools:text="Install" />
 
     </androidx.constraintlayout.widget.ConstraintLayout>
-</com.google.android.gms.ads.nativead.NativeAdView>
+</com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdView>

--- a/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/data/core/ads/TestAdsCoreManager.kt
+++ b/apptoolkit/src/test/kotlin/com/d4rk/android/libs/apptoolkit/data/core/ads/TestAdsCoreManager.kt
@@ -24,9 +24,10 @@ import com.d4rk.android.libs.apptoolkit.core.data.local.datastore.CommonDataStor
 import com.d4rk.android.libs.apptoolkit.core.data.remote.ads.AdsCoreManager
 import com.d4rk.android.libs.apptoolkit.core.di.TestDispatchers
 import com.d4rk.android.libs.apptoolkit.core.utils.interfaces.OnShowAdCompleteListener
-import com.google.android.gms.ads.FullScreenContentCallback
-import com.google.android.gms.ads.MobileAds
-import com.google.android.gms.ads.appopen.AppOpenAd
+import com.google.android.libraries.ads.mobile.sdk.MobileAds
+import com.google.android.libraries.ads.mobile.sdk.appopen.AppOpenAd
+import com.google.android.libraries.ads.mobile.sdk.appopen.AppOpenAdEventCallback
+import com.google.android.libraries.ads.mobile.sdk.common.AdLoadCallback
 import io.mockk.every
 import io.mockk.justRun
 import io.mockk.mockk
@@ -69,10 +70,10 @@ class TestAdsCoreManager {
         storeField.set(manager, dataStore)
 
         mockkStatic(MobileAds::class)
-        justRun { MobileAds.initialize(context) }
+        justRun { MobileAds.initialize(context, any(), any()) }
 
         runBlocking { manager.initializeAds("id") }
-        verify { MobileAds.initialize(context) }
+        verify { MobileAds.initialize(context, any(), any()) }
         println("🏁 [TEST DONE] initializeAds triggers MobileAds")
     }
 
@@ -116,7 +117,7 @@ class TestAdsCoreManager {
             isAccessible = true
             invoke(inner, context)
         }
-        verify(exactly = 0) { AppOpenAd.load(any(), any(), any(), any()) }
+        verify(exactly = 0) { AppOpenAd.load(any(), any()) }
 
         loadingField.setBoolean(inner, false)
         val adField = inner.javaClass.getDeclaredField("appOpenAd")
@@ -130,7 +131,7 @@ class TestAdsCoreManager {
             isAccessible = true
             invoke(inner, context)
         }
-        verify(exactly = 0) { AppOpenAd.load(any(), any(), any(), any()) }
+        verify(exactly = 0) { AppOpenAd.load(any(), any()) }
         println("🏁 [TEST DONE] loadAd does not load when already loading or available")
     }
 
@@ -149,7 +150,7 @@ class TestAdsCoreManager {
         runBlocking { manager.initializeAds("unit") }
 
         mockkStatic(AppOpenAd::class)
-        justRun { AppOpenAd.load(any(), any(), any(), any()) }
+        justRun { AppOpenAd.load(any(), any()) }
 
         var completed = false
         val mgrField2 = AdsCoreManager::class.java.getDeclaredField("appOpenAdManager")
@@ -170,7 +171,7 @@ class TestAdsCoreManager {
         method.invoke(inner2, mockk<Activity>(), listener, noopContinuation)
 
         assert(completed)
-        verify { AppOpenAd.load(any(), any(), any(), any()) }
+        verify { AppOpenAd.load(any(), any()) }
         println("🏁 [TEST DONE] showAdIfAvailable loads when no ad")
     }
 
@@ -197,10 +198,10 @@ class TestAdsCoreManager {
         adField.set(inner3, ad)
 
         mockkStatic(AppOpenAd::class)
-        justRun { AppOpenAd.load(any(), any(), any(), any()) }
+        justRun { AppOpenAd.load(any(), any()) }
 
-        val slot = slot<FullScreenContentCallback>()
-        every { ad.fullScreenContentCallback = capture(slot) } returns Unit
+        val slot = slot<AppOpenAdEventCallback>()
+        every { ad.adEventCallback = capture(slot) } returns Unit
 
         val method2 = inner3.javaClass.getDeclaredMethod(
             "showAdIfAvailable",
@@ -218,7 +219,7 @@ class TestAdsCoreManager {
         val showField = inner3.javaClass.getDeclaredField("isShowingAd")
         showField.isAccessible = true
         assertFalse(showField.getBoolean(inner3))
-        verify { AppOpenAd.load(any(), any(), any(), any()) }
+        verify { AppOpenAd.load(any(), any()) }
         println("🏁 [TEST DONE] callback dismiss reloads ad")
     }
 
@@ -237,12 +238,12 @@ class TestAdsCoreManager {
         runBlocking { manager.initializeAds("unit") }
 
         mockkStatic(AppOpenAd::class)
-        justRun { AppOpenAd.load(any(), any(), any(), any()) }
+        justRun { AppOpenAd.load(any(), any()) }
 
         val activity = mockk<Activity>()
         manager.showAdIfAvailable(activity, testScope)
 
-        verify(exactly = 0) { AppOpenAd.load(any(), any(), any(), any()) }
+        verify(exactly = 0) { AppOpenAd.load(any(), any()) }
         println("🏁 [TEST DONE] ads disabled skips load and show")
     }
 
@@ -265,9 +266,9 @@ class TestAdsCoreManager {
         val inner = mgrField.get(manager)!!
 
         mockkStatic(AppOpenAd::class)
-        val slot = slot<AppOpenAd.AppOpenAdLoadCallback>()
+        val slot = slot<AdLoadCallback<AppOpenAd>>()
         every {
-            AppOpenAd.load(any(), any(), any(), capture(slot))
+            AppOpenAd.load(any(), capture(slot))
         } answers {
             slot.captured.onAdFailedToLoad(mockk())
         }
@@ -305,7 +306,7 @@ class TestAdsCoreManager {
         showingField.setBoolean(inner, true)
 
         mockkStatic(AppOpenAd::class)
-        justRun { AppOpenAd.load(any(), any(), any(), any()) }
+        justRun { AppOpenAd.load(any(), any()) }
 
         val method = inner.javaClass.getDeclaredMethod(
             "showAdIfAvailable",
@@ -316,7 +317,7 @@ class TestAdsCoreManager {
         method.isAccessible = true
         method.invoke(inner, mockk<Activity>(), mockk<OnShowAdCompleteListener>(), noopContinuation)
 
-        verify(exactly = 0) { AppOpenAd.load(any(), any(), any(), any()) }
+        verify(exactly = 0) { AppOpenAd.load(any(), any()) }
         println("🏁 [TEST DONE] showAdIfAvailable ignores when already showing")
     }
 
@@ -339,8 +340,8 @@ class TestAdsCoreManager {
         val inner = mgrField.get(manager)!!
 
         mockkStatic(AppOpenAd::class)
-        val slot = slot<AppOpenAd.AppOpenAdLoadCallback>()
-        every { AppOpenAd.load(any(), any(), any(), capture(slot)) } answers {}
+        val slot = slot<AdLoadCallback<AppOpenAd>>()
+        every { AppOpenAd.load(any(), capture(slot)) } answers {}
 
         inner.javaClass.getDeclaredMethod("loadAd", Context::class.java).apply {
             isAccessible = true
@@ -351,7 +352,7 @@ class TestAdsCoreManager {
             invoke(inner, context)
         }
 
-        verify(exactly = 1) { AppOpenAd.load(any(), any(), any(), any()) }
+        verify(exactly = 1) { AppOpenAd.load(any(), any()) }
 
         slot.captured.onAdLoaded(mockk())
 
@@ -360,7 +361,7 @@ class TestAdsCoreManager {
             invoke(inner, context)
         }
 
-        verify(exactly = 2) { AppOpenAd.load(any(), any(), any(), any()) }
+        verify(exactly = 2) { AppOpenAd.load(any(), any()) }
         println("🏁 [TEST DONE] concurrent load requests chain correctly")
     }
 
@@ -383,7 +384,7 @@ class TestAdsCoreManager {
         val inner = mgrField.get(manager)!!
 
         mockkStatic(AppOpenAd::class)
-        every { AppOpenAd.load(any(), any(), any(), any()) } throws RuntimeException("fail")
+        every { AppOpenAd.load(any(), any()) } throws RuntimeException("fail")
 
         val method = inner.javaClass.getDeclaredMethod("loadAd", Context::class.java)
         method.isAccessible = true
@@ -413,12 +414,12 @@ class TestAdsCoreManager {
         runBlocking { manager.initializeAds("unit") }
 
         mockkStatic(AppOpenAd::class)
-        justRun { AppOpenAd.load(any(), any(), any(), any()) }
+        justRun { AppOpenAd.load(any(), any()) }
 
         manager.showAdIfAvailable(mockk(), testScope)
 
         assert(!slot.captured)
-        verify(exactly = 0) { AppOpenAd.load(any(), any(), any(), any()) }
+        verify(exactly = 0) { AppOpenAd.load(any(), any()) }
         println("🏁 [TEST DONE] ads disabled by default when debug build")
     }
 
@@ -439,12 +440,12 @@ class TestAdsCoreManager {
         runBlocking { manager.initializeAds("unit") }
 
         mockkStatic(AppOpenAd::class)
-        justRun { AppOpenAd.load(any(), any(), any(), any()) }
+        justRun { AppOpenAd.load(any(), any()) }
 
         manager.showAdIfAvailable(mockk(), testScope)
 
         assert(slot.captured)
-        verify { AppOpenAd.load(any(), any(), any(), any()) }
+        verify { AppOpenAd.load(any(), any()) }
         println("🏁 [TEST DONE] ads enabled by default when release build")
     }
 

--- a/docs/apptoolkit/ads/gma-next-gen-sdk-migration-notes.md
+++ b/docs/apptoolkit/ads/gma-next-gen-sdk-migration-notes.md
@@ -1,0 +1,72 @@
+# GMA Next-Gen SDK for Android (Beta) — Migration Notes
+
+## Why migrate
+
+Upgrading from `com.google.android.gms:play-services-ads` to GMA Next-Gen SDK can provide:
+
+- Faster banner ad request latency (Google reports up to 27% in an internal comparison).
+- Lower SDK footprint on device.
+- Background-oriented startup behavior to reduce startup impact.
+- Better stability by removing RPC/process-boundary communication patterns.
+- Kotlin-first API surface with Java support.
+- Support for all existing Google Mobile Ads formats.
+
+> Reference date from Google docs used for these notes: **January 10, 2025**.
+
+---
+
+## Core migration checklist
+
+1. Replace dependency:
+   - Remove: `com.google.android.gms:play-services-ads`
+   - Add: `com.google.android.libraries.ads.mobile.sdk:ads-mobile-sdk`
+2. If mediation adapters are present, globally exclude:
+   - `com.google.android.gms:play-services-ads`
+   - `com.google.android.gms:play-services-ads-lite`
+3. Verify SDK levels:
+   - `minSdk >= 24`
+   - `compileSdk >= 34` (or higher if required by current guidance)
+4. Keep `com.google.android.gms.ads.APPLICATION_ID` in manifest for UMP compatibility.
+5. Initialize `MobileAds` before loading any ad or calling most SDK APIs.
+6. Pass AdMob App ID via `InitializationConfig.Builder("<APP_ID>")`.
+7. Move UI work in ad callbacks onto main/UI thread (`runOnUiThread` / `Dispatchers.Main`).
+
+---
+
+## API pattern changes to apply across the codebase
+
+### Initialization
+
+- **Old:** `MobileAds.initialize(context) {}`
+- **Next-Gen:** `MobileAds.initialize(context, InitializationConfig.Builder(APP_ID).build()) {}`
+
+### Ad request construction
+
+- Ad unit ID moves into request builders.
+- Interstitial/rewarded/app open load methods no longer take context + adUnit in the old style.
+
+### Banner
+
+- Prefer Next-Gen `banner.AdView`.
+- Use `BannerAdRequest.Builder(adUnitId, adSize)`.
+- Event callbacks are format-specific (for example `BannerAdEventCallback`).
+
+### Native
+
+- Load with `NativeAdLoader.load(NativeAdRequest, NativeAdLoaderCallback)`.
+- Register the native ad with media content using `NativeAdView.registerNativeAd(...)`.
+
+### Threading
+
+- Next-Gen callbacks are not guaranteed on main thread.
+- Any UI updates inside callbacks must explicitly switch to the UI thread.
+
+---
+
+## Validation checklist before considering migration complete
+
+- Project builds cleanly.
+- No remaining imports from `com.google.android.gms.ads.*` in migrated files.
+- `MobileAds.initialize(...)` occurs before ad loads and before non-exempt API access.
+- Ad callbacks that touch UI are thread-safe (main thread dispatch).
+- Banner/native/interstitial/rewarded flows compile and run.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,7 +24,7 @@ googleMaterial = "1.13.0"
 googlePlayInAppReview = "2.0.2"
 googlePlayInAppUpdate = "2.1.0"
 googlePlayIntegrity = "1.6.0"
-googlePlayServicesAds = "25.1.0"
+googleAdsMobileSdk = "0.24.0-beta03"
 googleUserMessagingPlatform = "4.0.0"
 firebaseBom = "34.11.0"
 firebaseCrashlyticsPlugin = "3.0.6"
@@ -102,7 +102,7 @@ android-billing = { module = "com.android.billingclient:billing", version.ref = 
 google-accompanist-drawablepainter = { module = "com.google.accompanist:accompanist-drawablepainter", version.ref = "googleAccompanistDrawablePainter" }
 google-guava = { module = "com.google.guava:guava", version.ref = "googleGuava" }
 google-material = { module = "com.google.android.material:material", version.ref = "googleMaterial" }
-google-play-services-ads = { module = "com.google.android.gms:play-services-ads", version.ref = "googlePlayServicesAds" }
+google-ads-mobile-sdk = { module = "com.google.android.libraries.ads.mobile.sdk:ads-mobile-sdk", version.ref = "googleAdsMobileSdk" }
 google-user-messaging-platform = { module = "com.google.android.ump:user-messaging-platform", version.ref = "googleUserMessagingPlatform" }
 google-play-app-update-ktx = { module = "com.google.android.play:app-update-ktx", version.ref = "googlePlayInAppUpdate" }
 google-play-integrity = { module = "com.google.android.play:integrity", version.ref = "googlePlayIntegrity" }
@@ -222,7 +222,7 @@ google = [
     "google-accompanist-drawablepainter",
     "google-guava",
     "google-material",
-    "google-play-services-ads",
+    "google-ads-mobile-sdk",
     "google-user-messaging-platform",
 ]
 


### PR DESCRIPTION
### Motivation
- Replace legacy `com.google.android.gms:play-services-ads` usage with the GMA Next‑Gen SDK to adopt the new Kotlin-first APIs and reduced SDK footprint. 
- Update ad initialization and request patterns to the Next‑Gen API surface and ensure UI thread safety for ad callbacks. 
- Prepare project dependency and build rules to exclude the old Play Services ads artifacts and document migration notes. 

### Description
- Replaced imports and APIs across the app and library modules to use `com.google.android.libraries.ads.mobile.sdk` (banner, native, appopen, MobileAds, request builders, callbacks). 
- Updated initialization to `MobileAds.initialize(context, InitializationConfig.Builder(APP_ID).build()) {}` and pass the AdMob App ID from `R.string.ad_mob_app_id`. 
- Adapted banner and app open loads to the new request/loader signatures (e.g. `BannerAdRequest.Builder(adUnitId, adSize)`, `NativeAdLoader.load(NativeAdRequest, NativeAdLoaderCallback)`, `AppOpenAd.load(...)`) and replaced old callbacks with the Next‑Gen callback types; registered native ads via `NativeAdView.registerNativeAd(...)`. 
- Ensured UI updates in ad callbacks run on the main thread by posting via `Handler(Looper.getMainLooper())`. 
- Updated XML `NativeAdView` and `MediaView` namespaces to the new SDK. 
- Adjusted Gradle configuration and `libs.versions.toml` to use `ads-mobile-sdk`, globally exclude old `play-services-ads` modules, and added `gma-next-gen` migration notes under `docs/`. 
- Updated unit tests to match new API shapes (notably `TestAdsCoreManager`), and adapted mocks/verifications for the Next‑Gen signatures. 

### Testing
- Ran the unit test suite via `./gradlew test`, including the updated `TestAdsCoreManager`, and all tests completed successfully. 
- Verified the project builds after dependency and API changes with `./gradlew assemble` during the migration; build succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c1a0053350832d8a21bc443351f226)