### PR TITLE
Harden UMP consent params against malformed AdMob app IDs

### DIFF
--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainActivity.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainActivity.kt
@@ -31,7 +31,6 @@ import androidx.lifecycle.repeatOnLifecycle
 import com.d4rk.android.apps.apptoolkit.app.main.ui.contract.MainAction
 import com.d4rk.android.apps.apptoolkit.app.main.ui.contract.MainEvent
 import com.d4rk.android.apps.apptoolkit.core.data.local.DataStore
-import com.d4rk.android.libs.apptoolkit.app.consent.domain.usecases.ApplyInitialConsentUseCase
 import com.d4rk.android.libs.apptoolkit.app.main.ui.factory.GmsHostFactory
 import com.d4rk.android.libs.apptoolkit.app.startup.ui.StartupActivity
 import com.d4rk.android.libs.apptoolkit.app.theme.ui.style.AppTheme
@@ -39,9 +38,6 @@ import com.d4rk.android.libs.apptoolkit.core.coroutines.dispatchers.DispatcherPr
 import com.d4rk.android.libs.apptoolkit.core.utils.extensions.context.openActivity
 import com.google.android.libraries.ads.mobile.sdk.MobileAds
 import com.google.android.libraries.ads.mobile.sdk.initialization.InitializationConfig
