### PR TITLE
Threading, widget async, lazy device-info, and DataStore flow stability improvements

### DIFF
--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainViewModel.kt
@@ -143,7 +143,8 @@ class MainViewModel(
         )
         consentJob = consentJob.restart {
             requestConsentUseCase.invoke(host = host)
-                .flowOn(dispatchers.main)
+                // Keep consent flow collection on ViewModel scope (main-safe for UI updates)
+                // and avoid forcing the whole upstream chain onto Main via flowOn(main).
                 .onEach { result: DataState<Unit, Errors> ->
                     result.onFailure { error ->
                         updateStateThreadSafe {

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/widgets/apps/AppIconsWidgetReceiver.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/widgets/apps/AppIconsWidgetReceiver.kt
@@ -36,8 +36,13 @@ class AppIconsWidgetReceiver : GlanceAppWidgetReceiver() {
     override fun onReceive(context: Context, intent: Intent) {
         super.onReceive(context, intent)
         if (intent.action == ACTION_REFRESH_WIDGET) {
-            receiverScope.launch {
-                AppIconsWidget().updateAll(context)
+            val pendingResult = goAsync()
+            CoroutineScope(SupervisorJob() + Dispatchers.Default).launch {
+                try {
+                    AppIconsWidget().updateAll(context)
+                } finally {
+                    pendingResult.finish()
+                }
             }
         }
     }
@@ -45,7 +50,5 @@ class AppIconsWidgetReceiver : GlanceAppWidgetReceiver() {
     companion object {
         const val ACTION_REFRESH_WIDGET: String =
             "com.d4rk.android.apps.apptoolkit.action.APP_ICONS_WIDGET_REFRESH"
-
-        private val receiverScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
     }
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/ads/ui/AdsSettingsViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/ads/ui/AdsSettingsViewModel.kt
@@ -186,7 +186,7 @@ class AdsSettingsViewModel(
         )
         consentJob = consentJob.restart {
             requestConsentUseCase.invoke(host = host, showIfRequired = false)
-                .flowOn(dispatchers.main)
+                // Keep upstream consent work off Main by not applying flowOn(main) here.
                 .onEach { result ->
                     result.onFailure { error ->
                         updateStateThreadSafe {

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/IssueReporterScreen.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/IssueReporterScreen.kt
@@ -76,7 +76,6 @@ import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.ImeAction
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.d4rk.android.libs.apptoolkit.R
-import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.DeviceInfo
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.domain.model.github.GithubTarget
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.ui.contract.IssueReporterEvent
 import com.d4rk.android.libs.apptoolkit.app.issuereporter.ui.state.IssueReporterUiState
@@ -102,8 +101,6 @@ import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.SmallVerticalSpace
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.analytics.SettingsAnalytics
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.core.utils.extensions.context.openUrl
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.withContext
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 
@@ -253,20 +250,10 @@ fun IssueReporterScreenContent(
     data: IssueReporterUiState,
 ) {
     val uriHandler = LocalUriHandler.current
-    val context = LocalContext.current
     val hapticFeedback: HapticFeedback = LocalHapticFeedback.current
     val view: View = LocalView.current
 
     val deviceExpanded = rememberSaveable { mutableStateOf(false) }
-    val deviceInfoText = rememberSaveable { mutableStateOf<String?>(null) }
-
-    LaunchedEffect(deviceExpanded.value) {
-        if (deviceExpanded.value && deviceInfoText.value == null) {
-            deviceInfoText.value = withContext(Dispatchers.Default) {
-                DeviceInfo.create(context).toString()
-            }
-        }
-    }
 
     LazyColumn(
         modifier = Modifier.fillMaxSize(),
@@ -445,6 +432,9 @@ fun IssueReporterScreenContent(
 
                                 val newValue = !deviceExpanded.value
                                 deviceExpanded.value = newValue
+                                if (newValue) {
+                                    onEvent(IssueReporterEvent.RequestDeviceInfo)
+                                }
 
                                 firebaseController.logEvent(
                                     issueReporterActionEvent(
@@ -473,7 +463,7 @@ fun IssueReporterScreenContent(
 
                     AnimatedVisibility(visible = deviceExpanded.value) {
                         Text(
-                            text = deviceInfoText.value.orEmpty(),
+                            text = data.deviceInfoText.orEmpty(),
                             style = MaterialTheme.typography.bodySmall,
                             modifier = Modifier
                                 .padding(SizeConstants.LargeSize)

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/IssueReporterViewModel.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/IssueReporterViewModel.kt
@@ -53,6 +53,7 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.Error as RootError
 
 /**
@@ -82,6 +83,7 @@ class IssueReporterViewModel(
             is IssueReporterEvent.UpdateDescription -> updateDescription(event.value)
             is IssueReporterEvent.UpdateEmail -> updateEmail(event.value)
             is IssueReporterEvent.SetAnonymous -> updateAnonymous(event.anonymous)
+            is IssueReporterEvent.RequestDeviceInfo -> loadDeviceInfoIfNeeded()
             is IssueReporterEvent.Send -> sendReport()
             is IssueReporterEvent.DismissSnackbar -> dismissSnackbar()
         }
@@ -175,6 +177,29 @@ class IssueReporterViewModel(
                     showFailureSnackbar()
                 },
             )
+        }
+    }
+
+    /**
+     * Loads device information lazily the first time the UI expands the section.
+     *
+     * Threading rationale:
+     * - Device-info capture and string formatting are done off-main via [dispatchers.default]
+     *   to avoid blocking Compose recompositions.
+     */
+    private fun loadDeviceInfoIfNeeded() {
+        val currentDeviceInfo = screenData?.deviceInfoText
+        if (currentDeviceInfo != null) return
+
+        viewModelScope.launch {
+            val captured = withContext(dispatchers.default) {
+                deviceInfoProvider.capture().toString()
+            }
+            updateStateThreadSafe {
+                screenState.copyData {
+                    if (deviceInfoText != null) this else copy(deviceInfoText = captured)
+                }
+            }
         }
     }
 

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/contract/IssueReporterEvent.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/contract/IssueReporterEvent.kt
@@ -24,6 +24,7 @@ sealed interface IssueReporterEvent : UiEvent {
     data class UpdateDescription(val value: String) : IssueReporterEvent
     data class UpdateEmail(val value: String) : IssueReporterEvent
     data class SetAnonymous(val anonymous: Boolean) : IssueReporterEvent
+    data object RequestDeviceInfo : IssueReporterEvent
     data object Send : IssueReporterEvent
     data object DismissSnackbar : IssueReporterEvent
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/state/IssueReporterUiState.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/issuereporter/ui/state/IssueReporterUiState.kt
@@ -25,5 +25,6 @@ data class IssueReporterUiState(
     val description: String = "",
     val email: String = "",
     val anonymous: Boolean = true,
-    val issueUrl: String? = null
+    val issueUrl: String? = null,
+    val deviceInfoText: String? = null,
 )

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/data/local/datastore/CommonDataStore.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/data/local/datastore/CommonDataStore.kt
@@ -94,7 +94,7 @@ open class CommonDataStore(
         longPreferencesKey(name = DataStoreNamesConstants.DATA_STORE_LAST_USED)
     val lastUsed: Flow<Long> = dataStore.data.map { preferences: Preferences ->
         preferences[lastUsedKey] ?: 0
-    }
+    }.distinctUntilChanged()
 
     suspend fun saveLastUsed(timestamp: Long) {
         dataStore.edit { preferences: MutablePreferences ->
@@ -107,7 +107,7 @@ open class CommonDataStore(
         booleanPreferencesKey(name = DataStoreNamesConstants.DATA_STORE_STARTUP)
     override val startup: Flow<Boolean> = dataStore.data.map { preferences: Preferences ->
         preferences[startupKey] != false
-    }
+    }.distinctUntilChanged()
 
     private val startupPageKey =
         stringPreferencesKey(name = DataStoreNamesConstants.DATA_STORE_STARTUP_PAGE)
@@ -119,7 +119,7 @@ open class CommonDataStore(
      */
     fun getStartupPage(default: String = ""): Flow<String> = dataStore.data.map { preferences ->
         preferences[startupPageKey] ?: default
-    }
+    }.distinctUntilChanged()
 
     /** Stores whether the app has completed its first-time startup flow. */
     override suspend fun saveStartup(isFirstTime: Boolean) {
@@ -141,7 +141,7 @@ open class CommonDataStore(
         stringPreferencesKey(name = DataStoreNamesConstants.DATA_STORE_THEME_MODE)
     val themeMode: Flow<String> = dataStore.data.map { preferences: Preferences ->
         preferences[themeModeKey] ?: DataStoreNamesConstants.THEME_MODE_FOLLOW_SYSTEM
-    }
+    }.distinctUntilChanged()
 
     suspend fun saveThemeMode(mode: String) {
         dataStore.edit { preferences: MutablePreferences ->
@@ -153,7 +153,7 @@ open class CommonDataStore(
         booleanPreferencesKey(name = DataStoreNamesConstants.DATA_STORE_AMOLED_MODE)
     val amoledMode: Flow<Boolean> = dataStore.data.map { preferences: Preferences ->
         preferences[amoledModeKey] == true
-    }
+    }.distinctUntilChanged()
 
     suspend fun saveAmoledMode(isChecked: Boolean) {
         dataStore.edit { preferences: MutablePreferences ->
@@ -165,7 +165,7 @@ open class CommonDataStore(
         booleanPreferencesKey(name = DataStoreNamesConstants.DATA_STORE_DYNAMIC_COLORS)
     val dynamicColors: Flow<Boolean> = dataStore.data.map { preferences ->
         preferences[dynamicColorsKey] != false
-    }
+    }.distinctUntilChanged()
 
     suspend fun saveDynamicColors(isChecked: Boolean) {
         dataStore.edit { preferences: MutablePreferences ->
@@ -177,7 +177,7 @@ open class CommonDataStore(
         booleanPreferencesKey(name = DataStoreNamesConstants.DATA_STORE_SETTINGS_INTERACTED)
     val settingsInteracted: Flow<Boolean> = dataStore.data.map { preferences ->
         preferences[settingsInteractedKey] == true
-    }
+    }.distinctUntilChanged()
 
     suspend fun markSettingsInteracted() {
         dataStore.edit { preferences: MutablePreferences ->
@@ -223,7 +223,7 @@ open class CommonDataStore(
         booleanPreferencesKey(name = DataStoreNamesConstants.DATA_STORE_BOUNCY_BUTTONS)
     val bouncyButtons: Flow<Boolean> = dataStore.data.map { preferences ->
         preferences[bouncyButtonsKey] != false
-    }
+    }.distinctUntilChanged()
 
     suspend fun saveBouncyButtons(isChecked: Boolean) {
         dataStore.edit { preferences: MutablePreferences ->
@@ -234,7 +234,7 @@ open class CommonDataStore(
     fun getShowBottomBarLabels(): Flow<Boolean> {
         return dataStore.data.map { preferences ->
             preferences[booleanPreferencesKey(name = DataStoreNamesConstants.DATA_STORE_SHOW_BOTTOM_BAR_LABELS)] != false
-        }
+        }.distinctUntilChanged()
     }
 
     suspend fun saveShowLabelsOnBottomBar(isChecked: Boolean) {
@@ -249,7 +249,7 @@ open class CommonDataStore(
 
     fun getLanguage(): Flow<String> = dataStore.data.map { preferences: Preferences ->
         preferences[languageKey] ?: "en"
-    }
+    }.distinctUntilChanged()
 
     suspend fun saveLanguage(language: String) {
         dataStore.edit { preferences: MutablePreferences ->
@@ -261,7 +261,7 @@ open class CommonDataStore(
         booleanPreferencesKey(name = DataStoreNamesConstants.DATA_STORE_COMPONENTS_SHOWCASE_UNLOCKED)
     val componentsShowcaseUnlocked: Flow<Boolean> = dataStore.data.map { preferences ->
         preferences[componentsShowcaseUnlockedKey] == true
-    }
+    }.distinctUntilChanged()
 
     suspend fun saveComponentsShowcaseUnlocked(isUnlocked: Boolean) {
         dataStore.edit { preferences ->
@@ -276,7 +276,7 @@ open class CommonDataStore(
     override fun usageAndDiagnostics(default: Boolean): Flow<Boolean> =
         dataStore.data.map { preferences: Preferences ->
             preferences[usageAndDiagnosticsKey] ?: default
-        }
+        }.distinctUntilChanged()
 
     override suspend fun saveUsageAndDiagnostics(isChecked: Boolean) {
         dataStore.edit { preferences: MutablePreferences ->
@@ -291,7 +291,7 @@ open class CommonDataStore(
     override fun analyticsConsent(default: Boolean): Flow<Boolean> =
         dataStore.data.map { preferences: Preferences ->
             preferences[analyticsConsentKey] ?: default
-        }
+        }.distinctUntilChanged()
 
     override suspend fun saveAnalyticsConsent(isGranted: Boolean) {
         dataStore.edit { preferences: MutablePreferences ->
@@ -306,7 +306,7 @@ open class CommonDataStore(
     override fun adStorageConsent(default: Boolean): Flow<Boolean> =
         dataStore.data.map { preferences: Preferences ->
             preferences[adStorageConsentKey] ?: default
-        }
+        }.distinctUntilChanged()
 
     override suspend fun saveAdStorageConsent(isGranted: Boolean) {
         dataStore.edit { preferences: MutablePreferences ->
@@ -321,7 +321,7 @@ open class CommonDataStore(
     override fun adUserDataConsent(default: Boolean): Flow<Boolean> =
         dataStore.data.map { preferences: Preferences ->
             preferences[adUserDataConsentKey] ?: default
-        }
+        }.distinctUntilChanged()
 
     override suspend fun saveAdUserDataConsent(isGranted: Boolean) {
         dataStore.edit { preferences: MutablePreferences ->
@@ -336,7 +336,7 @@ open class CommonDataStore(
     override fun adPersonalizationConsent(default: Boolean): Flow<Boolean> =
         dataStore.data.map { preferences: Preferences ->
             preferences[adPersonalizationConsentKey] ?: default
-        }
+        }.distinctUntilChanged()
 
     override suspend fun saveAdPersonalizationConsent(isGranted: Boolean) {
         dataStore.edit { preferences: MutablePreferences ->
@@ -348,7 +348,7 @@ open class CommonDataStore(
     private val adsKey = booleanPreferencesKey(name = DataStoreNamesConstants.DATA_STORE_ADS)
     fun ads(default: Boolean): Flow<Boolean> = dataStore.data.map { prefs: Preferences ->
         prefs[adsKey] ?: default
-    }
+    }.distinctUntilChanged()
 
     val adsEnabledFlow: StateFlow<Boolean> =
         ads(default = defaultAdsEnabled).stateIn(
@@ -368,7 +368,7 @@ open class CommonDataStore(
         stringSetPreferencesKey(name = DataStoreNamesConstants.DATA_STORE_FAVORITE_APPS)
     val favoriteApps: Flow<Set<String>> = dataStore.data.map { prefs: Preferences ->
         prefs[favoriteAppsKey] ?: emptySet()
-    }
+    }.distinctUntilChanged()
 
     suspend fun toggleFavoriteApp(packageName: String) {
         dataStore.edit { prefs: MutablePreferences ->
@@ -385,13 +385,13 @@ open class CommonDataStore(
         longPreferencesKey(name = DataStoreNamesConstants.DATA_STORE_SESSION_COUNT)
     val sessionCount: Flow<Int> = dataStore.data.map { prefs: Preferences ->
         (prefs[sessionCountKey] ?: 0L).toInt()
-    }
+    }.distinctUntilChanged()
 
     private val reviewPromptedKey =
         booleanPreferencesKey(name = DataStoreNamesConstants.DATA_STORE_REVIEW_PROMPTED)
     val hasPromptedReview: Flow<Boolean> = dataStore.data.map { prefs: Preferences ->
         prefs[reviewPromptedKey] == true
-    }
+    }.distinctUntilChanged()
 
     // Last seen changelog version
     private val lastSeenVersionKey =
@@ -400,7 +400,7 @@ open class CommonDataStore(
     fun getLastSeenVersion(default: String = ""): Flow<String> =
         dataStore.data.map { prefs: Preferences ->
             prefs[lastSeenVersionKey] ?: default
-        }
+        }.distinctUntilChanged()
 
     suspend fun saveLastSeenVersion(version: String) {
         dataStore.edit { prefs: MutablePreferences ->
@@ -415,7 +415,7 @@ open class CommonDataStore(
     fun getCachedChangelog(default: String = ""): Flow<String> =
         dataStore.data.map { prefs: Preferences ->
             prefs[cachedChangelogKey] ?: default
-        }
+        }.distinctUntilChanged()
 
     suspend fun saveCachedChangelog(changelog: String) {
         dataStore.edit { prefs: MutablePreferences ->

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/data/local/datastore/StartupRouteExtensions.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/data/local/datastore/StartupRouteExtensions.kt
@@ -19,6 +19,7 @@ package com.d4rk.android.libs.apptoolkit.core.data.local.datastore
 
 import com.d4rk.android.libs.apptoolkit.core.ui.model.navigation.StableNavKey
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
 
 /**
@@ -33,4 +34,4 @@ fun <T : StableNavKey> CommonDataStore.startupDestinationFlow(
 ): Flow<T> = getStartupPage(default = defaultRoute).map { route ->
     val safeRoute = route.ifBlank { defaultRoute }
     mapToKey(safeRoute)
-}
+}.distinctUntilChanged()


### PR DESCRIPTION
### Motivation
- Avoid forcing upstream flows onto the Main dispatcher and keep UI-safe collections on the ViewModel scope to prevent unnecessary main-thread work.
- Load heavy device-info capture lazily to avoid blocking Compose recompositions and reduce unnecessary work when the section is collapsed.
- Ensure the Glance widget broadcast handler completes asynchronous work before the receiver returns to avoid dropped work.
- Prevent duplicate downstream emissions from DataStore-derived `Flow`s by de-duplicating values.

### Description
- Removed `.flowOn(dispatchers.main)` usage in `MainViewModel` and `AdsSettingsViewModel` and added comments to keep consent flow collection on the ViewModel scope while avoiding forcing upstream onto Main.
- Reworked `AppIconsWidgetReceiver` to use `goAsync()` and a short-lived `CoroutineScope` with `SupervisorJob + Dispatchers.Default` and call `pendingResult.finish()` in `finally`, removing the long-lived `receiverScope` variable.
- Added lazy device-info support for the Issue Reporter: introduced `RequestDeviceInfo` event, added `deviceInfoText` to `IssueReporterUiState`, updated the composable to request device info when the section is expanded, and implemented `loadDeviceInfoIfNeeded()` in `IssueReporterViewModel` to capture and store device info off-main via `dispatchers.default` using `withContext`.
- Appended `.distinctUntilChanged()` to many `dataStore.data.map { ... }` flows in `CommonDataStore` and added `distinctUntilChanged()` to `startupDestinationFlow` to suppress redundant emissions from unchanged preferences.

### Testing
- Ran `./gradlew build` which completed successfully.
- Ran unit tests via `./gradlew test` and the test suite passed without failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca12544868832d81e59b3b021e267d)