### PR TITLE
Introduce remembered collapsed TopAppBar state and use it in TopAppBarScaffold

### DIFF
--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/navigation/TopAppBar.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/navigation/TopAppBar.kt
@@ -34,7 +34,6 @@ import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.input.nestedscroll.nestedScroll
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.AnimatedIconButtonDirection
 
@@ -145,19 +144,7 @@ fun TopAppBarScaffold(
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 private fun rememberCollapsedLargeTopAppBarScrollBehavior(): TopAppBarScrollBehavior {
-    val density = LocalDensity.current
-
-    val expandedHeight = TopAppBarDefaults.LargeAppBarExpandedHeight
-    val collapsedHeight = TopAppBarDefaults.LargeAppBarCollapsedHeight
-
-    val collapsedOffsetPx = with(density) {
-        -(expandedHeight - collapsedHeight).toPx()
-    }
-
-    val topAppBarState = rememberTopAppBarState(
-        initialHeightOffsetLimit = collapsedOffsetPx,
-        initialHeightOffset = collapsedOffsetPx,
-    )
+    val topAppBarState = rememberCollapsedTopAppBarState()
 
     return TopAppBarDefaults.enterAlwaysScrollBehavior(topAppBarState)
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/navigation/TopAppBarState.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/navigation/TopAppBarState.kt
@@ -1,0 +1,56 @@
+/*
+ * Copyright (©) 2026 Mihai-Cristian Condrea
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.d4rk.android.libs.apptoolkit.core.ui.views.navigation
+
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.TopAppBarState
+import androidx.compose.material3.rememberTopAppBarState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+
+/**
+ * Creates and remembers a [TopAppBarState] that starts in a collapsed position.
+ *
+ * This helper waits until Material 3 calculates [TopAppBarState.heightOffsetLimit],
+ * then applies that limit as the current [TopAppBarState.heightOffset] exactly once.
+ *
+ * It is intended for usage such as:
+ * `val state = rememberCollapsedTopAppBarState()` and
+ * `val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(state)`.
+ *
+ * @return A remembered [TopAppBarState] initialized to the collapsed offset.
+ */
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun rememberCollapsedTopAppBarState(): TopAppBarState {
+    val state = rememberTopAppBarState()
+    var initialized by remember { mutableStateOf(false) }
+
+    LaunchedEffect(state.heightOffsetLimit) {
+        if (!initialized && state.heightOffsetLimit < 0f) {
+            state.heightOffset = state.heightOffsetLimit
+            initialized = true
+        }
+    }
+
+    return state
+}


### PR DESCRIPTION
### Motivation

- Ensure the Material 3 `LargeTopAppBar` can reliably start in a collapsed state without doing manual density and pixel math inside the composable. 
- Avoid race conditions by waiting for Material 3 to provide the `heightOffsetLimit` before applying the collapsed offset.

### Description

- Add `TopAppBarState.kt` with `@Composable fun rememberCollapsedTopAppBarState()` which remembers a `TopAppBarState` and sets `heightOffset` to `heightOffsetLimit` once the limit is available using `LaunchedEffect`.
- Update `TopAppBar.kt` to use `rememberCollapsedTopAppBarState()` instead of computing pixel offsets with `LocalDensity` and manual height arithmetic. 
- Remove the now-unused `LocalDensity` import and related manual offset logic.

### Testing

- Ran a full build with `./gradlew build` which completed successfully. 
- Ran module unit tests with `./gradlew :apptoolkit:test` which passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c98db2b0e8832da70c3afe62a1f415)