### PR TITLE
Use `isTopLevel` for top-level route detection and update docs for activity-like destinations

### DIFF
--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainScreen.kt
@@ -114,6 +114,7 @@ import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.navigation.animations.NativeActivityTransitions
 import com.d4rk.android.libs.apptoolkit.navigation.animations.rememberBottomNavTransitions
 import com.d4rk.android.libs.apptoolkit.navigation.animations.rememberNativeActivityTransitions
+import com.d4rk.android.libs.apptoolkit.navigation.models.isTopLevel
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.persistentListOf
 import kotlinx.collections.immutable.persistentSetOf
@@ -249,7 +250,7 @@ private class MainSceneStrategy(
             "Main navigation entries must use their StableNavKey as NavEntry.contentKey."
         }
 
-        return if (currentRoute in NavigationRoutes.topLevelRoutes) {
+        return if (currentRoute.isTopLevel) {
             MainShellScene(
                 key = "main-shell",
                 entry = currentEntry,

--- a/docs/apptoolkit/screens/main/main.md
+++ b/docs/apptoolkit/screens/main/main.md
@@ -24,7 +24,7 @@ still giving host apps a ready-to-go default shell that can be customized or rep
 
 ### Navigation behavior helpers
 - **`handleNavigationItemClick(...)`**: default drawer click handling for common routes:
-  Settings, Help & Feedback, Updates (changelog), Share with support for host overrides.
+  Settings, Help & Feedback, Support, Updates (changelog), Share with support for host overrides.
 - **`appToolkitNavigationEntryBuilders(...)`**: shared Navigation 3 entries for library-owned
   destinations such as Settings, Help, Support, permissions, licenses, ads settings, and library
   extras.
@@ -176,7 +176,7 @@ drawer destinations so every top-level route remains reachable.
 ### 3) Nav3 scenes and motion
 
 Use a stable main-shell scene key for top-level destinations and a dedicated sub-screen scene for
-Settings, Help, Support, and other pushed destinations. Assign transition metadata on each scene:
+embedded Settings, Help, Support, and other pushed destinations. Assign transition metadata on each scene:
 top-level tab content uses a fade within the mounted shell; transitions crossing between the shell
 and a pushed destination, plus transitions between pushed destinations, use activity-like forward,
 pop, and predictive-pop motion. This avoids animating the app bar and navigation chrome when
@@ -184,7 +184,10 @@ switching tabs and preserves native back motion when returning from a pushed scr
 reported by destination content, such as FAB actions, must be delivered through stable state
 holders rather than scene-strategy identity so returning content cannot restart an active motion.
 Pushed settings, Help, Support, and similar destinations retain their expanded large top app bars
-inside the sub-screen shell; only the persistent top-level shell uses the compact app bar.
+inside the sub-screen shell; only the persistent top-level shell uses the compact app bar. Routes
+whose `destinationType` is `ActivityLike`, such as Components and Support, should be pushed through
+the Navigation 3 back stack so the navigation module can provide native activity-like motion without
+creating a separate Android `Activity`.
 
 ### 4) Drawer item click handling (`handleNavigationItemClick`)
 
@@ -198,10 +201,15 @@ handleNavigationItemClick(
     coroutineScope = scope,
     onChangelogRequested = { showChangelogDialog = true },
     additionalHandlers = mapOf(
-        "route_custom" to { /* custom action */ }
+        "route_custom" to { /* custom action */ },
+        NavigationRoutes.ROUTE_COMPONENTS to { navigator.navigate(ComponentsRoute) },
     ),
 )
 ```
+
+When a destination is declared as `NavigationDestinationType.ActivityLike`, prefer pushing its
+`StableNavKey` through the app `Navigator`. This keeps the screen inside the Navigation 3 graph while
+still applying the activity-like transitions supplied by the navigation module.
 
 ### 5) In-app update flow (Play Core via `RequestInAppUpdateUseCase`)
 

--- a/docs/apptoolkit/screens/support.md
+++ b/docs/apptoolkit/screens/support.md
@@ -58,8 +58,9 @@ Typical usage:
 
 1. Add a “Support” entry in settings or an app bar action menu.
 2. Navigate to the shared `SupportRoute` when the host shell embeds AppToolkit destinations, or
-   launch
-   `SupportActivity` for standalone flows.
+   launch `SupportActivity` for standalone flows. The sample app uses `SupportRoute` from its
+   top-app-bar support action and drawer support entry so the Navigation 3 activity-like scene owns
+   toolbar and back behavior consistently.
 3. Let users complete support or donation actions and return to previous flow.
 
 ---


### PR DESCRIPTION
### Motivation
- Replace an ad-hoc top-level route membership check with the navigation model's `isTopLevel` predicate to centralize route semantics.
- Clarify documentation around activity-like destinations and recommended Navigation 3 usage so hosts consistently get activity-like transitions without creating new Android `Activity`s.
- Provide a concrete example and minor copy fixes to make the sample integration and support flow guidance clearer.

### Description
- Updated `MainScreen.kt` to import `isTopLevel` and switch the top-level route check from `currentRoute in NavigationRoutes.topLevelRoutes` to `currentRoute.isTopLevel` to rely on the navigation model for route typing.
- Extended docs in `docs/apptoolkit/screens/main/main.md` to mention `NavigationDestinationType.ActivityLike` destinations and recommend pushing their `StableNavKey` through the `Navigator`, and added an example mapping for `NavigationRoutes.ROUTE_COMPONENTS` in `handleNavigationItemClick` usage.
- Minor wording and formatting fixes in `docs/apptoolkit/screens/main/main.md` and `docs/apptoolkit/screens/support.md` to improve clarity about embedding `SupportRoute` in a shared Navigation 3 shell and how the sample app handles toolbar/back behavior.

### Testing
- Built the project with `./gradlew assemble` and confirmed the app module compiles successfully.
- Ran `./gradlew check` to execute the unit tests and lint checks, which completed without failures.
- Verified the documentation changes are static edits and do not affect runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d770bfae0832d96e9d088e341d04d)