### PR TITLE
Polish navigation drawer badge styling

### DIFF
--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/main/ui/views/navigation/NavigationDrawerItemContent.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/main/ui/views/navigation/NavigationDrawerItemContent.kt
@@ -21,6 +21,7 @@ import android.view.SoundEffectConstants
 import android.view.View
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.material3.Badge
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.NavigationDrawerItem
@@ -58,7 +59,9 @@ fun NavigationDrawerItemContent(
             )
         }, badge = {
             if (item.badgeText.isNotBlank()) {
-                Text(text = item.badgeText)
+                Badge {
+                    Text(text = item.badgeText)
+                }
             }
         }, modifier = Modifier
             .padding(paddingValues = NavigationDrawerItemDefaults.ItemPadding)


### PR DESCRIPTION
### Motivation
- Align drawer item badges with the bottom app bar visuals by using Material 3 `Badge` instead of plain `Text`, improving visual consistency and affordance.

### Description
- Replaced the inline `Text` badge in `NavigationDrawerItemContent.kt` with `Badge { Text(...) }`, keeping the existing `item.badgeText.isNotBlank()` visibility behavior.

### Testing
- Ran `./gradlew :apptoolkit:compileDebugKotlin --no-daemon`, which could not complete due to a missing Android SDK location (`ANDROID_HOME` / `local.properties` `sdk.dir`) in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c990543ef8832da0d10e8fbc579247)