### PR TITLE
Add directional between-tab animations and top-level navigation history

### DIFF
--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainScreen.kt
@@ -509,7 +509,21 @@ private fun MainShell(
                     AnimatedContent(
                         targetState = entry,
                         contentKey = { targetEntry -> targetEntry.contentKey },
-                        transitionSpec = { bottomNavTransitions.transition() },
+                        transitionSpec = {
+                            val initialIndex = MainNavigationDefaults.bottomBarItems.indexOfFirst {
+                                it.route == (initialState.contentKey as? StableNavKey)
+                            }
+                            val targetIndex = MainNavigationDefaults.bottomBarItems.indexOfFirst {
+                                it.route == (targetState.contentKey as? StableNavKey)
+                            }
+                            val isBottomBarRouteSwitch = initialIndex >= 0 && targetIndex >= 0
+
+                            if (isBottomBarRouteSwitch) {
+                                bottomNavTransitions.betweenTabs(forward = targetIndex >= initialIndex)
+                            } else {
+                                bottomNavTransitions.transition()
+                            }
+                        },
                         label = "TabAnimation",
                     ) { targetEntry ->
                         targetEntry.Content()

--- a/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/navigation/NavigationState.kt
+++ b/apptoolkit/src/main/kotlin/com/d4rk/android/libs/apptoolkit/core/ui/navigation/NavigationState.kt
@@ -23,6 +23,7 @@ import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.mutableStateListOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.Saver
@@ -118,6 +119,8 @@ class NavigationState<T : StableNavKey>(
 
     val currentRoute: T
         get() = currentBackStack.last()
+
+    val topLevelHistory = mutableStateListOf<T>()
 }
 
 @Stable
@@ -133,6 +136,9 @@ class Navigator<T : StableNavKey>(val state: NavigationState<T>) {
         if (route == state.currentRoute) return
 
         if (route in state.backStacks.keys) {
+            if (state.topLevelRoute != route) {
+                state.topLevelHistory.add(state.topLevelRoute)
+            }
             state.topLevelRoute = route
             state.currentBackStack.popToRoot()
             return
@@ -162,6 +168,13 @@ class Navigator<T : StableNavKey>(val state: NavigationState<T>) {
         val currentRoute = currentBackStack.lastOrNull() ?: return false
 
         if (currentRoute == state.topLevelRoute) {
+            val previousTopLevelRoute = state.topLevelHistory.removeLastOrNull()
+            if (previousTopLevelRoute != null && previousTopLevelRoute != state.topLevelRoute) {
+                state.topLevelRoute = previousTopLevelRoute
+                state.currentBackStack.popToRoot()
+                return true
+            }
+
             if (state.topLevelRoute != state.startRoute) {
                 state.topLevelRoute = state.startRoute
                 return true

--- a/navigation/src/main/java/com/d4rk/android/libs/apptoolkit/navigation/animations/BottomNavTransitions.kt
+++ b/navigation/src/main/java/com/d4rk/android/libs/apptoolkit/navigation/animations/BottomNavTransitions.kt
@@ -21,6 +21,8 @@ import androidx.compose.animation.ContentTransform
 import androidx.compose.animation.core.tween
 import androidx.compose.animation.fadeIn
 import androidx.compose.animation.fadeOut
+import androidx.compose.animation.slideInHorizontally
+import androidx.compose.animation.slideOutHorizontally
 import androidx.compose.animation.togetherWith
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
@@ -64,5 +66,22 @@ class BottomNavTransitions {
      */
     fun transition(): ContentTransform {
         return fadeIn(animationSpec = tween(300)) togetherWith fadeOut(animationSpec = tween(300))
+    }
+
+    /**
+     * Directional bottom-bar transition used when moving between tab indices.
+     */
+    fun betweenTabs(forward: Boolean): ContentTransform {
+        val enter = slideInHorizontally(
+            animationSpec = tween(260),
+            initialOffsetX = { fullWidth -> if (forward) fullWidth / 5 else -fullWidth / 5 },
+        ) + fadeIn(animationSpec = tween(220))
+
+        val exit = slideOutHorizontally(
+            animationSpec = tween(260),
+            targetOffsetX = { fullWidth -> if (forward) -fullWidth / 8 else fullWidth / 8 },
+        ) + fadeOut(animationSpec = tween(220))
+
+        return enter togetherWith exit
     }
 }


### PR DESCRIPTION
### Motivation
- Provide a directional slide animation when switching between bottom-bar tabs so tab changes feel spatially consistent.
- Preserve and restore previous top-level tab selections so back navigation can return to the previously viewed top-level destination instead of always going to the start route.

### Description
- Updated `MainScreen.kt` to choose a directional transition when switching between bottom-bar items by computing `initialIndex` and `targetIndex` from `MainNavigationDefaults.bottomBarItems` and calling `bottomNavTransitions.betweenTabs(...)` for tab switches, falling back to the existing fade transition otherwise.
- Added `betweenTabs(forward: Boolean)` to `BottomNavTransitions.kt` implementing a combined `slideInHorizontally`/`fadeIn` and `slideOutHorizontally`/`fadeOut` `ContentTransform` to animate directionally between tabs.
- Added a `topLevelHistory` `mutableStateListOf<T>()` to `NavigationState` and updated `Navigator.navigate` to push the previous top-level route when switching tabs, and updated `Navigator.goBack` to restore the last top-level route from `topLevelHistory` when appropriate; also added the `mutableStateListOf` import.

### Testing
- Ran the project's automated unit tests and navigation-related tests which exercised `Navigator` behavior and they completed successfully.
- Verified UI animation behavior via automated UI checks for the bottom navigation transitions and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1834fe01c0832d865852ab26a378d3)