-import kotlinx.coroutines.async
-import kotlinx.coroutines.awaitAll
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -53,7 +49,6 @@ class MainActivity : AppCompatActivity() {
     private val dataStore: DataStore by inject()
     private val dispatchers: DispatcherProvider by inject()
     private val viewModel: MainViewModel by viewModel()
-    private val applyInitialConsentUseCase: ApplyInitialConsentUseCase by inject()
     private val gmsHostFactory: GmsHostFactory by inject()
     private var updateResultLauncher: ActivityResultLauncher<IntentSenderRequest> =
         registerForActivityResult(contract = ActivityResultContracts.StartIntentSenderForResult()) {}
@@ -76,18 +71,12 @@ class MainActivity : AppCompatActivity() {
 
     private fun initializeDependencies() {
         lifecycleScope.launch {
-            coroutineScope {
-                val adsInitialization =
-                    async(dispatchers.default) {
-                        MobileAds.initialize(
-                            this@MainActivity,
-                            InitializationConfig.Builder(getString(com.d4rk.android.libs.apptoolkit.R.string.ad_mob_app_id))
-                                .build()
-                        ) {}
-                    }
-                val consentInitialization =
-                    async(dispatchers.io) { applyInitialConsentUseCase.invoke() }
-                awaitAll(adsInitialization, consentInitialization)
+            withContext(dispatchers.default) {
+                MobileAds.initialize(
+                    this@MainActivity,
+                    InitializationConfig.Builder(getString(com.d4rk.android.libs.apptoolkit.R.string.ad_mob_app_id))
+                        .build()
+                ) {}
             }
         }
     }

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainViewModel.kt
@@ -24,6 +24,7 @@ import com.d4rk.android.apps.apptoolkit.app.main.ui.contract.MainEvent
 import com.d4rk.android.apps.apptoolkit.app.main.ui.state.MainUiState
 import com.d4rk.android.libs.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.app.consent.domain.model.ConsentHost
+import com.d4rk.android.libs.apptoolkit.app.consent.domain.usecases.ApplyInitialConsentUseCase
 import com.d4rk.android.libs.apptoolkit.app.consent.domain.usecases.RequestConsentUseCase
 import com.d4rk.android.libs.apptoolkit.app.main.domain.model.InAppUpdateHost
 import com.d4rk.android.libs.apptoolkit.app.main.domain.model.InAppUpdateResult
@@ -52,13 +53,13 @@ import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
-import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.withContext
 
 class MainViewModel(
     private val getNavigationDrawerItemsUseCase: GetNavigationDrawerItemsUseCase,
+    private val applyInitialConsentUseCase: ApplyInitialConsentUseCase,
     private val requestConsentUseCase: RequestConsentUseCase,
     private val requestInAppReviewUseCase: RequestInAppReviewUseCase,
     private val requestInAppUpdateUseCase: RequestInAppUpdateUseCase,
@@ -71,17 +72,19 @@ class MainViewModel(
 ) {
 
     private var navigationJob: Job? = null
+    private var initialConsentJob: Job? = null
     private var consentJob: Job? = null
     private var reviewJob: Job? = null
     private var updateJob: Job? = null
-    private var isConsentRequestInProgress: Boolean = false
 
     init {
+        onEvent(MainEvent.ApplyInitialConsent)
         onEvent(MainEvent.LoadNavigation)
     }
 
     override fun handleEvent(event: MainEvent) {
         when (event) {
+            is MainEvent.ApplyInitialConsent -> applyInitialConsent()
             is MainEvent.LoadNavigation -> loadNavigationItems()
             is MainEvent.RequestConsent -> requestConsent(host = event.host)
             is MainEvent.RequestReview -> requestReview(host = event.host)
@@ -138,8 +141,29 @@ class MainViewModel(
         }
     }
 
+    private fun applyInitialConsent() {
+        initialConsentJob = initialConsentJob.restart {
+            launchReport(
+                action = Actions.APPLY_INITIAL_CONSENT,
+                block = {
+                    withContext(dispatchers.io) {
+                        applyInitialConsentUseCase.invoke()
+                    }
+                },
+                onError = {
+                    breadcrumb(
+                        message = "consent_initialization_failed",
+                        attributes = mapOf(
+                            ExtraKeys.ERROR to (it::class.java.simpleName ?: "Throwable")
+                        )
+                    )
+                }
+            )
+        }
+    }
+
     private fun requestConsent(host: ConsentHost) {
-        if (isConsentRequestInProgress) {
+        if (consentJob?.isActive == true) {
             breadcrumb(
                 message = "consent_request_skipped",
                 attributes = mapOf(
@@ -150,7 +174,6 @@ class MainViewModel(
             return
         }
 
-        isConsentRequestInProgress = true
         startOperation(
             action = Actions.REQUEST_CONSENT,
             extra = mapOf(ExtraKeys.HOST to host.activity::class.java.name)
@@ -204,9 +227,6 @@ class MainViewModel(
                             }
                         }
                     }
-                }
-                .onCompletion {
-                    isConsentRequestInProgress = false
                 }
                 .catchReport(
                     action = Actions.REQUEST_CONSENT,
@@ -265,6 +285,7 @@ class MainViewModel(
     }
 
     private object Actions {
+        const val APPLY_INITIAL_CONSENT: String = "applyInitialConsent"
         const val LOAD_NAVIGATION: String = "loadNavigationItems"
         const val REQUEST_CONSENT: String = "requestConsent"
         const val REQUEST_REVIEW: String = "requestReview"

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainViewModel.kt
@@ -210,7 +210,7 @@ class MainViewModel(
                                 attributes = mapOf(
                                     ExtraKeys.HOST to host.activity::class.java.name,
                                     ExtraKeys.STAGE to "error",
-                                    ExtraKeys.ERROR to result.error.name
+                                    ExtraKeys.ERROR to result.error.toString()
                                 )
                             )
                             result.onFailure { error ->

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainViewModel.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainViewModel.kt
@@ -52,6 +52,7 @@ import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.withContext
@@ -73,6 +74,7 @@ class MainViewModel(
     private var consentJob: Job? = null
     private var reviewJob: Job? = null
     private var updateJob: Job? = null
+    private var isConsentRequestInProgress: Boolean = false
 
     init {
         onEvent(MainEvent.LoadNavigation)
@@ -137,6 +139,18 @@ class MainViewModel(
     }
 
     private fun requestConsent(host: ConsentHost) {
+        if (isConsentRequestInProgress) {
+            breadcrumb(
+                message = "consent_request_skipped",
+                attributes = mapOf(
+                    ExtraKeys.HOST to host.activity::class.java.name,
+                    ExtraKeys.REASON to "already_in_progress"
+                )
+            )
+            return
+        }
+
+        isConsentRequestInProgress = true
         startOperation(
             action = Actions.REQUEST_CONSENT,
             extra = mapOf(ExtraKeys.HOST to host.activity::class.java.name)
@@ -146,18 +160,53 @@ class MainViewModel(
                 // Keep consent flow collection on ViewModel scope (main-safe for UI updates)
                 // and avoid forcing the whole upstream chain onto Main via flowOn(main).
                 .onEach { result: DataState<Unit, Errors> ->
-                    result.onFailure { error ->
-                        updateStateThreadSafe {
-                            screenState.showSnackbar(
-                                UiSnackbar(
-                                    type = ScreenMessageType.SNACKBAR,
-                                    message = error.asUiText(),
-                                    isError = true,
-                                    timeStamp = System.nanoTime(),
+                    when (result) {
+                        is DataState.Loading -> {
+                            breadcrumb(
+                                message = "consent_request_state",
+                                attributes = mapOf(
+                                    ExtraKeys.HOST to host.activity::class.java.name,
+                                    ExtraKeys.STAGE to "loading"
                                 )
                             )
                         }
+
+                        is DataState.Success -> {
+                            breadcrumb(
+                                message = "consent_request_state",
+                                attributes = mapOf(
+                                    ExtraKeys.HOST to host.activity::class.java.name,
+                                    ExtraKeys.STAGE to "success"
+                                )
+                            )
+                        }
+
+                        is DataState.Error -> {
+                            breadcrumb(
+                                message = "consent_request_state",
+                                attributes = mapOf(
+                                    ExtraKeys.HOST to host.activity::class.java.name,
+                                    ExtraKeys.STAGE to "error",
+                                    ExtraKeys.ERROR to result.error.name
+                                )
+                            )
+                            result.onFailure { error ->
+                                updateStateThreadSafe {
+                                    screenState.showSnackbar(
+                                        UiSnackbar(
+                                            type = ScreenMessageType.SNACKBAR,
+                                            message = error.asUiText(),
+                                            isError = true,
+                                            timeStamp = System.nanoTime(),
+                                        )
+                                    )
+                                }
+                            }
+                        }
                     }
+                }
+                .onCompletion {
+                    isConsentRequestInProgress = false
                 }
                 .catchReport(
                     action = Actions.REQUEST_CONSENT,
@@ -224,5 +273,8 @@ class MainViewModel(
 
     private object ExtraKeys {
         const val HOST: String = "host"
+        const val STAGE: String = "stage"
+        const val ERROR: String = "error"
+        const val REASON: String = "reason"
     }
 }

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/contract/MainEvent.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/contract/MainEvent.kt
@@ -23,6 +23,7 @@ import com.d4rk.android.libs.apptoolkit.app.review.domain.model.ReviewHost
 import com.d4rk.android.libs.apptoolkit.core.ui.base.handling.UiEvent
 
 sealed interface MainEvent : UiEvent {
+    data object ApplyInitialConsent : MainEvent
     data object LoadNavigation : MainEvent
     data class RequestConsent(val host: ConsentHost) : MainEvent
     data class RequestReview(val host: ReviewHost) : MainEvent

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/app/modules/AppModule.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/app/modules/AppModule.kt
@@ -46,6 +46,7 @@ val appModule: Module = module {
     viewModel {
         MainViewModel(
             getNavigationDrawerItemsUseCase = get(),
+            applyInitialConsentUseCase = get(),
             requestConsentUseCase = get(),
             requestInAppReviewUseCase = get<RequestInAppReviewUseCase>(),
             requestInAppUpdateUseCase = get<RequestInAppUpdateUseCase>(),

--- a/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainViewModelTest.kt
+++ b/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainViewModelTest.kt
@@ -22,6 +22,7 @@ import app.cash.turbine.test
 import com.d4rk.android.apps.apptoolkit.app.core.utils.dispatchers.StandardDispatcherExtension
 import com.d4rk.android.apps.apptoolkit.app.core.utils.dispatchers.TestDispatchers
 import com.d4rk.android.apps.apptoolkit.app.main.domain.usecases.GetNavigationDrawerItemsUseCase
+import com.d4rk.android.apps.apptoolkit.app.main.ui.contract.MainEvent
 import com.d4rk.android.apps.apptoolkit.app.main.ui.state.MainUiState
 import com.d4rk.android.libs.apptoolkit.app.consent.domain.model.ConsentHost
 import com.d4rk.android.libs.apptoolkit.app.consent.domain.model.ConsentSettings
@@ -40,6 +41,7 @@ import io.mockk.mockk
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -223,6 +225,41 @@ class MainViewModelTest {
         assertEquals(1, repo.callCount)
     }
 
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `requestConsent skips overlapping calls while one is in progress`() =
+        runTest(dispatcherExtension.testDispatcher) {
+            val firebaseController = mockk<FirebaseController>(relaxed = true)
+            val consentRepository = CountingConsentRepository(
+                upstream = MutableSharedFlow(extraBufferCapacity = 2).apply {
+                    tryEmit(DataState.Loading())
+                }
+            )
+
+            val viewModel = MainViewModel(
+                getNavigationDrawerItemsUseCase = GetNavigationDrawerItemsUseCase(
+                    navigationRepository = FakeNavigationRepository(flowOf(emptyList())),
+                    firebaseController = firebaseController
+                ),
+                requestConsentUseCase = RequestConsentUseCase(
+                    repository = consentRepository,
+                    firebaseController = firebaseController
+                ),
+                requestInAppReviewUseCase = mockk(relaxed = true),
+                requestInAppUpdateUseCase = mockk(relaxed = true),
+                firebaseController = firebaseController,
+                dispatchers = TestDispatchers(dispatcherExtension.testDispatcher),
+            )
+
+            val host = ConsentHost(activity = mockk(relaxed = true))
+            viewModel.onEvent(MainEvent.RequestConsent(host = host))
+            viewModel.onEvent(MainEvent.RequestConsent(host = host))
+
+            runCurrent()
+
+            assertEquals(1, consentRepository.callCount)
+        }
+
     private class FakeNavigationRepository(
         private val upstream: Flow<List<NavigationDrawerItem>>
     ) : NavigationRepository {
@@ -250,6 +287,25 @@ private class FakeConsentRepository : ConsentRepository {
         host: ConsentHost,
         showIfRequired: Boolean,
     ) = flowOf(DataState.Success<Unit, Errors.UseCase>(Unit))
+
+    override suspend fun applyInitialConsent() = Unit
+
+    override suspend fun applyConsentSettings(settings: ConsentSettings) = Unit
+}
+
+private class CountingConsentRepository(
+    private val upstream: Flow<DataState<Unit, Errors.UseCase>>,
+) : ConsentRepository {
+    var callCount: Int = 0
+        private set
+
+    override fun requestConsent(
+        host: ConsentHost,
+        showIfRequired: Boolean,
+    ): Flow<DataState<Unit, Errors.UseCase>> {
+        callCount++
+        return upstream
+    }
 
     override suspend fun applyInitialConsent() = Unit
 

--- a/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainViewModelTest.kt
+++ b/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainViewModelTest.kt
@@ -27,6 +27,7 @@ import com.d4rk.android.apps.apptoolkit.app.main.ui.state.MainUiState
 import com.d4rk.android.libs.apptoolkit.app.consent.domain.model.ConsentHost
 import com.d4rk.android.libs.apptoolkit.app.consent.domain.model.ConsentSettings
 import com.d4rk.android.libs.apptoolkit.app.consent.domain.repository.ConsentRepository
+import com.d4rk.android.libs.apptoolkit.app.consent.domain.usecases.ApplyInitialConsentUseCase
 import com.d4rk.android.libs.apptoolkit.app.consent.domain.usecases.RequestConsentUseCase
 import com.d4rk.android.libs.apptoolkit.app.main.domain.repository.NavigationRepository
 import com.d4rk.android.libs.apptoolkit.core.domain.model.network.DataState
@@ -37,6 +38,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.state.ScreenState
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.core.utils.platform.UiTextHelper
 import io.mockk.clearAllMocks
+import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.ExperimentalCoroutinesApi
@@ -86,6 +88,7 @@ class MainViewModelTest {
 
         MainViewModel(
             getNavigationDrawerItemsUseCase = useCase,
+            applyInitialConsentUseCase = mockk<ApplyInitialConsentUseCase>(relaxed = true),
             requestConsentUseCase = RequestConsentUseCase(
                 repository = FakeConsentRepository(),
                 firebaseController = mockk<FirebaseController>(relaxed = true)
@@ -100,6 +103,33 @@ class MainViewModelTest {
         advanceUntilIdle()
 
         assertEquals(1, repo.callCount)
+    }
+
+    @OptIn(ExperimentalCoroutinesApi::class)
+    @Test
+    fun `initialization applies persisted consent once`() = runTest(dispatcherExtension.testDispatcher) {
+        val applyInitialConsentUseCase = mockk<ApplyInitialConsentUseCase>(relaxed = true)
+
+        MainViewModel(
+            getNavigationDrawerItemsUseCase = GetNavigationDrawerItemsUseCase(
+                navigationRepository = FakeNavigationRepository(flowOf(emptyList())),
+                firebaseController = mockk(relaxed = true)
+            ),
+            applyInitialConsentUseCase = applyInitialConsentUseCase,
+            requestConsentUseCase = RequestConsentUseCase(
+                repository = FakeConsentRepository(),
+                firebaseController = mockk(relaxed = true)
+            ),
+            requestInAppReviewUseCase = mockk(relaxed = true),
+            requestInAppUpdateUseCase = mockk(relaxed = true),
+            firebaseController = mockk<FirebaseController>(relaxed = true),
+            dispatchers = TestDispatchers(testDispatcher = dispatcherExtension.testDispatcher),
+        )
+
+        runCurrent()
+        advanceUntilIdle()
+
+        coVerify(exactly = 1) { applyInitialConsentUseCase.invoke() }
     }
 
     @OptIn(ExperimentalCoroutinesApi::class)
@@ -121,6 +151,7 @@ class MainViewModelTest {
 
             val viewModel = MainViewModel(
                 getNavigationDrawerItemsUseCase = useCase,
+                applyInitialConsentUseCase = mockk<ApplyInitialConsentUseCase>(relaxed = true),
                 requestConsentUseCase = RequestConsentUseCase(
                     FakeConsentRepository(),
                     firebaseController
@@ -150,6 +181,7 @@ class MainViewModelTest {
 
         val viewModel = MainViewModel(
             getNavigationDrawerItemsUseCase = useCase,
+            applyInitialConsentUseCase = mockk<ApplyInitialConsentUseCase>(relaxed = true),
             requestConsentUseCase = RequestConsentUseCase(
                 FakeConsentRepository(),
                 firebaseController
@@ -197,6 +229,7 @@ class MainViewModelTest {
 
         val viewModel = MainViewModel(
             getNavigationDrawerItemsUseCase = useCase,
+            applyInitialConsentUseCase = mockk<ApplyInitialConsentUseCase>(relaxed = true),
             requestConsentUseCase = RequestConsentUseCase(
                 FakeConsentRepository(),
                 firebaseController
@@ -241,6 +274,7 @@ class MainViewModelTest {
                     navigationRepository = FakeNavigationRepository(flowOf(emptyList())),
                     firebaseController = firebaseController
                 ),
+                applyInitialConsentUseCase = mockk<ApplyInitialConsentUseCase>(relaxed = true),
                 requestConsentUseCase = RequestConsentUseCase(
                     repository = consentRepository,
                     firebaseController = firebaseController

--- a/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainViewModelTest.kt
+++ b/app/src/test/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainViewModelTest.kt
@@ -42,8 +42,8 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -264,8 +264,9 @@ class MainViewModelTest {
         runTest(dispatcherExtension.testDispatcher) {
             val firebaseController = mockk<FirebaseController>(relaxed = true)
             val consentRepository = CountingConsentRepository(
-                upstream = MutableSharedFlow(extraBufferCapacity = 2).apply {
-                    tryEmit(DataState.Loading())
+                upstream = flow {
+                    emit(DataState.Loading<Unit, Errors.UseCase>())
+                    awaitCancellation()
                 }
             )
 
@@ -285,7 +286,9 @@ class MainViewModelTest {
                 dispatchers = TestDispatchers(dispatcherExtension.testDispatcher),
             )
 
-            val host = ConsentHost(activity = mockk(relaxed = true))
+            val host = object : ConsentHost {
+                override val activity = mockk<android.app.Activity>(relaxed = true)
+            }
             viewModel.onEvent(MainEvent.RequestConsent(host = host))
             viewModel.onEvent(MainEvent.RequestConsent(host = host))
 

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/consent/data/remote/datasource/UmpConsentRemoteDataSource.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/consent/data/remote/datasource/UmpConsentRemoteDataSource.kt
@@ -35,6 +35,16 @@ import kotlinx.coroutines.flow.callbackFlow
  */
 class UmpConsentRemoteDataSource : ConsentRemoteDataSource {
 
+    private companion object {
+        /**
+         * Canonical AdMob app id format used by UMP.
+         *
+         * Example: `ca-app-pub-3940256099942544~3347511713`
+         */
+        val AD_MOB_APP_ID_REGEX: Regex =
+            Regex(pattern = "^ca-app-pub-[0-9]{16}~[0-9]{10}$")
+    }
+
     override fun requestConsent(
         host: ConsentHost,
         showIfRequired: Boolean,
@@ -130,19 +140,23 @@ class UmpConsentRemoteDataSource : ConsentRemoteDataSource {
     /**
      * Builds the request parameters for UMP.
      *
-     * Change rationale: previously the AdMob app id was always passed to UMP. If the host app
-     * provided a blank or malformed id, the SDK could crash while parsing it. We now validate the
-     * id before setting it to avoid runtime exceptions while still allowing consent requests.
+     * Change rationale: we previously accepted any id prefixed with `ca-app-pub-`, which still
+     * allowed malformed values to reach UMP internals. Those malformed values can crash parsing in
+     * the consent SDK, so we now gate `setAdMobAppId` behind the canonical AdMob app id regex and
+     * skip invalid values safely.
      */
     private fun buildRequestParameters(activity: android.app.Activity): ConsentRequestParameters {
         val appId = activity.getString(R.string.ad_mob_app_id).trim()
         val builder = ConsentRequestParameters.Builder()
             .setTagForUnderAgeOfConsent(false)
 
-        if (appId.isNotBlank() && appId.startsWith("ca-app-pub-")) {
+        if (appId.matches(AD_MOB_APP_ID_REGEX)) {
             builder.setAdMobAppId(appId)
         } else {
-            Log.w(CONSENT_LOG_TAG, "Skipping AdMob app id because it is blank or malformed.")
+            Log.w(
+                CONSENT_LOG_TAG,
+                "Skipping AdMob app id because it does not match canonical format."
+            )
         }
 
         return builder.build()


### PR DESCRIPTION
### Motivation
- Crash reports showed a `NoSuchElementException` originating inside the consent SDK parser path, which can be triggered by malformed AdMob app id strings passed into UMP. 
- The goal is to avoid passing malformed host-provided `ad_mob_app_id` values into UMP internals so the consent flow remains resilient.

### Description
- Added a companion object with a canonical AdMob app id regex (`^ca-app-pub-[0-9]{16}~[0-9]{10}$`) to `UmpConsentRemoteDataSource` and used it to validate IDs before calling `setAdMobAppId`.
- Replaced the previous loose check (`startsWith("ca-app-pub-")`) with `appId.matches(AD_MOB_APP_ID_REGEX)` in `buildRequestParameters` so only correctly formatted IDs are applied.
- Updated KDoc to explain the change rationale and changed the warning log message to indicate the canonical format requirement.
- Behavior preserves the consent request flow by skipping invalid IDs and logging a warning instead of forwarding malformed values to UMP.

### Testing
- Attempted to run unit tests via `./gradlew :apptoolkit:testDebugUnitTest --tests "*ConsentRepositoryImplTest" --tests "*RequestConsentUseCaseTest" --tests "*ApplyInitialConsentUseCaseTest" --tests "*ApplyConsentSettingsUseCaseTest"`, but Gradle failed because the Android SDK location is not configured (`ANDROID_HOME` / `local.properties sdk.dir`).
- No other automated tests were executed in this environment due to the SDK configuration limitation.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d7a8cd8ab8832db7c8cf053af891cf)