### PR TITLE
Add badge support for bottom navigation items

### DIFF
--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/main/domain/model/BottomBarItem.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/main/domain/model/BottomBarItem.kt
@@ -21,10 +21,20 @@ import androidx.compose.runtime.Immutable
 import androidx.compose.ui.graphics.vector.ImageVector
 import com.d4rk.android.libs.apptoolkit.core.ui.model.navigation.StableNavKey
 
+/**
+ * Represents an item rendered in bottom navigation surfaces (bottom bar and navigation rail).
+ *
+ * @property route Stable route key used for navigation.
+ * @property icon Icon displayed when the destination is not selected.
+ * @property selectedIcon Icon displayed when the destination is selected.
+ * @property title String resource id used for both label and content description.
+ * @property badgeText Optional badge text. When blank, no badge is shown.
+ */
 @Immutable
 data class BottomBarItem<T : StableNavKey>(
     val route: T,
     val icon: ImageVector,
     val selectedIcon: ImageVector,
-    val title: Int
+    val title: Int,
+    val badgeText: String = "",
 )

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/main/ui/views/navigation/BottomNavigationBar.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/main/ui/views/navigation/BottomNavigationBar.kt
@@ -20,6 +20,8 @@ package com.d4rk.android.libs.apptoolkit.app.main.ui.views.navigation
 import android.view.SoundEffectConstants
 import android.view.View
 import androidx.compose.foundation.basicMarquee
+import androidx.compose.material3.Badge
+import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationBar
@@ -70,11 +72,21 @@ fun <T : StableNavKey> BottomNavigationBar(
                 selected = selected,
                 alwaysShowLabel = showLabels,
                 icon = {
-                    Icon(
-                        imageVector = if (selected) item.selectedIcon else item.icon,
-                        contentDescription = stringResource(id = item.title),
-                        modifier = Modifier.bounceClick()
-                    )
+                    BadgedBox(
+                        badge = {
+                            if (item.badgeText.isNotBlank()) {
+                                Badge {
+                                    Text(text = item.badgeText)
+                                }
+                            }
+                        }
+                    ) {
+                        Icon(
+                            imageVector = if (selected) item.selectedIcon else item.icon,
+                            contentDescription = stringResource(id = item.title),
+                            modifier = Modifier.bounceClick()
+                        )
+                    }
                 },
                 label = {
                     Text(

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/main/ui/views/navigation/LeftNavigationRail.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/main/ui/views/navigation/LeftNavigationRail.kt
@@ -41,6 +41,8 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Badge
+import androidx.compose.material3.BadgedBox
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationRail
 import androidx.compose.material3.NavigationRailItem
@@ -130,13 +132,23 @@ fun <T : StableNavKey> LeftNavigationRail(
                         }
                     },
                     icon = {
-                        Icon(
-                            imageVector = if (isSelected) item.selectedIcon else item.icon,
-                            contentDescription = stringResource(item.title),
-                            modifier = Modifier
-                                .size(size = SizeConstants.TwentyFourSize)
-                                .bounceClick()
-                        )
+                        BadgedBox(
+                            badge = {
+                                if (item.badgeText.isNotBlank()) {
+                                    Badge {
+                                        Text(text = item.badgeText)
+                                    }
+                                }
+                            }
+                        ) {
+                            Icon(
+                                imageVector = if (isSelected) item.selectedIcon else item.icon,
+                                contentDescription = stringResource(item.title),
+                                modifier = Modifier
+                                    .size(size = SizeConstants.TwentyFourSize)
+                                    .bounceClick()
+                            )
+                        }
                     },
                     label = {
                         AnimatedVisibility(


### PR DESCRIPTION
### Motivation
- Bottom navigation items could not display badges while drawer items supported `badgeText`, making it impossible to show counts/alerts on bottom destinations without customizations.
- The change aims to provide a backwards-compatible way to surface destination badges on both the bottom bar and the left navigation rail using Material 3 badges.

### Description
- Extend `BottomBarItem` with an optional `badgeText: String = ""` and documented the model with KDoc to explain the new field and keep the API backward compatible.
- Update `BottomNavigationBar` to wrap the item `Icon` in a `BadgedBox` and render a `Badge` when `item.badgeText.isNotBlank()`.
- Apply the same `BadgedBox` + `Badge` rendering to `LeftNavigationRail` so shared navigation items show badges consistently across navigation surfaces.
- Changes touch `BottomBarItem.kt`, `BottomNavigationBar.kt`, and `LeftNavigationRail.kt` and rely on Material 3's `BadgedBox`/`Badge` components.

### Testing
- Attempted to run `./gradlew :apptoolkit:compileDebugKotlin`, which could not complete due to missing Android SDK configuration (`ANDROID_HOME` / `local.properties`) in the execution environment, so compilation could not be validated here.
- Repository search and basic static inspections were performed to ensure the new `badgeText` field is consumed where appropriate and there are no obvious unresolved references.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c7ab765234832da08ba87ce20ab48f)