### PR TITLE
Add missing AdSize banner qualifiers to AdsQualifiers

### DIFF
--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/utils/constants/ads/AdsQualifiers.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/utils/constants/ads/AdsQualifiers.kt
@@ -22,7 +22,13 @@ package com.d4rk.android.libs.apptoolkit.core.utils.constants.ads
  * bindings.
  */
 object AdsQualifiers {
-    // TODO: Add the qualifiers for normal ad banner, medium ad rectangle, full banner, and all type of default ads
+    const val BANNER_AD: String = "banner_ad"
+    const val LARGE_BANNER_AD: String = "large_banner_ad"
+    const val MEDIUM_RECTANGLE_AD: String = "medium_rectangle_ad"
+    const val FULL_BANNER_AD: String = "full_banner_ad"
+    const val LEADERBOARD_AD: String = "leaderboard_ad"
+    const val FLUID_AD: String = "fluid_ad"
+
     const val NATIVE_AD: String = "native_ad"
     const val APPS_LIST_NATIVE_AD: String = "apps_list_native_ad" // TODO: Move to app module
     const val APP_DETAILS_NATIVE_AD: String = "app_details_native_ad" // TODO: Move to app module


### PR DESCRIPTION
### Motivation
- Provide explicit Koin qualifier names for the various `AdSize` banner types so `AdsConfig` registrations can be wired consistently for other banner/ad formats.

### Description
- Added banner-related qualifier constants to `AdsQualifiers` (`BANNER_AD`, `LARGE_BANNER_AD`, `MEDIUM_RECTANGLE_AD`, `FULL_BANNER_AD`, `LEADERBOARD_AD`, `FLUID_AD`) in `apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/utils/constants/ads/AdsQualifiers.kt`.

### Testing
- Ran `./gradlew :apptoolkit:compileDebugKotlin`, which could not complete in this environment because the Android SDK location is not configured (missing `ANDROID_HOME`/`sdk.dir`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e1d0a79cf0832d855e5a7c5b68a869)