### PR TITLE
fix(core): add INTERNET permission for MobileAds lint failure

### DIFF
--- a/core/src/main/AndroidManifest.xml
+++ b/core/src/main/AndroidManifest.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <uses-permission android:name="android.permission.INTERNET" />
+</manifest>


### PR DESCRIPTION
### Motivation
- Android lint reported a `MissingPermission` for `MobileAds.initialize` in `AdsCoreManager` because the `core` module had no manifest declaring `android.permission.INTERNET`.

### Description
- Add `core/src/main/AndroidManifest.xml` containing `<uses-permission android:name="android.permission.INTERNET" />` so the module's usage of the Ads SDK is covered by the required permission contract.

### Testing
- Attempted to run `./gradlew :core:lintDebug` in this environment, but the run is blocked due to missing Android SDK configuration (`ANDROID_HOME`/`sdk.dir`), so lint could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12cdbb3e50832d8d28bf1814abce7c)