### PR TITLE
Add DI lifetime policy and switch GeneralSettingsContentProvider to factory

### DIFF
--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/settings/modules/GeneralSettingsModule.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/core/di/modules/settings/modules/GeneralSettingsModule.kt
@@ -46,7 +46,9 @@ val generalSettingsModule: Module = module {
         )
     }
     single<UnlockComponentsShowcaseUseCase> { UnlockComponentsShowcaseUseCase(dataStore = get()) }
-    single<GeneralSettingsContentProvider> {
+    // Keep as factory: this provider carries composable content lambdas and should stay short-lived
+    // to avoid accidental capture of screen-scoped references in global state.
+    factory<GeneralSettingsContentProvider> {
         GeneralSettingsContentProvider(
             aboutContent = { paddingValues, snackbarHostState ->
                 AppAboutSettingsContent(

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/di/modules/AppToolkitFeatureModules.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/di/modules/AppToolkitFeatureModules.kt
@@ -77,6 +77,13 @@ fun appToolkitFeatureModules(
     reviewModule(),
 )
 
+/**
+ * DI lifetime checklist (see docs/apptoolkit/core/di-lifetime-policy.md):
+ * - Use `single` for heavy/stateful managers (billing, datastore, network clients).
+ * - Use `factory` for lightweight builders or objects that may later capture Activity/screen refs.
+ * - Keep `viewModel` bindings unchanged because lifecycle is managed by Koin ViewModel DSL.
+ * - Add one-line rationale for non-obvious bindings, especially `*Factory` types.
+ */
 private fun appToolkitCoreModule(
     hostBuildConfig: AppToolkitHostBuildConfig,
     startupProviderFactory: () -> StartupProvider,
@@ -95,7 +102,7 @@ private fun appToolkitCoreModule(
 }
 
 private fun supportModule(): Module = module {
-    single<BillingRepository>(createdAtStart = true) {
+    single<BillingRepository>(createdAtStart = true) { // Heavy stateful billing manager with long-lived scope; eager init avoids purchase flow lag.
         val dispatchers = get<DispatcherProvider>()
         BillingRepository.getInstance(
             context = get(),

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/di/modules/AppToolkitFoundationModules.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/di/modules/AppToolkitFoundationModules.kt
@@ -66,6 +66,13 @@ fun appToolkitFoundationModules(hostBuildConfig: AppToolkitHostBuildConfig): Lis
     adsSettingsSharedModule(),
 )
 
+/**
+ * DI lifetime checklist (see docs/apptoolkit/core/di-lifetime-policy.md):
+ * - Use `single` for heavy/stateful managers (datastore, ads manager, network clients).
+ * - Use `factory` for lightweight builders or objects that may later capture Activity/screen refs.
+ * - Keep `viewModel` bindings unchanged because lifecycle is managed by Koin ViewModel DSL.
+ * - Add one-line rationale for non-obvious bindings, especially `*Factory` types.
+ */
 private fun dispatchersModule(): Module = module {
     single<DispatcherProvider> { StandardDispatchers() }
 }
@@ -114,7 +121,7 @@ private fun consentModule(): Module = module {
 }
 
 private fun mainSharedModule(hostBuildConfig: AppToolkitHostBuildConfig): Module = module {
-    single { GmsHostFactory() }
+    single { GmsHostFactory() } // Lightweight creator without screen references; safe as singleton.
     single<InAppUpdateRepository> { InAppUpdateRepositoryImpl() }
     single { RequestInAppUpdateUseCase(repository = get()) }
     single<String>(qualifier = named(name = AppToolkitDiConstants.DEVELOPER_APPS_API_URL)) {

--- a/docs/apptoolkit/core/di-lifetime-policy.md
+++ b/docs/apptoolkit/core/di-lifetime-policy.md
@@ -1,0 +1,32 @@
+# DI Lifetime Policy (Koin)
+
+This policy defines when App Toolkit bindings should use `single` vs `factory`.
+
+## Use cases
+
+1. **Default to `single` for stateless use cases** that only delegate to repositories/services and keep no mutable execution state.
+2. Use `factory` **only** when a use case keeps mutable execution state, per-screen/per-request caches, host objects, or cancellation handles.
+
+### Current examples
+
+- `FetchDeveloperAppsUseCase` is a good `single` example because it is a stateless repository wrapper.
+- `ObserveFavoritesUseCase`, `ToggleFavoriteUseCase`, `GetFaqUseCase`, and `RequestInAppReviewUseCase` follow the same pattern and should remain `single`.
+
+### Anti-examples for future contributors
+
+Prefer `factory` if a use case:
+
+- stores mutable properties between executions,
+- owns request-specific resources (e.g., per-screen host/controller),
+- retains cancellable jobs/handles that should not leak across screens.
+
+## Services, managers, and factories
+
+- Use `single` for heavy/stateful managers (for example `BillingRepository`, datastore, network clients).
+- Use `factory` for lightweight creators or providers that may later capture Activity/screen references (for example UI content providers with composable lambdas).
+- Keep `viewModel` bindings as `viewModel { ... }`.
+
+## Related bindings in this repo
+
+- `GeneralSettingsContentProvider` should remain `factory` because it carries UI content lambdas and is safer as short-lived.
+- `GmsHostFactory` is currently `single` because it is a lightweight creator without screen-scoped capture.


### PR DESCRIPTION
### Motivation
- Make DI lifetimes explicit to avoid accidental retention of screen-scoped objects by long-lived singletons. 
- Reduce future risk from UI-producing providers (composable lambdas) being registered as `single`. 
- Provide maintainers a concise, local policy for choosing `single` vs `factory` when editing Koin modules. 

### Description
- Change `GeneralSettingsContentProvider` binding from `single` to `factory` in `app/src/main/kotlin/.../GeneralSettingsModule.kt` and add an inline rationale comment, keeping constructor arguments unchanged. 
- Add a new policy doc at `docs/apptoolkit/core/di-lifetime-policy.md` that defines when to use `single` vs `factory`, includes examples (`FetchDeveloperAppsUseCase`, favorites/help/review use cases) and anti-examples. 
- Insert DI lifetime checklist KDoc in `apptoolkit/src/main/kotlin/.../AppToolkitFoundationModules.kt` and `apptoolkit/src/main/kotlin/.../AppToolkitFeatureModules.kt`, and add one-line rationales for the `GmsHostFactory` singleton and the eager `BillingRepository` singleton. 

### Testing
- Ran `./gradlew :app:compileDebugKotlin :apptoolkit:compileDebugKotlin` to validate Kotlin compilation, which failed due to missing Android SDK configuration (`ANDROID_HOME` / `local.properties`), so compilation could not be verified here (failure).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1f5b28918832d803baafb9a1596f2)