### PR TITLE
Make navigation keys Parcelable and persist NavBackStack with `rememberSaveable`

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,6 +21,7 @@ import java.util.Properties
 plugins {
     alias(notation = libs.plugins.android.application)
     alias(notation = libs.plugins.kotlin.compose)
+    alias(notation = libs.plugins.kotlin.parcelize)
     alias(notation = libs.plugins.kotlin.serialization)
     alias(notation = libs.plugins.google.mobile.services) apply false
     alias(notation = libs.plugins.firebase.crashlytics) apply false

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/utils/constants/NavigationRoutes.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/utils/constants/NavigationRoutes.kt
@@ -21,19 +21,18 @@ import androidx.compose.runtime.Immutable
 import com.d4rk.android.libs.apptoolkit.core.ui.model.navigation.StableNavKey
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentSetOf
-import kotlinx.serialization.Serializable
+import kotlinx.parcelize.Parcelize
 
 @Immutable
-@Serializable
 sealed interface AppNavKey : StableNavKey
 
-@Serializable
+@Parcelize
 data object AppsListRoute : AppNavKey
 
-@Serializable
+@Parcelize
 data object FavoriteAppsRoute : AppNavKey
 
-@Serializable
+@Parcelize
 data object ComponentsRoute : AppNavKey
 
 object NavigationRoutes {

--- a/apptoolkit/build.gradle.kts
+++ b/apptoolkit/build.gradle.kts
@@ -27,6 +27,7 @@ version = publishingVersion.get()
 plugins {
     alias(notation = libs.plugins.android.library)
     alias(notation = libs.plugins.kotlin.compose)
+    alias(notation = libs.plugins.kotlin.parcelize)
     alias(notation = libs.plugins.kotlin.serialization)
     alias(notation = libs.plugins.about.libraries)
     alias(notation = libs.plugins.mannodermaus.android.junit5)

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/model/navigation/StableNavKey.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/model/navigation/StableNavKey.kt
@@ -17,6 +17,7 @@
 
 package com.d4rk.android.libs.apptoolkit.core.ui.model.navigation
 
+import android.os.Parcelable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.Stable
 import androidx.navigation3.runtime.NavKey
@@ -29,4 +30,4 @@ import androidx.navigation3.runtime.NavKey
  */
 @Immutable
 @Stable
-interface StableNavKey : NavKey
+interface StableNavKey : NavKey, Parcelable

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/navigation/NavigationState.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/navigation/NavigationState.kt
@@ -87,7 +87,7 @@ fun <T : StableNavKey> rememberTypedNavBackStack(
     return rememberSaveable(
         saver = navBackStackSaver()
     ) {
-        NavBackStack(*initialElements.toTypedArray())
+        buildNavBackStack(initialElements)
     }
 }
 
@@ -97,8 +97,13 @@ fun <T : StableNavKey> rememberTypedNavBackStack(
 private fun <T : StableNavKey> navBackStackSaver(): Saver<NavBackStack<T>, List<T>> =
     Saver(
         save = { backStack -> backStack.toList() },
-        restore = { savedRoutes -> NavBackStack(*savedRoutes.toTypedArray()) }
+        restore = { savedRoutes -> buildNavBackStack(savedRoutes) }
     )
+
+private fun <T : StableNavKey> buildNavBackStack(routes: List<T>): NavBackStack<T> =
+    NavBackStack<T>().apply {
+        routes.forEach(::add)
+    }
 
 @Stable
 class NavigationState<T : StableNavKey>(

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/navigation/NavigationState.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/navigation/NavigationState.kt
@@ -24,20 +24,18 @@ import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.saveable.Saver
 import androidx.compose.runtime.rememberUpdatedState
-import androidx.compose.runtime.saveable.rememberSerializable
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.lifecycle.viewmodel.navigation3.rememberViewModelStoreNavEntryDecorator
 import androidx.navigation3.runtime.NavBackStack
 import androidx.navigation3.runtime.NavEntryDecorator
 import androidx.navigation3.runtime.rememberSaveableStateHolderNavEntryDecorator
-import androidx.navigation3.runtime.serialization.NavBackStackSerializer
-import androidx.savedstate.compose.serialization.serializers.MutableStateSerializer
 import com.d4rk.android.libs.apptoolkit.core.ui.model.navigation.StableNavKey
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.persistentListOf
-import kotlinx.serialization.serializer
 
 /**
  * Remembers navigation state for a set of top-level destinations.
@@ -45,15 +43,14 @@ import kotlinx.serialization.serializer
  * Generic + type-safe: keeps your NavBackStack typed as T instead of collapsing to NavKey.
  */
 @Composable
-inline fun <reified T : StableNavKey> rememberNavigationState(
+fun <T : StableNavKey> rememberNavigationState(
     startRoute: T,
     topLevelRoutes: ImmutableSet<T>,
 ): NavigationState<T> {
     val stableStartRoute by rememberUpdatedState(newValue = startRoute)
-    val topLevelRouteState: MutableState<T> = rememberSerializable(
+    val topLevelRouteState: MutableState<T> = rememberSaveable(
         stableStartRoute,
-        topLevelRoutes,
-        serializer = MutableStateSerializer(serializer<T>())
+        topLevelRoutes
     ) {
         mutableStateOf(stableStartRoute)
     }
@@ -76,23 +73,32 @@ inline fun <reified T : StableNavKey> rememberNavigationState(
 /**
  * Remembers a type-safe [NavBackStack] that is preserved across process death and configuration changes.
  *
- * This function uses [rememberSerializable] to persist the back stack, ensuring that the
- * navigation history of type [T] is restored correctly.
+ * This function uses [rememberSaveable] with Parcelable route keys to persist the back stack,
+ * ensuring that navigation history of type [T] is restored correctly without JSON serialization.
  *
  * @param T The type of the navigation keys, which must implement [StableNavKey].
  * @param initialElements The initial list of destinations to populate the back stack with.
  * @return A [NavBackStack] instance initialized with the provided elements.
  */
 @Composable
-inline fun <reified T : StableNavKey> rememberTypedNavBackStack(
+fun <T : StableNavKey> rememberTypedNavBackStack(
     initialElements: ImmutableList<T> = persistentListOf(),
 ): NavBackStack<T> {
-    return rememberSerializable(
-        serializer = NavBackStackSerializer(elementSerializer = serializer<T>())
+    return rememberSaveable(
+        saver = navBackStackSaver()
     ) {
         NavBackStack(*initialElements.toTypedArray())
     }
 }
+
+/**
+ * Saves and restores [NavBackStack] using Bundle-compatible Parcelable route keys.
+ */
+private fun <T : StableNavKey> navBackStackSaver(): Saver<NavBackStack<T>, List<T>> =
+    Saver(
+        save = { backStack -> backStack.toList() },
+        restore = { savedRoutes -> NavBackStack(*savedRoutes.toTypedArray()) }
+    )
 
 @Stable
 class NavigationState<T : StableNavKey>(

--- a/docs/apptoolkit/screens/main/main.md
+++ b/docs/apptoolkit/screens/main/main.md
@@ -24,6 +24,8 @@ still giving host apps a ready-to-go default shell that can be customized or rep
 ### Navigation behavior helpers
 - **`handleNavigationItemClick(...)`**: default drawer click handling for common routes:
   Settings, Help & Feedback, Updates (changelog), Share with support for host overrides.
+- Navigation key/state serialization guidance: see
+  [`docs/general/core/serialization-boundaries.md`](../../../general/core/serialization-boundaries.md).
 
 ### App update & GMS host abstractions
 - **In-app update flow** (Play Core):

--- a/docs/general/core/serialization-boundaries.md
+++ b/docs/general/core/serialization-boundaries.md
@@ -1,0 +1,28 @@
+# Serialization Boundaries
+
+## Purpose
+
+Define which serialization strategy is allowed at each layer to keep performance, architecture
+boundaries, and maintainability aligned.
+
+## Rules
+
+- **Data/remote layer DTOs must use `kotlinx.serialization` (`@Serializable`)** for HTTP/JSON
+  payloads.
+- **Android UI state transport must use `Parcelable` (`@Parcelize`)** for Bundle-compatible
+  persistence (for example `rememberSaveable`, SavedState, and navigation keys).
+- Do not annotate domain models with `@Parcelize` unless the domain type itself is explicitly a UI
+  transport model.
+
+## Why
+
+- `@Serializable` is the right tool for API encoding/decoding and keeps network contracts explicit.
+- `@Parcelize` is optimized for Android framework state transport and avoids unnecessary JSON-style
+  encoding for restore paths.
+
+## Checklist for code reviews
+
+- If a model crosses a network boundary, ensure it remains `@Serializable`.
+- If a model is saved/restored through Android state transport, prefer a Parcelable transport model.
+- If a type is used in both contexts, split it into dedicated transport models instead of mixing
+  responsibilities.

--- a/docs/general/style-guidance.md
+++ b/docs/general/style-guidance.md
@@ -7,3 +7,9 @@
 - Compose UI uses Material 3 theming; reference `MaterialTheme` for colors, typography, and spacing.
 - Use Kotlin Coroutines and Flow for asynchronous work and state streams.
 - Inject dependencies with Koin; obtain ViewModels via Koin helpers.
+
+## Serialization checklist
+
+- Keep remote/data DTOs on `kotlinx.serialization` (`@Serializable`).
+- Use `@Parcelize` only for Android state transport boundaries (Bundle/SavedState/navigation keys).
+- If one model appears to need both, split it into dedicated transport models.

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -162,6 +162,7 @@ test-mockk-android = { module = "io.mockk:mockk-android", version.ref = "testMoc
 android-application = { id = "com.android.application", version.ref = "androidGradlePlugin" }
 android-library = { id = "com.android.library", version.ref = "androidGradlePlugin" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
+kotlin-parcelize = { id = "kotlin-parcelize" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
 google-mobile-services = { id = "com.google.gms.google-services", version.ref = "googleMobileServices" }
 firebase-crashlytics = { id = "com.google.firebase.crashlytics", version.ref = "firebaseCrashlyticsPlugin" }


### PR DESCRIPTION
### Motivation

- Replace JSON-style serialization for UI/navigation state with Android-optimized Parcelable transport to improve restore performance and respect architecture boundaries.
- Ensure navigation keys are Bundle-compatible so `rememberSaveable` / SavedState can persist navigation stacks without serializing to JSON.

### Description

- Add `kotlin-parcelize` plugin alias in `gradle/libs.versions.toml` and enable the plugin in `app` and `apptoolkit` modules by adding `alias(notation = libs.plugins.kotlin.parcelize)` in their Gradle files.
- Convert navigation route objects from `@Serializable` to `@Parcelize` and make `StableNavKey` extend `Parcelable` so route keys are Bundle-compatible.
- Replace `rememberSerializable` / kotlinx-serialization-based nav back stack persistence with `rememberSaveable` and a custom `navBackStackSaver()` that saves/restores the `NavBackStack` using Parcelable route keys.
- Add documentation `docs/general/core/serialization-boundaries.md` and update docs and style guidance to explain when to use `kotlinx.serialization` vs `@Parcelize`.

### Testing

- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c290d24664832db7b3fb48b6dd6809)