### PR TITLE
Extract Ads Koin qualifier strings into shared `AdsQualifiers` constants

### DIFF
--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/ui/views/screens/AppsList.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/ui/views/screens/AppsList.kt
@@ -49,6 +49,7 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.coroutines.flow.distinctUntilChangedBy
 import kotlinx.coroutines.flow.filterNotNull
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ads.AdsQualifiers
 import org.koin.compose.koinInject
 import org.koin.core.qualifier.named
 
@@ -99,7 +100,7 @@ fun AppsList(
         buildAppListItems(apps, adsEnabled, adFrequency)
     }
 
-    val adsConfig: AdsConfig = koinInject(qualifier = named("apps_list_native_ad"))
+    val adsConfig: AdsConfig = koinInject(qualifier = named(AdsQualifiers.APPS_LIST_NATIVE_AD))
 
     AppsGrid(
         items = items,

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsScreen.kt
@@ -66,6 +66,7 @@ import kotlinx.collections.immutable.toImmutableSet
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ads.AdsQualifiers
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.qualifier.named
@@ -100,7 +101,7 @@ fun FavoriteAppsRoute(
     val context = LocalContext.current
     val adsEnabled = rememberAdsEnabled()
 
-    val appDetailsAdsConfig: AdsConfig = koinInject(qualifier = named("app_details_native_ad"))
+    val appDetailsAdsConfig: AdsConfig = koinInject(qualifier = named(AdsQualifiers.APP_DETAILS_NATIVE_AD))
     val dispatchers: DispatcherProvider = koinInject()
     val firebaseController: FirebaseController = koinInject()
 

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListScreen.kt
@@ -60,6 +60,7 @@ import kotlinx.collections.immutable.toImmutableSet
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ads.AdsQualifiers
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.qualifier.named
@@ -101,7 +102,7 @@ fun AppsListRoute(
     val context = LocalContext.current
     val adsEnabled = rememberAdsEnabled()
 
-    val appDetailsAdsConfig: AdsConfig = koinInject(qualifier = named("app_details_native_ad"))
+    val appDetailsAdsConfig: AdsConfig = koinInject(qualifier = named(AdsQualifiers.APP_DETAILS_NATIVE_AD))
     val dispatchers: DispatcherProvider = koinInject()
     val firebaseController: FirebaseController = koinInject()
 

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainScreen.kt
@@ -91,6 +91,7 @@ import kotlinx.collections.immutable.ImmutableList
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ads.AdsQualifiers
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.qualifier.named
@@ -214,7 +215,7 @@ fun MainScaffoldContent(
         },
         snackbarHost = { DefaultSnackbarHost(snackbarState = snackBarHostState) },
         bottomBar = {
-            val adsConfig: AdsConfig = koinInject(qualifier = named("bottom_nav_bar_native_ad"))
+            val adsConfig: AdsConfig = koinInject(qualifier = named(AdsQualifiers.BOTTOM_NAV_BAR_NATIVE_AD))
             HideOnScrollBottomBar(scrollBehavior = bottomAppBarScrollBehavior) {
                 BottomAppBarNativeAdBanner(
                     adUnitId = adsConfig.bannerAdUnitId

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/app/modules/AdsModule.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/app/modules/AdsModule.kt
@@ -25,6 +25,7 @@ import com.d4rk.android.libs.apptoolkit.app.ads.domain.usecases.SetAdsEnabledUse
 import com.d4rk.android.libs.apptoolkit.app.ads.ui.AdsSettingsViewModel
 import com.d4rk.android.libs.apptoolkit.app.settings.utils.providers.BuildInfoProvider
 import com.d4rk.android.libs.apptoolkit.core.ui.model.ads.AdsConfig
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ads.AdsQualifiers
 import com.google.android.libraries.ads.mobile.sdk.banner.AdSize
 import org.koin.core.module.Module
 import org.koin.core.module.dsl.viewModel
@@ -59,34 +60,34 @@ val adsModule: Module = module {
         )
     }
 
-    single<AdsConfig>(named(name = "native_ad")) {
+    single<AdsConfig>(named(name = AdsQualifiers.NATIVE_AD)) {
         AdsConfig(bannerAdUnitId = AdsConstants.NATIVE_AD_UNIT_ID)
     }
 
-    single<AdsConfig>(named(name = "apps_list_native_ad")) {
+    single<AdsConfig>(named(name = AdsQualifiers.APPS_LIST_NATIVE_AD)) {
         AdsConfig(bannerAdUnitId = AdsConstants.APPS_LIST_NATIVE_AD_UNIT_ID)
     }
 
-    single<AdsConfig>(named(name = "app_details_native_ad")) {
+    single<AdsConfig>(named(name = AdsQualifiers.APP_DETAILS_NATIVE_AD)) {
         AdsConfig(bannerAdUnitId = AdsConstants.APP_DETAILS_NATIVE_AD_UNIT_ID)
     }
 
-    single<AdsConfig>(named(name = "no_data_native_ad")) {
+    single<AdsConfig>(named(name = AdsQualifiers.NO_DATA_NATIVE_AD)) {
         AdsConfig(bannerAdUnitId = AdsConstants.NO_DATA_NATIVE_AD_UNIT_ID)
     }
 
-    single<AdsConfig>(named(name = "bottom_nav_bar_native_ad")) {
+    single<AdsConfig>(named(name = AdsQualifiers.BOTTOM_NAV_BAR_NATIVE_AD)) {
         AdsConfig(bannerAdUnitId = AdsConstants.BOTTOM_NAV_BAR_NATIVE_AD_UNIT_ID)
     }
 
-    single<AdsConfig>(named(name = "help_large_banner_ad")) {
+    single<AdsConfig>(named(name = AdsQualifiers.HELP_LARGE_BANNER_AD)) {
         AdsConfig(
             bannerAdUnitId = AdsConstants.HELP_NATIVE_AD_UNIT_ID,
             adSize = AdSize.LARGE_BANNER
         )
     }
 
-    single<AdsConfig>(named(name = "support_native_ad")) {
+    single<AdsConfig>(named(name = AdsQualifiers.SUPPORT_NATIVE_AD)) {
         AdsConfig(bannerAdUnitId = AdsConstants.SUPPORT_NATIVE_AD_UNIT_ID)
     }
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/help/ui/views/content/HelpScreenContent.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/help/ui/views/content/HelpScreenContent.kt
@@ -40,6 +40,7 @@ import com.d4rk.android.libs.apptoolkit.core.utils.constants.analytics.SettingsA
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.core.utils.extensions.context.sendEmailToDeveloper
 import kotlinx.collections.immutable.ImmutableList
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ads.AdsQualifiers
 import org.koin.compose.koinInject
 import org.koin.core.qualifier.named
 
@@ -50,7 +51,7 @@ fun HelpScreenContent(
 ) {
     val firebaseController: FirebaseController = koinInject()
     val context = LocalContext.current
-    val adsConfig: AdsConfig = koinInject(qualifier = named("help_large_banner_ad"))
+    val adsConfig: AdsConfig = koinInject(qualifier = named(AdsQualifiers.HELP_LARGE_BANNER_AD))
 
     LazyColumn(
         modifier = Modifier.fillMaxSize(),

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportScreen.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/support/ui/SupportScreen.kt
@@ -71,6 +71,7 @@ import com.d4rk.android.libs.apptoolkit.core.utils.constants.analytics.SettingsA
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.core.utils.extensions.context.openUrl
 import kotlinx.collections.immutable.ImmutableMap
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ads.AdsQualifiers
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.qualifier.named
@@ -175,7 +176,7 @@ fun SupportScreenContent(
     onDonateClick: (String) -> Unit,
 ) {
     val context: Context = LocalContext.current
-    val nativeAdsConfig: AdsConfig = koinInject(qualifier = named(name = "support_native_ad"))
+    val nativeAdsConfig: AdsConfig = koinInject(qualifier = named(name = AdsQualifiers.SUPPORT_NATIVE_AD))
 
     LazyColumn(
         modifier = Modifier.padding(paddingValues),

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/layouts/NoDataScreen.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/layouts/NoDataScreen.kt
@@ -47,6 +47,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.views.ads.NoDataNativeAdCard
 import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.GeneralButton
 import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.LargeVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ads.AdsQualifiers
 import org.koin.compose.koinInject
 import org.koin.core.qualifier.named
 
@@ -78,7 +79,7 @@ fun NoDataScreen(
     paddingValues: PaddingValues = PaddingValues(),
 ) {
     val adUnitId = koinInject<AdsConfig>(
-        qualifier = named(name = "no_data_native_ad")
+        qualifier = named(name = AdsQualifiers.NO_DATA_NATIVE_AD)
     ).bannerAdUnitId
     Column(
         modifier = Modifier

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/utils/constants/ads/AdsQualifiers.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/utils/constants/ads/AdsQualifiers.kt
@@ -1,0 +1,32 @@
+/*
+ * Copyright (©) 2026 Mihai-Cristian Condrea
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.d4rk.android.libs.apptoolkit.core.utils.constants.ads
+
+/**
+ * Koin qualifier names used for [com.d4rk.android.libs.apptoolkit.core.ui.model.ads.AdsConfig]
+ * bindings.
+ */
+object AdsQualifiers {
+    const val NATIVE_AD: String = "native_ad"
+    const val APPS_LIST_NATIVE_AD: String = "apps_list_native_ad"
+    const val APP_DETAILS_NATIVE_AD: String = "app_details_native_ad"
+    const val NO_DATA_NATIVE_AD: String = "no_data_native_ad"
+    const val BOTTOM_NAV_BAR_NATIVE_AD: String = "bottom_nav_bar_native_ad"
+    const val HELP_LARGE_BANNER_AD: String = "help_large_banner_ad"
+    const val SUPPORT_NATIVE_AD: String = "support_native_ad"
+}


### PR DESCRIPTION
### Motivation
- Ad DI qualifier names were duplicated as raw string literals across app and library modules, increasing risk of typos and making refactors harder.  
- Centralizing these names into constants improves maintainability and ensures bindings and consumers stay in sync at compile time.

### Description
- Added `apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/utils/constants/ads/AdsQualifiers.kt` providing constants such as `NATIVE_AD`, `APPS_LIST_NATIVE_AD`, `APP_DETAILS_NATIVE_AD`, `NO_DATA_NATIVE_AD`, `BOTTOM_NAV_BAR_NATIVE_AD`, `HELP_LARGE_BANNER_AD`, and `SUPPORT_NATIVE_AD` for Koin qualifiers.  
- Updated the DI registrations in `app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/app/modules/AdsModule.kt` to use `AdsQualifiers.*` instead of hardcoded strings.  
- Replaced hardcoded qualifier strings at injection sites to use `AdsQualifiers.*` in the following files: `AppsList.kt`, `AppsListScreen.kt`, `FavoriteAppsScreen.kt`, `MainScreen.kt`, `HelpScreenContent.kt`, `SupportScreen.kt`, and `NoDataScreen.kt`.  
- Change rationale: previously qualifiers were string literals in multiple places which could diverge silently, so consolidating to `AdsQualifiers` reduces duplication, prevents typos, and makes future renames straightforward.

### Testing
- Ran a repository search to verify all known injection sites now reference `AdsQualifiers.*`, and the replacements were found in the expected files (success).  
- Attempted an automated Kotlin build with `./gradlew :app:compileDebugKotlin`, which failed due to the environment lacking an Android SDK location (missing `ANDROID_HOME` or `local.properties`), so a full compile could not be completed in this environment (failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1c4e062c4832d9b8c608fd16eb5e2)