### PR TITLE
Bump Netty buildscript constraints to 4.1.132.Final

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -33,16 +33,16 @@ buildscript {
             classpath("org.jdom:jdom2:2.0.6.1") {
                 because("Mitigates CVE-2021-33813 (XXE) from AGP transitive dependency chain")
             }
-            classpath("io.netty:netty-handler:4.1.129.Final") {
+            classpath("io.netty:netty-handler:4.1.132.Final") {
                 because("Mitigates known Netty handler vulnerabilities (native crash and SNI allocation DoS)")
             }
-            classpath("io.netty:netty-codec-http2:4.1.129.Final") {
-                because("Mitigates known HTTP/2 vulnerabilities, including Rapid Reset and MadeYouReset")
+            classpath("io.netty:netty-codec-http2:4.1.132.Final") {
+                because("Mitigates known HTTP/2 vulnerabilities, including Rapid Reset, MadeYouReset, and CONTINUATION flood DoS (CVE-2026-33871)")
             }
-            classpath("io.netty:netty-codec:4.1.129.Final") {
+            classpath("io.netty:netty-codec:4.1.132.Final") {
                 because("Mitigates Netty decoder DoS vulnerabilities (including CVE-2025-58057)")
             }
-            classpath("io.netty:netty-codec-http:4.1.129.Final") {
+            classpath("io.netty:netty-codec-http:4.1.132.Final") {
                 because("Mitigates CRLF injection/request smuggling vulnerability (CVE-2025-67735)")
             }
             classpath("org.bitbucket.b_c:jose4j:0.9.6") {


### PR DESCRIPTION
### Motivation
- Dependabot reported `io.netty:netty-codec-http2` versions < `4.1.132.Final` vulnerable to a CONTINUATION-frame flood DoS (CVE-2026-33871), and the project previously constrained Netty buildscript artifacts to `4.1.129.Final`, so bumping to `4.1.132.Final` ensures the buildscript resolves a patched Netty baseline and records the security rationale.

### Description
- Updated the root `build.gradle.kts` buildscript dependency constraints by bumping `io.netty:netty-handler`, `io.netty:netty-codec-http2`, `io.netty:netty-codec`, and `io.netty:netty-codec-http` from `4.1.129.Final` to `4.1.132.Final`, and expanded the `because(...)` text for `netty-codec-http2` to reference `CVE-2026-33871`.

### Testing
- Ran `./gradlew -q help` and `./gradlew buildEnvironment --no-daemon` successfully to verify Gradle and the buildscript dependency graph resolve with the updated constraints, and attempted `./gradlew dependencyInsight --configuration classpath --dependency io.netty:netty-codec-http2 --no-daemon` which failed because the root project does not expose a `classpath` configuration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69d624e6e5dc832d9362796f6a66d3ef)