### PR TITLE
Optimize Glance app widget UX, performance, and docs

### DIFF
--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/widgets/apps/AppIconsWidget.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/widgets/apps/AppIconsWidget.kt
@@ -35,6 +35,7 @@ import androidx.glance.GlanceModifier
 import androidx.glance.GlanceTheme
 import androidx.glance.Image
 import androidx.glance.ImageProvider
+import androidx.glance.LocalContext
 import androidx.glance.LocalSize
 import androidx.glance.action.actionParametersOf
 import androidx.glance.action.clickable
@@ -54,6 +55,9 @@ import androidx.glance.layout.fillMaxSize
 import androidx.glance.layout.fillMaxWidth
 import androidx.glance.layout.padding
 import androidx.glance.layout.size
+import androidx.glance.text.FontWeight
+import androidx.glance.text.Text
+import androidx.glance.text.TextStyle
 import com.d4rk.android.apps.apptoolkit.R
 import com.d4rk.android.apps.apptoolkit.app.apps.common.domain.model.AppInfo
 import com.d4rk.android.apps.apptoolkit.app.apps.common.domain.usecases.FetchDeveloperAppsUseCase
@@ -67,7 +71,13 @@ import kotlinx.coroutines.withContext
 import org.koin.core.context.GlobalContext
 
 /**
- * A highly expressive, resizable 3x3 grid widget that purely focuses on iconography.
+ * A highly expressive, resizable 3x3 grid widget that focuses on fast app launching.
+ *
+ * Change rationale:
+ * - Previously, the widget resolved package icons for the full app list even though only the first
+ *   3x3 slots were rendered.
+ * - Now, app loading is capped to the visible 9 entries before icon decoding, reducing background
+ *   work and memory pressure for each update.
  */
 class AppIconsWidget : GlanceAppWidget(errorUiLayout = R.layout.widget_app_icons_error) {
 
@@ -104,7 +114,9 @@ class AppIconsWidget : GlanceAppWidget(errorUiLayout = R.layout.widget_app_icons
             is DataState.Loading -> emptyList()
         }
 
-        apps.ifEmpty { listOf(createFallbackEntry(context)) }
+        apps
+            .ifEmpty { listOf(createFallbackEntry(context)) }
+            .take(MAX_GRID_ITEMS)
             .map { app ->
                 WidgetAppEntry(
                     app = app,
@@ -133,7 +145,7 @@ class AppIconsWidget : GlanceAppWidget(errorUiLayout = R.layout.widget_app_icons
             context.packageManager.getApplicationIcon(context.packageName)
         }
 
-        return drawable.toBitmap(sizePx = 96)
+        return drawable.toBitmap(sizePx = DEFAULT_ICON_BITMAP_SIZE_PX)
     }
 
     private fun createRefreshIntent(context: Context): PendingIntent {
@@ -149,6 +161,11 @@ class AppIconsWidget : GlanceAppWidget(errorUiLayout = R.layout.widget_app_icons
     }
 
     companion object {
+        const val GRID_COLUMNS: Int = 3
+        const val GRID_ROWS: Int = 3
+        private const val MAX_GRID_ITEMS: Int = GRID_COLUMNS * GRID_ROWS
+        private const val DEFAULT_ICON_BITMAP_SIZE_PX: Int = 72
+
         val SMALL_SIZE: DpSize = DpSize(width = 120.dp, height = 120.dp)
         val MEDIUM_SIZE: DpSize = DpSize(width = 180.dp, height = 180.dp)
         val LARGE_SIZE: DpSize = DpSize(width = 250.dp, height = 250.dp)
@@ -159,9 +176,10 @@ class AppIconsWidget : GlanceAppWidget(errorUiLayout = R.layout.widget_app_icons
 private fun AppIconsWidgetContent(apps: ImmutableList<WidgetAppEntry>) {
     GlanceTheme {
         val widgetSize = LocalSize.current
+        val showTitle = widgetSize.width >= AppIconsWidget.MEDIUM_SIZE.width
         val iconSize = when {
-            widgetSize.width < 150.dp -> 26.dp
-            widgetSize.width < 200.dp -> 38.dp
+            widgetSize.width < 150.dp -> 28.dp
+            widgetSize.width < 200.dp -> 36.dp
             else -> 48.dp
         }
 
@@ -170,7 +188,7 @@ private fun AppIconsWidgetContent(apps: ImmutableList<WidgetAppEntry>) {
                 .fillMaxSize()
                 .appWidgetBackground()
                 .background(GlanceTheme.colors.surface)
-                .padding(8.dp), // Outer breathing room
+                .padding(8.dp),
             contentAlignment = Alignment.Center
         ) {
             Column(
@@ -178,12 +196,19 @@ private fun AppIconsWidgetContent(apps: ImmutableList<WidgetAppEntry>) {
                     .fillMaxSize()
                     .background(GlanceTheme.colors.secondaryContainer)
                     .cornerRadius(16.dp)
-                    .padding(4.dp)
+                    .padding(horizontal = 6.dp, vertical = 4.dp)
             ) {
-                val appsToDisplay = apps.take(9)
-                val rows = appsToDisplay.chunked(3)
+                if (showTitle) {
+                    Text(
+                        text = LocalContext.current.getString(R.string.widget_apps_title),
+                        style = TextStyle(fontWeight = FontWeight.Medium),
+                        modifier = GlanceModifier.padding(start = 4.dp, top = 2.dp, bottom = 2.dp)
+                    )
+                }
 
-                for (rowIndex in 0 until 3) {
+                val rows = apps.chunked(AppIconsWidget.GRID_COLUMNS)
+
+                for (rowIndex in 0 until AppIconsWidget.GRID_ROWS) {
                     val rowApps = rows.getOrNull(rowIndex) ?: emptyList()
 
                     Row(
@@ -191,7 +216,7 @@ private fun AppIconsWidgetContent(apps: ImmutableList<WidgetAppEntry>) {
                             .fillMaxWidth()
                             .defaultWeight()
                     ) {
-                        for (colIndex in 0 until 3) {
+                        for (colIndex in 0 until AppIconsWidget.GRID_COLUMNS) {
                             val item = rowApps.getOrNull(colIndex)
 
                             if (item != null) {
@@ -199,9 +224,9 @@ private fun AppIconsWidgetContent(apps: ImmutableList<WidgetAppEntry>) {
                                     modifier = GlanceModifier
                                         .defaultWeight()
                                         .fillMaxHeight()
-                                        .padding(4.dp) // Spacing between the grid cells
+                                        .padding(4.dp)
                                         .background(GlanceTheme.colors.primaryContainer)
-                                        .cornerRadius(4.dp)
+                                        .cornerRadius(8.dp)
                                         .appWidgetClickAction(item.app.packageName),
                                     contentAlignment = Alignment.Center
                                 ) {

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/widgets/apps/AppIconsWidgetReceiver.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/widgets/apps/AppIconsWidgetReceiver.kt
@@ -28,7 +28,7 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
 
 /**
- * Broadcast receiver entry point for the scrollable developer apps widget.
+ * Broadcast receiver entry point for the Glance app icons grid widget.
  */
 class AppIconsWidgetReceiver : GlanceAppWidgetReceiver() {
     override val glanceAppWidget: GlanceAppWidget = AppIconsWidget()

--- a/app/src/main/res/drawable/widget_app_icons_preview.xml
+++ b/app/src/main/res/drawable/widget_app_icons_preview.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  ~ Copyright (©) 2026 Mihai-Cristian Condrea
+  ~
+  ~ This program is free software: you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation, either version 3 of the License, or
+  ~ (at your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful,
+  ~ but WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+  ~ GNU General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program. If not, see <https://www.gnu.org/licenses/>.
+  -->
+
+<layer-list xmlns:android="http://schemas.android.com/apk/res/android">
+    <item>
+        <shape android:shape="rectangle">
+            <corners android:radius="24dp" />
+            <solid android:color="#FFE8EAF6" />
+        </shape>
+    </item>
+
+    <item android:left="12dp" android:top="12dp" android:right="12dp" android:bottom="12dp">
+        <shape android:shape="rectangle">
+            <corners android:radius="16dp" />
+            <solid android:color="#FFC5CAE9" />
+        </shape>
+    </item>
+
+    <item android:left="28dp" android:top="28dp" android:right="28dp" android:bottom="28dp">
+        <shape android:shape="rectangle">
+            <corners android:radius="12dp" />
+            <solid android:color="#FF9FA8DA" />
+        </shape>
+    </item>
+
+    <item android:drawable="@drawable/ic_launcher_foreground" android:gravity="center" />
+</layer-list>

--- a/app/src/main/res/xml/app_icons_widget_info.xml
+++ b/app/src/main/res/xml/app_icons_widget_info.xml
@@ -26,7 +26,7 @@
     android:minResizeWidth="120dp"
     android:maxResizeHeight="250dp"
     android:maxResizeWidth="250dp"
-    android:previewImage="@drawable/ic_launcher_foreground"
+    android:previewImage="@drawable/widget_app_icons_preview"
     android:resizeMode="horizontal|vertical"
     android:targetCellHeight="2"
     android:targetCellWidth="2"

--- a/docs/apptoolkit/screens/main/widgets.md
+++ b/docs/apptoolkit/screens/main/widgets.md
@@ -1,35 +1,41 @@
 # Home Screen Widget (Glance)
 
-This document describes the current App Toolkit app widget implementation in
-`app/widgets/apps` and how to evolve it safely.
+This document describes the App Toolkit home-screen widget implementation in
+`app/widgets/apps` and the constraints to preserve when evolving it.
 
 ## Current behavior
 
-- The widget is implemented with **Jetpack Glance** (`AppIconsWidget`) and registered via
-  `AppIconsWidgetReceiver`.
-- It loads developer app entries from `FetchDeveloperAppsUseCase` and renders a scrollable list of app rows.
-- Tapping a row executes `OpenAppOrStoreAction`, which launches the installed app or falls back to its Play Store listing.
-- The widget uses responsive breakpoints (`120dp`, `180dp`, `250dp`) to adapt density:
-  - small: compact list
-  - medium/large: includes a header and more visible rows
+- The widget is implemented with **Jetpack Glance** (`AppIconsWidget`) and registered through
+  `AppIconsWidgetReceiver` in the application manifest.
+- It renders a **3x3 app-launch grid** (up to 9 actions) and uses
+  `OpenAppOrStoreAction` to open the installed app first, then fallback to the Play Store.
+- It uses responsive breakpoints (`120dp`, `180dp`, `250dp`) through `SizeMode.Responsive`.
+  - small: icon-first compact grid
+  - medium/large: grid plus a lightweight title row for orientation
 
 ## Reliability and UX safeguards
 
-- `provideGlance` loads app data on `Dispatchers.IO` before composition, to keep main-thread work minimal.
-- `onCompositionError` falls back to `widget_app_icons_error.xml`, with a retry button that triggers a full widget refresh.
+- `provideGlance` loads app data on `Dispatchers.IO` before composition, keeping composition work
+  lightweight and avoiding main-thread data orchestration.
+- Widget loading now caps to visible entries before icon decoding (first 9 only), reducing update
+  cost and bitmap churn.
+- `onCompositionError` falls back to `widget_app_icons_error.xml`, with a retry button that
+  triggers a full `updateAll` refresh path.
+- `app_icons_widget_info.xml` defines a dedicated `previewImage` drawable for better picker
+  quality on hosts that rely on static previews.
 
 ## Update model
 
-- The widget remains passive and stateless; source-of-truth data stays in domain/data layers.
+- The widget remains passive and stateless; source-of-truth data lives in domain/data layers.
 - Refreshes are triggered through Glance update APIs (`updateAll`) from receiver callbacks.
-- Avoid frequent periodic updates; update opportunistically after data changes or explicit user actions.
+- Prefer opportunistic updates (user interaction / data refresh) over aggressive periodic updates.
 
 ## Extension guidelines
 
 When extending this widget:
 
-1. Keep business/data orchestration outside composables.
-2. Keep rows lightweight; avoid allocation-heavy operations in composition.
-3. Prefer predefined breakpoints over fully exact re-layouts for smoother resize transitions.
-4. Keep action callbacks short; offload long work to workers.
-5. Ensure non-composition failures still provide actionable UI through error fallback paths.
+1. Keep data orchestration outside composables.
+2. Keep each cell action short; offload long work to workers.
+3. Prefer bounded responsive sizes instead of fully exact relayouts for smoother resize behavior.
+4. Keep error handling actionable (`errorUiLayout` + retry intent path).
+5. If layout semantics change significantly, update this document in the same PR.


### PR DESCRIPTION
### Motivation

- The widget previously decoded icons for the entire fetched app list even though only a 3x3 grid is rendered, which caused unnecessary work and memory pressure during updates. 
- The Glance UI needed small responsive refinements (icon breakpoints, spacing, corner radius and an optional title) to improve readability across sizes. 
- Widget picker quality and documentation were incomplete: a static preview drawable and accurate developer docs were missing or out of sync.

### Description

- Cap app loading to the visible grid by limiting resolved entries to the first 9 items before decoding icons via `take(MAX_GRID_ITEMS)` in `AppIconsWidget` (`app/src/main/kotlin/.../AppIconsWidget.kt`).
- Add explicit grid constants (`GRID_COLUMNS`, `GRID_ROWS`, `MAX_GRID_ITEMS`) and set a controlled icon decode size (`DEFAULT_ICON_BITMAP_SIZE_PX`) to reduce bitmap churn and memory overhead. 
- Improve Glance layout responsiveness by tuning icon sizing breakpoints, adding a lightweight title row for medium+ sizes, adjusting padding and increasing cell corner radii for better visual balance in `AppIconsWidgetContent`. 
- Preserve robust fallback behavior: composition errors still use `errorUiLayout` and a retry path that triggers `updateAll` via the receiver; clarified receiver comment in `AppIconsWidgetReceiver`. 
- Add a dedicated static preview drawable (`app/src/main/res/drawable/widget_app_icons_preview.xml`) and wire it into `app_icons_widget_info.xml` for improved widget picker previews. 
- Update developer documentation at `docs/apptoolkit/screens/main/widgets.md` to reflect the grid implementation, performance safeguards, and extension guidelines. 

### Testing

- Attempted to run a local compile with `./gradlew :app:compileDebugKotlin`, but the build could not complete in this environment because the Android SDK location is not configured (`ANDROID_HOME` / `local.properties` missing). 
- Dependency and project inspection commands were executed to validate changed APIs and resources; no unit/instrumentation tests were run in this environment due to SDK/tooling constraints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c80d1c40b0832d92911d1456de1a58)