### PR TITLE
Introduce grouped preference component and adaptive shapes

### DIFF
--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsScreen.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsScreen.kt
@@ -79,7 +79,6 @@ import com.d4rk.android.libs.apptoolkit.core.ui.views.navigation.LargeTopAppBarW
 import com.d4rk.android.libs.apptoolkit.core.ui.views.preferences.GroupedItemPosition
 import com.d4rk.android.libs.apptoolkit.core.ui.views.preferences.SettingsPreferenceItem
 import com.d4rk.android.libs.apptoolkit.core.ui.views.preferences.groupedCorners
-import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.ExtraTinyVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.LargeVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.SmallVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.ui.window.AppWindowWidthSizeClass
@@ -354,11 +353,7 @@ fun SettingsList(
         settingsConfig.categories.forEach { category: SettingsCategory ->
             item {
                 LargeVerticalSpacer()
-                Column(
-                    modifier = Modifier
-                        .padding(horizontal = SizeConstants.LargeSize),
-                ) {
-                    category.preferences.forEachIndexed { index: Int, preference: SettingsPreference ->
+                category.preferences.forEachIndexed { index: Int, preference: SettingsPreference ->
                         val position = when {
                             category.preferences.size == 1 -> GroupedItemPosition.SINGLE
                             index == 0 -> GroupedItemPosition.FIRST
@@ -384,11 +379,11 @@ fun SettingsList(
                                 )
                             },
                             onClick = { onPreferenceClick(preference) },
-                            modifier = Modifier.groupedCorners(position = position),
+                            modifier = Modifier
+                                .padding(horizontal = SizeConstants.LargeSize)
+                                .groupedCorners(position = position),
                         )
-                        if (index != category.preferences.lastIndex) ExtraTinyVerticalSpacer()
                     }
-                }
             }
         }
     }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsScreen.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsScreen.kt
@@ -360,6 +360,23 @@ fun SettingsList(
                             index == category.preferences.lastIndex -> GroupedItemPosition.LAST
                             else -> GroupedItemPosition.MIDDLE
                         }
+                        val itemModifier = Modifier
+                            .padding(
+                                start = SizeConstants.LargeSize,
+                                end = SizeConstants.LargeSize,
+                                top = if (position == GroupedItemPosition.SINGLE) {
+                                    SizeConstants.ExtraTinySize
+                                } else {
+                                    SizeConstants.ZeroSize
+                                },
+                                bottom = if (position == GroupedItemPosition.SINGLE) {
+                                    SizeConstants.ExtraTinySize
+                                } else {
+                                    SizeConstants.ZeroSize
+                                },
+                            )
+                            .groupedCorners(position = position)
+
                         SettingsPreferenceItem(
                             icon = preference.icon,
                             title = preference.title,
@@ -379,9 +396,7 @@ fun SettingsList(
                                 )
                             },
                             onClick = { onPreferenceClick(preference) },
-                            modifier = Modifier
-                                .padding(horizontal = SizeConstants.LargeSize)
-                                .groupedCorners(position = position),
+                            modifier = itemModifier,
                         )
                     }
             }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsScreen.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsScreen.kt
@@ -31,6 +31,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ContactSupport
 import androidx.compose.material.icons.outlined.Settings

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsScreen.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsScreen.kt
@@ -76,7 +76,6 @@ import com.d4rk.android.libs.apptoolkit.core.ui.views.layouts.ScreenStateHandler
 import com.d4rk.android.libs.apptoolkit.core.ui.views.layouts.TrackScreenState
 import com.d4rk.android.libs.apptoolkit.core.ui.views.layouts.TrackScreenView
 import com.d4rk.android.libs.apptoolkit.core.ui.views.navigation.LargeTopAppBarWithScaffold
-import com.d4rk.android.libs.apptoolkit.core.ui.views.preferences.GroupedItemPosition
 import com.d4rk.android.libs.apptoolkit.core.ui.views.preferences.SettingsPreferenceItem
 import com.d4rk.android.libs.apptoolkit.core.ui.views.preferences.groupedItemPosition
 import com.d4rk.android.libs.apptoolkit.core.ui.views.preferences.groupedPreferenceItem
@@ -355,34 +354,33 @@ fun SettingsList(
             item {
                 LargeVerticalSpacer()
                 category.preferences.forEachIndexed { index: Int, preference: SettingsPreference ->
-                        val position = groupedItemPosition(
-                            index = index,
-                            size = category.preferences.size,
-                        )
-                        val itemModifier = Modifier.groupedPreferenceItem(position = position)
-
-                        SettingsPreferenceItem(
-                            icon = preference.icon,
-                            title = preference.title,
-                            summary = preference.summary,
-                            firebaseController = firebaseController,
-                            ga4EventProvider = {
-                                Ga4EventData(
-                                    name = SettingsAnalytics.Events.PREFERENCE_VIEW,
-                                    params = mapOf(
-                                        SettingsAnalytics.Params.SCREEN to AnalyticsValue.Str(
-                                            SETTINGS_SCREEN_NAME
-                                        ),
-                                        SettingsAnalytics.Params.PREFERENCE_KEY to AnalyticsValue.Str(
-                                            preference.key ?: UNKNOWN_PREFERENCE_KEY
-                                        ),
+                    SettingsPreferenceItem(
+                        icon = preference.icon,
+                        title = preference.title,
+                        summary = preference.summary,
+                        firebaseController = firebaseController,
+                        ga4EventProvider = {
+                            Ga4EventData(
+                                name = SettingsAnalytics.Events.PREFERENCE_VIEW,
+                                params = mapOf(
+                                    SettingsAnalytics.Params.SCREEN to AnalyticsValue.Str(
+                                        SETTINGS_SCREEN_NAME
                                     ),
-                                )
-                            },
-                            onClick = { onPreferenceClick(preference) },
-                            modifier = itemModifier,
-                        )
-                    }
+                                    SettingsAnalytics.Params.PREFERENCE_KEY to AnalyticsValue.Str(
+                                        preference.key ?: UNKNOWN_PREFERENCE_KEY
+                                    ),
+                                ),
+                            )
+                        },
+                        onClick = { onPreferenceClick(preference) },
+                        modifier = Modifier.groupedPreferenceItem(
+                            position = groupedItemPosition(
+                                index = index,
+                                size = category.preferences.size
+                            )
+                        ),
+                    )
+                }
             }
         }
     }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsScreen.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsScreen.kt
@@ -78,7 +78,8 @@ import com.d4rk.android.libs.apptoolkit.core.ui.views.layouts.TrackScreenView
 import com.d4rk.android.libs.apptoolkit.core.ui.views.navigation.LargeTopAppBarWithScaffold
 import com.d4rk.android.libs.apptoolkit.core.ui.views.preferences.GroupedItemPosition
 import com.d4rk.android.libs.apptoolkit.core.ui.views.preferences.SettingsPreferenceItem
-import com.d4rk.android.libs.apptoolkit.core.ui.views.preferences.groupedCorners
+import com.d4rk.android.libs.apptoolkit.core.ui.views.preferences.groupedItemPosition
+import com.d4rk.android.libs.apptoolkit.core.ui.views.preferences.groupedPreferenceItem
 import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.LargeVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.SmallVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.ui.window.AppWindowWidthSizeClass
@@ -354,28 +355,11 @@ fun SettingsList(
             item {
                 LargeVerticalSpacer()
                 category.preferences.forEachIndexed { index: Int, preference: SettingsPreference ->
-                        val position = when {
-                            category.preferences.size == 1 -> GroupedItemPosition.SINGLE
-                            index == 0 -> GroupedItemPosition.FIRST
-                            index == category.preferences.lastIndex -> GroupedItemPosition.LAST
-                            else -> GroupedItemPosition.MIDDLE
-                        }
-                        val itemModifier = Modifier
-                            .padding(
-                                start = SizeConstants.LargeSize,
-                                end = SizeConstants.LargeSize,
-                                top = if (position == GroupedItemPosition.SINGLE) {
-                                    SizeConstants.ExtraTinySize
-                                } else {
-                                    SizeConstants.ZeroSize
-                                },
-                                bottom = if (position == GroupedItemPosition.SINGLE) {
-                                    SizeConstants.ExtraTinySize
-                                } else {
-                                    SizeConstants.ZeroSize
-                                },
-                            )
-                            .groupedCorners(position = position)
+                        val position = groupedItemPosition(
+                            index = index,
+                            size = category.preferences.size,
+                        )
+                        val itemModifier = Modifier.groupedPreferenceItem(position = position)
 
                         SettingsPreferenceItem(
                             icon = preference.icon,

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsScreen.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsScreen.kt
@@ -76,9 +76,8 @@ import com.d4rk.android.libs.apptoolkit.core.ui.views.layouts.TrackScreenState
 import com.d4rk.android.libs.apptoolkit.core.ui.views.layouts.TrackScreenView
 import com.d4rk.android.libs.apptoolkit.core.ui.views.navigation.LargeTopAppBarWithScaffold
 import com.d4rk.android.libs.apptoolkit.core.ui.views.preferences.GroupedItemPosition
-import com.d4rk.android.libs.apptoolkit.core.ui.views.preferences.GroupedPreferenceColumn
 import com.d4rk.android.libs.apptoolkit.core.ui.views.preferences.SettingsPreferenceItem
-import com.d4rk.android.libs.apptoolkit.core.ui.views.preferences.groupedItemShape
+import com.d4rk.android.libs.apptoolkit.core.ui.views.preferences.groupedCorners
 import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.ExtraTinyVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.LargeVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.SmallVerticalSpacer
@@ -354,7 +353,10 @@ fun SettingsList(
         settingsConfig.categories.forEach { category: SettingsCategory ->
             item {
                 LargeVerticalSpacer()
-                GroupedPreferenceColumn {
+                Column(
+                    modifier = Modifier
+                        .padding(horizontal = SizeConstants.LargeSize),
+                ) {
                     category.preferences.forEachIndexed { index: Int, preference: SettingsPreference ->
                         val position = when {
                             category.preferences.size == 1 -> GroupedItemPosition.SINGLE
@@ -381,7 +383,7 @@ fun SettingsList(
                                 )
                             },
                             onClick = { onPreferenceClick(preference) },
-                            shape = groupedItemShape(position = position),
+                            modifier = Modifier.groupedCorners(position = position),
                         )
                         if (index != category.preferences.lastIndex) ExtraTinyVerticalSpacer()
                     }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsScreen.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/app/settings/settings/ui/SettingsScreen.kt
@@ -31,7 +31,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.ContactSupport
 import androidx.compose.material.icons.outlined.Settings
@@ -49,7 +48,6 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.draw.clip
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
@@ -77,7 +75,10 @@ import com.d4rk.android.libs.apptoolkit.core.ui.views.layouts.ScreenStateHandler
 import com.d4rk.android.libs.apptoolkit.core.ui.views.layouts.TrackScreenState
 import com.d4rk.android.libs.apptoolkit.core.ui.views.layouts.TrackScreenView
 import com.d4rk.android.libs.apptoolkit.core.ui.views.navigation.LargeTopAppBarWithScaffold
+import com.d4rk.android.libs.apptoolkit.core.ui.views.preferences.GroupedItemPosition
+import com.d4rk.android.libs.apptoolkit.core.ui.views.preferences.GroupedPreferenceColumn
 import com.d4rk.android.libs.apptoolkit.core.ui.views.preferences.SettingsPreferenceItem
+import com.d4rk.android.libs.apptoolkit.core.ui.views.preferences.groupedItemShape
 import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.ExtraTinyVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.LargeVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.SmallVerticalSpacer
@@ -353,12 +354,14 @@ fun SettingsList(
         settingsConfig.categories.forEach { category: SettingsCategory ->
             item {
                 LargeVerticalSpacer()
-                Column(
-                    modifier = Modifier
-                        .padding(horizontal = SizeConstants.LargeSize)
-                        .clip(shape = RoundedCornerShape(size = SizeConstants.ExtraLargeSize)),
-                ) {
-                    category.preferences.forEach { preference: SettingsPreference ->
+                GroupedPreferenceColumn {
+                    category.preferences.forEachIndexed { index: Int, preference: SettingsPreference ->
+                        val position = when {
+                            category.preferences.size == 1 -> GroupedItemPosition.SINGLE
+                            index == 0 -> GroupedItemPosition.FIRST
+                            index == category.preferences.lastIndex -> GroupedItemPosition.LAST
+                            else -> GroupedItemPosition.MIDDLE
+                        }
                         SettingsPreferenceItem(
                             icon = preference.icon,
                             title = preference.title,
@@ -378,8 +381,9 @@ fun SettingsList(
                                 )
                             },
                             onClick = { onPreferenceClick(preference) },
+                            shape = groupedItemShape(position = position),
                         )
-                        ExtraTinyVerticalSpacer()
+                        if (index != category.preferences.lastIndex) ExtraTinyVerticalSpacer()
                     }
                 }
             }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/preferences/GroupedPreferenceColumn.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/preferences/GroupedPreferenceColumn.kt
@@ -1,0 +1,65 @@
+package com.d4rk.android.libs.apptoolkit.core.ui.views.preferences
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ColumnScope
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.unit.dp
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
+
+/**
+ * Position of a row inside a grouped preference container.
+ */
+enum class GroupedItemPosition {
+    FIRST, MIDDLE, LAST, SINGLE
+}
+
+/**
+ * Provides the adaptive shape used by grouped preference rows.
+ */
+fun groupedItemShape(
+    position: GroupedItemPosition,
+    outerRadiusDp: Int = 16,
+    innerRadiusDp: Int = 2,
+): Shape {
+    val outer = outerRadiusDp.dp
+    val inner = innerRadiusDp.dp
+    return when (position) {
+        GroupedItemPosition.FIRST -> RoundedCornerShape(
+            topStart = outer,
+            topEnd = outer,
+            bottomStart = inner,
+            bottomEnd = inner,
+        )
+
+        GroupedItemPosition.MIDDLE -> RoundedCornerShape(inner)
+        GroupedItemPosition.LAST -> RoundedCornerShape(
+            topStart = inner,
+            topEnd = inner,
+            bottomStart = outer,
+            bottomEnd = outer,
+        )
+
+        GroupedItemPosition.SINGLE -> RoundedCornerShape(outer)
+    }
+}
+
+/**
+ * Shared grouped container used by settings-style lists.
+ */
+@Composable
+fun GroupedPreferenceColumn(
+    modifier: Modifier = Modifier,
+    content: @Composable ColumnScope.() -> Unit,
+) {
+    Column(
+        modifier = modifier
+            .padding(horizontal = SizeConstants.LargeSize)
+            .background(shape = RoundedCornerShape(SizeConstants.ExtraLargeSize), color = androidx.compose.material3.MaterialTheme.colorScheme.surfaceContainerHigh),
+        content = content,
+    )
+}

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/preferences/GroupedPreferenceColumn.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/preferences/GroupedPreferenceColumn.kt
@@ -1,16 +1,30 @@
 package com.d4rk.android.libs.apptoolkit.core.ui.views.preferences
 
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 
 /**
  * Position of an item inside a grouped list.
  */
 enum class GroupedItemPosition {
     FIRST, MIDDLE, LAST, SINGLE
+}
+
+/**
+ * Returns the item position for an indexed list row.
+ */
+fun groupedItemPosition(index: Int, size: Int): GroupedItemPosition {
+    return when {
+        size <= 1 -> GroupedItemPosition.SINGLE
+        index == 0 -> GroupedItemPosition.FIRST
+        index == size - 1 -> GroupedItemPosition.LAST
+        else -> GroupedItemPosition.MIDDLE
+    }
 }
 
 /**
@@ -43,4 +57,28 @@ fun Modifier.groupedCorners(
         GroupedItemPosition.SINGLE -> RoundedCornerShape(outerRadius)
     }
     return this.clip(shape)
+}
+
+/**
+ * Applies standard grouped-list item spacing and grouped corners in one call.
+ */
+fun Modifier.groupedPreferenceItem(
+    position: GroupedItemPosition,
+    horizontalPadding: Dp = SizeConstants.LargeSize,
+    singleItemVerticalPadding: Dp = SizeConstants.ExtraTinySize,
+): Modifier {
+    val verticalPadding = if (position == GroupedItemPosition.SINGLE) {
+        singleItemVerticalPadding
+    } else {
+        SizeConstants.ZeroSize
+    }
+
+    return this
+        .padding(
+            start = horizontalPadding,
+            end = horizontalPadding,
+            top = verticalPadding,
+            bottom = verticalPadding,
+        )
+        .groupedCorners(position = position)
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/preferences/GroupedPreferenceColumn.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/preferences/GroupedPreferenceColumn.kt
@@ -1,65 +1,46 @@
 package com.d4rk.android.libs.apptoolkit.core.ui.views.preferences
 
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ColumnScope
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Shape
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 
 /**
- * Position of a row inside a grouped preference container.
+ * Position of an item inside a grouped list.
  */
 enum class GroupedItemPosition {
     FIRST, MIDDLE, LAST, SINGLE
 }
 
 /**
- * Provides the adaptive shape used by grouped preference rows.
+ * Clips an item with adaptive grouped-corner radii based on [position].
+ *
+ * Modifier ordering matters: apply this modifier before drawing modifiers like `background`
+ * so the drawn content respects the rounded clipping.
  */
-fun groupedItemShape(
+fun Modifier.groupedCorners(
     position: GroupedItemPosition,
-    outerRadiusDp: Int = 16,
-    innerRadiusDp: Int = 2,
-): Shape {
-    val outer = outerRadiusDp.dp
-    val inner = innerRadiusDp.dp
-    return when (position) {
+    outerRadius: Dp = 16.dp,
+    innerRadius: Dp = 2.dp,
+): Modifier {
+    val shape = when (position) {
         GroupedItemPosition.FIRST -> RoundedCornerShape(
-            topStart = outer,
-            topEnd = outer,
-            bottomStart = inner,
-            bottomEnd = inner,
+            topStart = outerRadius,
+            topEnd = outerRadius,
+            bottomStart = innerRadius,
+            bottomEnd = innerRadius,
         )
 
-        GroupedItemPosition.MIDDLE -> RoundedCornerShape(inner)
+        GroupedItemPosition.MIDDLE -> RoundedCornerShape(innerRadius)
         GroupedItemPosition.LAST -> RoundedCornerShape(
-            topStart = inner,
-            topEnd = inner,
-            bottomStart = outer,
-            bottomEnd = outer,
+            topStart = innerRadius,
+            topEnd = innerRadius,
+            bottomStart = outerRadius,
+            bottomEnd = outerRadius,
         )
 
-        GroupedItemPosition.SINGLE -> RoundedCornerShape(outer)
+        GroupedItemPosition.SINGLE -> RoundedCornerShape(outerRadius)
     }
-}
-
-/**
- * Shared grouped container used by settings-style lists.
- */
-@Composable
-fun GroupedPreferenceColumn(
-    modifier: Modifier = Modifier,
-    content: @Composable ColumnScope.() -> Unit,
-) {
-    Column(
-        modifier = modifier
-            .padding(horizontal = SizeConstants.LargeSize)
-            .background(shape = RoundedCornerShape(SizeConstants.ExtraLargeSize), color = androidx.compose.material3.MaterialTheme.colorScheme.surfaceContainerHigh),
-        content = content,
-    )
+    return this.clip(shape)
 }

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/preferences/PreferenceItem.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/preferences/PreferenceItem.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.Icon
+import androidx.compose.ui.graphics.RectangleShape
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -34,7 +35,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
@@ -148,17 +148,17 @@ fun SettingsPreferenceItem(
     icon: ImageVector? = null,
     title: String? = null,
     summary: String? = null,
+    modifier: Modifier = Modifier,
     rippleEffectDp: Dp = SizeConstants.ExtraTinySize,
-    shape: Shape = RoundedCornerShape(size = SizeConstants.ExtraTinySize),
     onClick: () -> Unit = {},
     firebaseController: FirebaseController? = null,
     ga4Event: Ga4EventData? = null,
     ga4EventProvider: (() -> Ga4EventData?)? = null,
 ) {
     Card(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth(),
-        shape = shape,
+        shape = RectangleShape,
     ) {
         PreferenceItem(
             rippleEffectDp = rippleEffectDp,

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/preferences/PreferenceItem.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/views/preferences/PreferenceItem.kt
@@ -34,6 +34,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.hapticfeedback.HapticFeedback
 import androidx.compose.ui.hapticfeedback.HapticFeedbackType
@@ -148,6 +149,7 @@ fun SettingsPreferenceItem(
     title: String? = null,
     summary: String? = null,
     rippleEffectDp: Dp = SizeConstants.ExtraTinySize,
+    shape: Shape = RoundedCornerShape(size = SizeConstants.ExtraTinySize),
     onClick: () -> Unit = {},
     firebaseController: FirebaseController? = null,
     ga4Event: Ga4EventData? = null,
@@ -156,7 +158,7 @@ fun SettingsPreferenceItem(
     Card(
         modifier = Modifier
             .fillMaxWidth(),
-        shape = RoundedCornerShape(size = SizeConstants.ExtraTinySize),
+        shape = shape,
     ) {
         PreferenceItem(
             rippleEffectDp = rippleEffectDp,


### PR DESCRIPTION
### Motivation
- Settings lists used small-radius cards nested inside a large-radius container, causing inconsistent corner rendering and breaking the grouped visual hierarchy.
- The change implements the correct inset-grouped approach where each row receives contextual radii (first/middle/last/single) so grouped lists look cohesive and align with Material-style grouping.

### Description
- Added `GroupedPreferenceColumn.kt` with `GroupedItemPosition`, `groupedItemShape(...)` and a `GroupedPreferenceColumn` composable that provides the shared grouped container and adaptive shape logic.
- Updated `SettingsPreferenceItem` in `PreferenceItem.kt` to accept a `shape: Shape` parameter and apply it to the wrapping `Card` so callers can set per-row shapes instead of nesting small cards.
- Refactored `SettingsScreen.kt` to use `GroupedPreferenceColumn`, map each preference to a `GroupedItemPosition`, call `groupedItemShape(...)`, and only add spacing between rows (not after the last row) to preserve the grouped appearance.
- Small import and API adjustments to support `Shape` propagation and reuse across settings lists.

### Testing
- Attempted to compile `:apptoolkit:compileDebugKotlin` with `./gradlew`, but the build failed in this environment due to missing Android SDK configuration (`ANDROID_HOME`/`sdk.dir` not set).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f8af95afe0832d99a7b227c1c01687)