### PR TITLE
Add app detail control panel and AppActionLauncher with safe intent fallbacks

### DIFF
--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/data/mapper/AppInfoMappers.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/data/mapper/AppInfoMappers.kt
@@ -37,6 +37,8 @@ fun AppInfoDto.toDomain(): AppInfo = AppInfo(
         }
         .orEmpty(),
     category = category?.toDomain(),
+    githubUrl = githubUrl.sanitizeUrlOrNull(),
+    privacyPolicyUrl = privacyPolicyUrl.sanitizeUrlOrNull(),
 )
 
 fun AppCategoryDto.toDomain(): AppCategory = AppCategory(

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/data/remote/model/AppInfoDto.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/data/remote/model/AppInfoDto.kt
@@ -27,7 +27,9 @@ data class AppInfoDto(
     @SerialName("iconLogo") val iconUrl: String,
     @SerialName("category") val category: AppCategoryDto? = null,
     @SerialName("description") val description: String? = null,
-    @SerialName("screenshots") val screenshots: List<AppScreenshotDto>? = null
+    @SerialName("screenshots") val screenshots: List<AppScreenshotDto>? = null,
+    @SerialName("githubUrl") val githubUrl: String? = null,
+    @SerialName("privacyPolicyUrl") val privacyPolicyUrl: String? = null,
 )
 
 @Serializable

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/domain/model/AppInfo.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/domain/model/AppInfo.kt
@@ -19,6 +19,12 @@ package com.d4rk.android.apps.apptoolkit.app.apps.common.domain.model
 
 import androidx.compose.runtime.Immutable
 
+/**
+ * Catalog entry rendered by the app list and app detail control panel.
+ *
+ * Link fields are optional because not every listed app exposes source-code or privacy pages in
+ * the remote catalog.
+ */
 @Immutable
 data class AppInfo(
     val name: String,
@@ -27,8 +33,11 @@ data class AppInfo(
     val description: String,
     val screenshots: List<String>,
     val category: AppCategory? = null,
+    val githubUrl: String? = null,
+    val privacyPolicyUrl: String? = null,
 )
 
+/** Category metadata provided by the remote developer-app catalog. */
 @Immutable
 data class AppCategory(
     val label: String,

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/ui/views/AppActionLauncher.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/ui/views/AppActionLauncher.kt
@@ -1,0 +1,136 @@
+/*
+ * Copyright (©) 2026 Mihai-Cristian Condrea
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program. If not, see <https://www.gnu.org/licenses/>.
+ */
+
+package com.d4rk.android.apps.apptoolkit.app.apps.common.ui.views
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.provider.Settings
+import android.widget.Toast
+import androidx.core.net.toUri
+import com.d4rk.android.apps.apptoolkit.R
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.links.AppLinks
+import com.d4rk.android.libs.apptoolkit.core.utils.extensions.context.openUrl
+import com.d4rk.android.libs.apptoolkit.core.utils.extensions.context.startActivitySafely
+
+/**
+ * Launches Android and external app surfaces for a selected catalog app.
+ *
+ * The launcher intentionally opens public Android Settings pages instead of trying to mutate
+ * settings directly. That keeps the app detail sheet reliable across Android releases and OEM
+ * skins while still giving users fast access to notifications, permissions, storage, battery,
+ * sharing, and store pages.
+ */
+interface AppActionLauncher {
+    fun openApp(packageName: String): Boolean
+    fun openAppInfo(packageName: String): Boolean
+    fun openNotifications(packageName: String): Boolean
+    fun openPermissions(packageName: String): Boolean
+    fun openStorage(packageName: String): Boolean
+    fun openBattery(packageName: String): Boolean
+    fun openPlayStore(packageName: String): Boolean
+    fun shareApp(packageName: String, appName: String): Boolean
+    fun copyPackageName(packageName: String): Boolean
+    fun openUrl(url: String): Boolean
+}
+
+/** Android implementation of [AppActionLauncher] backed by public intents and safe fallbacks. */
+class AndroidAppActionLauncher(
+    private val context: Context,
+) : AppActionLauncher {
+
+    companion object {
+        private const val PLAY_STORE_PACKAGE_NAME: String = "com.android.vending"
+    }
+
+    override fun openApp(packageName: String): Boolean {
+        val launchIntent = context.packageManager.getLaunchIntentForPackage(packageName)
+            ?.apply { addFlags(Intent.FLAG_ACTIVITY_NEW_TASK) }
+
+        return if (launchIntent != null) {
+            context.startActivitySafely(launchIntent) || openAppInfo(packageName)
+        } else {
+            openAppInfo(packageName)
+        }
+    }
+
+    override fun openAppInfo(packageName: String): Boolean = context.startActivitySafely(
+        Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
+            data = Uri.fromParts("package", packageName, null)
+        }
+    )
+
+    override fun openNotifications(packageName: String): Boolean {
+        val notificationIntent = Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
+            putExtra(Settings.EXTRA_APP_PACKAGE, packageName)
+        }
+        return context.startActivitySafely(notificationIntent) || openAppInfo(packageName)
+    }
+
+    override fun openPermissions(packageName: String): Boolean = openAppInfo(packageName)
+
+    override fun openStorage(packageName: String): Boolean = openAppInfo(packageName)
+
+    override fun openBattery(packageName: String): Boolean = openAppInfo(packageName)
+
+    override fun openPlayStore(packageName: String): Boolean {
+        val marketIntent = Intent(
+            Intent.ACTION_VIEW,
+            "${AppLinks.MARKET_APP_PAGE}$packageName".toUri(),
+        ).apply {
+            setPackage(PLAY_STORE_PACKAGE_NAME)
+        }
+
+        return context.startActivitySafely(marketIntent) ||
+            context.openUrl("${AppLinks.PLAY_STORE_APP}$packageName")
+    }
+
+    override fun shareApp(packageName: String, appName: String): Boolean {
+        val playStoreUrl = "${AppLinks.PLAY_STORE_APP}$packageName"
+        val send = Intent(Intent.ACTION_SEND).apply {
+            type = "text/plain"
+            putExtra(Intent.EXTRA_SUBJECT, appName)
+            putExtra(
+                Intent.EXTRA_TEXT,
+                context.getString(R.string.app_details_share_text, appName, playStoreUrl)
+            )
+        }
+        val chooser = Intent.createChooser(send, context.getString(R.string.app_details_share_title))
+        return context.startActivitySafely(chooser)
+    }
+
+    override fun copyPackageName(packageName: String): Boolean {
+        val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+        clipboard.setPrimaryClip(
+            ClipData.newPlainText(
+                context.getString(R.string.app_details_package_name_clip_label),
+                packageName
+            )
+        )
+        Toast.makeText(
+            context,
+            context.getString(R.string.app_details_package_name_copied),
+            Toast.LENGTH_SHORT
+        ).show()
+        return true
+    }
+
+    override fun openUrl(url: String): Boolean = context.openUrl(url)
+}

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/ui/views/AppActionLauncher.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/ui/views/AppActionLauncher.kt
@@ -71,15 +71,24 @@ class AndroidAppActionLauncher(
         }
     }
 
-    override fun openAppInfo(packageName: String): Boolean = context.startActivitySafely(
-        Intent(Settings.ACTION_APPLICATION_DETAILS_SETTINGS).apply {
-            data = Uri.fromParts("package", packageName, null)
+    override fun openAppInfo(packageName: String): Boolean {
+        val appDetails = Intent(
+            Settings.ACTION_APPLICATION_DETAILS_SETTINGS,
+            Uri.fromParts("package", packageName, null),
+        ).apply {
+            addCategory(Intent.CATEGORY_DEFAULT)
         }
-    )
+
+        return context.startActivitySafely(appDetails) ||
+            context.startActivitySafely(Intent(Settings.ACTION_APPLICATION_SETTINGS)) ||
+            context.startActivitySafely(Intent(Settings.ACTION_SETTINGS))
+    }
 
     override fun openNotifications(packageName: String): Boolean {
         val notificationIntent = Intent(Settings.ACTION_APP_NOTIFICATION_SETTINGS).apply {
             putExtra(Settings.EXTRA_APP_PACKAGE, packageName)
+            putExtra("app_package", packageName)
+            putExtra("android.provider.extra.APP_PACKAGE", packageName)
         }
         return context.startActivitySafely(notificationIntent) || openAppInfo(packageName)
     }
@@ -97,8 +106,13 @@ class AndroidAppActionLauncher(
         ).apply {
             setPackage(PLAY_STORE_PACKAGE_NAME)
         }
+        val marketChooserIntent = Intent(
+            Intent.ACTION_VIEW,
+            "${AppLinks.MARKET_APP_PAGE}$packageName".toUri(),
+        )
 
         return context.startActivitySafely(marketIntent) ||
+            context.startActivitySafely(marketChooserIntent) ||
             context.openUrl("${AppLinks.PLAY_STORE_APP}$packageName")
     }
 

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/ui/views/AppDetailsBottomSheet.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/ui/views/AppDetailsBottomSheet.kt
@@ -22,6 +22,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
@@ -32,7 +33,6 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
@@ -357,24 +357,43 @@ private fun QuickActionsPanel(
             containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
         ),
     ) {
-        FlowRow(
-            modifier = Modifier.padding(SizeConstants.MediumSize),
-            maxItemsInEachRow = 4,
-            horizontalArrangement = Arrangement.spacedBy(SizeConstants.SmallSize),
-            verticalArrangement = Arrangement.spacedBy(SizeConstants.SmallSize),
-        ) {
-            quickActions.forEach { quickAction ->
-                QuickActionTile(quickAction = quickAction)
+        BoxWithConstraints(modifier = Modifier.padding(SizeConstants.MediumSize)) {
+            val columnCount = if (maxWidth < SizeConstants.TwoHundredFortySize * 2) {
+                COMPACT_QUICK_ACTION_COLUMNS
+            } else {
+                EXPANDED_QUICK_ACTION_COLUMNS
+            }
+
+            Column(verticalArrangement = Arrangement.spacedBy(SizeConstants.SmallSize)) {
+                quickActions.chunked(columnCount).forEach { rowActions ->
+                    Row(
+                        modifier = Modifier.fillMaxWidth(),
+                        horizontalArrangement = Arrangement.spacedBy(SizeConstants.SmallSize),
+                    ) {
+                        rowActions.forEach { quickAction ->
+                            QuickActionTile(
+                                quickAction = quickAction,
+                                modifier = Modifier.weight(1f),
+                            )
+                        }
+                        repeat(columnCount - rowActions.size) {
+                            Box(modifier = Modifier.weight(1f))
+                        }
+                    }
+                }
             }
         }
     }
 }
 
 @Composable
-private fun QuickActionTile(quickAction: QuickActionUi) {
+private fun QuickActionTile(
+    quickAction: QuickActionUi,
+    modifier: Modifier = Modifier,
+) {
     ElevatedCard(
         onClick = quickAction.onClick,
-        modifier = Modifier.widthIn(min = SizeConstants.ExtraExtraLargeSize * 2),
+        modifier = modifier.height(SizeConstants.NinetySixSize),
         colors = CardDefaults.elevatedCardColors(
             containerColor = MaterialTheme.colorScheme.surfaceContainer,
         ),
@@ -491,6 +510,9 @@ private fun AppLinksSection(
         }
     }
 }
+
+private const val COMPACT_QUICK_ACTION_COLUMNS: Int = 2
+private const val EXPANDED_QUICK_ACTION_COLUMNS: Int = 4
 
 @Immutable
 private data class QuickActionUi(

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/ui/views/AppDetailsBottomSheet.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/ui/views/AppDetailsBottomSheet.kt
@@ -22,10 +22,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
-import androidx.compose.foundation.layout.BoxWithConstraints
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.ExperimentalLayoutApi
-import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
@@ -86,7 +83,7 @@ import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.MediumHorizontalSp
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import com.d4rk.android.libs.apptoolkit.core.ui.model.AppVersionInfo as InstalledAppVersionInfo
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalLayoutApi::class)
+@OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
 fun AppDetailsBottomSheet(
     appInfo: AppInfo,
@@ -108,7 +105,9 @@ fun AppDetailsBottomSheet(
         AppDetailsHeader(
             appInfo = appInfo,
             isAppInstalled = isAppInstalled,
+            isFavorite = isFavorite,
             actionLauncher = actionLauncher,
+            onFavoriteClick = onFavoriteClick,
         )
         LargeVerticalSpacer()
         AppMetadataChips(
@@ -172,12 +171,6 @@ fun AppDetailsBottomSheet(
         }
         AppLinksSection(appInfo = appInfo, actionLauncher = actionLauncher)
         LargeVerticalSpacer()
-        GeneralOutlinedButton(
-            onClick = onFavoriteClick,
-            vectorIcon = if (isFavorite) Icons.Outlined.Verified else Icons.Outlined.CheckBox,
-            label = stringResource(id = R.string.favorite_apps)
-        )
-        LargeVerticalSpacer()
     }
 }
 
@@ -185,7 +178,9 @@ fun AppDetailsBottomSheet(
 private fun AppDetailsHeader(
     appInfo: AppInfo,
     isAppInstalled: Boolean?,
+    isFavorite: Boolean,
     actionLauncher: AppActionLauncher,
+    onFavoriteClick: () -> Unit,
 ) {
     Row(
         modifier = Modifier
@@ -239,44 +234,47 @@ private fun AppDetailsHeader(
                 null -> CircularWavyProgressIndicator()
             }
             GeneralOutlinedButton(
-                onClick = { actionLauncher.openAppInfo(appInfo.packageName) },
-                vectorIcon = Icons.Outlined.Info,
-                label = stringResource(id = R.string.app_details_app_info)
+                onClick = onFavoriteClick,
+                vectorIcon = if (isFavorite) Icons.Outlined.Verified else Icons.Outlined.CheckBox,
+                label = stringResource(id = R.string.favorite_apps)
             )
         }
     }
 }
 
-@OptIn(ExperimentalLayoutApi::class)
 @Composable
 private fun AppMetadataChips(
     appInfo: AppInfo,
     isAppInstalled: Boolean?,
     installedVersionInfo: InstalledAppVersionInfo?,
 ) {
-    FlowRow(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(horizontal = SizeConstants.LargeSize),
-        horizontalArrangement = Arrangement.spacedBy(SizeConstants.MediumSize),
-        verticalArrangement = Arrangement.spacedBy(SizeConstants.SmallSize),
-    ) {
-        AppInfoChip(
+    val chipItems = listOfNotNull(
+        AppInfoChipUi(
             icon = Icons.Outlined.CheckBox,
             label = when (isAppInstalled) {
                 true -> stringResource(id = R.string.app_details_installed)
                 false -> stringResource(id = R.string.app_details_not_installed)
                 null -> stringResource(id = R.string.app_details_checking_install_state)
             }
-        )
+        ),
         appInfo.category?.label?.takeIf { it.isNotBlank() }?.let { category ->
-            AppInfoChip(icon = Icons.Outlined.Category, label = category)
-        }
+            AppInfoChipUi(icon = Icons.Outlined.Category, label = category)
+        },
         installedVersionInfo?.versionName?.takeIf { it.isNotBlank() }?.let { versionName ->
-            AppInfoChip(
+            AppInfoChipUi(
                 icon = Icons.Outlined.Verified,
                 label = stringResource(id = R.string.app_details_version, versionName)
             )
+        },
+    )
+
+    LazyRow(
+        modifier = Modifier.fillMaxWidth(),
+        contentPadding = PaddingValues(horizontal = SizeConstants.LargeSize),
+        horizontalArrangement = Arrangement.spacedBy(SizeConstants.MediumSize),
+    ) {
+        items(chipItems) { chipItem ->
+            AppInfoChip(icon = chipItem.icon, label = chipItem.label)
         }
     }
 }
@@ -325,9 +323,6 @@ private fun QuickActionsPanel(
             QuickActionUi(R.string.app_details_battery, Icons.Outlined.BatteryFull) {
                 actionLauncher.openBattery(appInfo.packageName)
             },
-            QuickActionUi(R.string.app_details_app_info, Icons.Outlined.Info) {
-                actionLauncher.openAppInfo(appInfo.packageName)
-            },
             QuickActionUi(R.string.app_details_share, Icons.Outlined.Share) {
                 actionLauncher.shareApp(appInfo.packageName, appInfo.name)
             },
@@ -357,28 +352,23 @@ private fun QuickActionsPanel(
             containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
         ),
     ) {
-        BoxWithConstraints(modifier = Modifier.padding(SizeConstants.MediumSize)) {
-            val columnCount = if (maxWidth < SizeConstants.TwoHundredFortySize * 2) {
-                COMPACT_QUICK_ACTION_COLUMNS
-            } else {
-                EXPANDED_QUICK_ACTION_COLUMNS
-            }
-
-            Column(verticalArrangement = Arrangement.spacedBy(SizeConstants.SmallSize)) {
-                quickActions.chunked(columnCount).forEach { rowActions ->
-                    Row(
-                        modifier = Modifier.fillMaxWidth(),
-                        horizontalArrangement = Arrangement.spacedBy(SizeConstants.SmallSize),
-                    ) {
-                        rowActions.forEach { quickAction ->
-                            QuickActionTile(
-                                quickAction = quickAction,
-                                modifier = Modifier.weight(1f),
-                            )
-                        }
-                        repeat(columnCount - rowActions.size) {
-                            Box(modifier = Modifier.weight(1f))
-                        }
+        Column(
+            modifier = Modifier.padding(SizeConstants.MediumSize),
+            verticalArrangement = Arrangement.spacedBy(SizeConstants.SmallSize),
+        ) {
+            quickActions.chunked(QUICK_ACTION_COLUMNS).forEach { rowActions ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    horizontalArrangement = Arrangement.spacedBy(SizeConstants.SmallSize),
+                ) {
+                    rowActions.forEach { quickAction ->
+                        QuickActionTile(
+                            quickAction = quickAction,
+                            modifier = Modifier.weight(1f),
+                        )
+                    }
+                    repeat(QUICK_ACTION_COLUMNS - rowActions.size) {
+                        Box(modifier = Modifier.weight(1f))
                     }
                 }
             }
@@ -511,8 +501,13 @@ private fun AppLinksSection(
     }
 }
 
-private const val COMPACT_QUICK_ACTION_COLUMNS: Int = 2
-private const val EXPANDED_QUICK_ACTION_COLUMNS: Int = 4
+private const val QUICK_ACTION_COLUMNS: Int = 3
+
+@Immutable
+private data class AppInfoChipUi(
+    val icon: ImageVector,
+    val label: String,
+)
 
 @Immutable
 private data class QuickActionUi(

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/ui/views/AppDetailsBottomSheet.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/common/ui/views/AppDetailsBottomSheet.kt
@@ -21,7 +21,10 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.aspectRatio
@@ -29,6 +32,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.widthIn
 import androidx.compose.foundation.lazy.LazyRow
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
@@ -36,48 +40,61 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.automirrored.outlined.OpenInNew
-import androidx.compose.material.icons.filled.Star
+import androidx.compose.material.icons.outlined.BatteryFull
+import androidx.compose.material.icons.outlined.Category
+import androidx.compose.material.icons.outlined.CheckBox
+import androidx.compose.material.icons.outlined.ContentCopy
 import androidx.compose.material.icons.outlined.Info
+import androidx.compose.material.icons.outlined.Notifications
+import androidx.compose.material.icons.outlined.PlayArrow
+import androidx.compose.material.icons.outlined.PrivacyTip
+import androidx.compose.material.icons.outlined.Security
 import androidx.compose.material.icons.outlined.Share
-import androidx.compose.material.icons.outlined.StarOutline
+import androidx.compose.material.icons.outlined.Source
+import androidx.compose.material.icons.outlined.Storage
+import androidx.compose.material.icons.outlined.Verified
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.CircularWavyProgressIndicator
+import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
-import androidx.compose.ui.text.style.TextAlign
 import coil3.compose.AsyncImage
 import com.d4rk.android.apps.apptoolkit.R
 import com.d4rk.android.apps.apptoolkit.app.apps.common.domain.model.AppInfo
 import com.d4rk.android.libs.apptoolkit.core.ui.model.ads.AdsConfig
 import com.d4rk.android.libs.apptoolkit.core.ui.views.ads.AppDetailsNativeAd
+import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.GeneralButton
 import com.d4rk.android.libs.apptoolkit.core.ui.views.buttons.GeneralOutlinedButton
 import com.d4rk.android.libs.apptoolkit.core.ui.views.modifiers.bounceClick
 import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.ExtraSmallVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.LargeVerticalSpacer
 import com.d4rk.android.libs.apptoolkit.core.ui.views.spacers.MediumHorizontalSpacer
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
+import com.d4rk.android.libs.apptoolkit.core.ui.model.AppVersionInfo as InstalledAppVersionInfo
 
-@OptIn(ExperimentalMaterial3ExpressiveApi::class)
+@OptIn(ExperimentalMaterial3ExpressiveApi::class, ExperimentalLayoutApi::class)
 @Composable
 fun AppDetailsBottomSheet(
     appInfo: AppInfo,
     isFavorite: Boolean,
     isAppInstalled: Boolean?,
-    onShareClick: () -> Unit,
+    installedVersionInfo: InstalledAppVersionInfo?,
+    actionLauncher: AppActionLauncher,
     onFavoriteClick: () -> Unit,
-    onOpenAppClick: () -> Unit,
-    onOpenInPlayStoreClick: () -> Unit,
     adsConfig: AdsConfig,
     modifier: Modifier = Modifier,
 ) {
@@ -88,74 +105,22 @@ fun AppDetailsBottomSheet(
         horizontalAlignment = Alignment.CenterHorizontally
     ) {
         LargeVerticalSpacer()
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = SizeConstants.LargeSize),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.spacedBy(SizeConstants.MediumSize)
-        ) {
-            Card(
-                shape = RoundedCornerShape(SizeConstants.LargeSize),
-            ) {
-                AsyncImage(
-                    model = appInfo.iconUrl,
-                    contentDescription = appInfo.name,
-                    modifier = Modifier.size(SizeConstants.ExtraExtraLargeSize * 2)
-                )
-            }
-            Column {
-                Text(
-                    text = appInfo.name,
-                    style = MaterialTheme.typography.headlineMedium,
-                    fontWeight = FontWeight.SemiBold,
-                )
-                Text(
-                    text = appInfo.packageName,
-                    style = MaterialTheme.typography.bodyMedium,
-                    color = MaterialTheme.colorScheme.primary,
-                    textAlign = TextAlign.Center,
-                )
-            }
-        }
+        AppDetailsHeader(
+            appInfo = appInfo,
+            isAppInstalled = isAppInstalled,
+            actionLauncher = actionLauncher,
+        )
         LargeVerticalSpacer()
-        Row(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = SizeConstants.LargeSize),
-            horizontalArrangement = Arrangement.End,
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            when (isAppInstalled) {
-                true -> {
-                    GeneralOutlinedButton(
-                        onClick = onOpenAppClick,
-                        vectorIcon = Icons.AutoMirrored.Outlined.OpenInNew,
-                        label = stringResource(id = R.string.app_details_open_app)
-                    )
-                }
-
-                false -> {
-                    Image(
-                        painter = painterResource(id = R.drawable.get_it_on_google_play),
-                        contentDescription = stringResource(R.string.app_details_view_on_play_store),
-                        contentScale = ContentScale.Fit,
-                        modifier = Modifier
-                            .bounceClick()
-                            .clickable(
-                                interactionSource = remember { MutableInteractionSource() },
-                                indication = null
-                            ) {
-                                onOpenInPlayStoreClick()
-                            }
-                    )
-                }
-
-                null -> {
-                    CircularWavyProgressIndicator()
-                }
-            }
-        }
+        AppMetadataChips(
+            appInfo = appInfo,
+            isAppInstalled = isAppInstalled,
+            installedVersionInfo = installedVersionInfo,
+        )
+        LargeVerticalSpacer()
+        QuickActionsPanel(
+            appInfo = appInfo,
+            actionLauncher = actionLauncher,
+        )
 
         AppDetailsNativeAd(
             modifier = Modifier
@@ -165,30 +130,15 @@ fun AppDetailsBottomSheet(
         )
 
         if (appInfo.description.isNotEmpty()) {
-            Row(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = SizeConstants.LargeSize)
+            AppSectionCard(
+                title = stringResource(id = R.string.app_details_about_title),
+                icon = Icons.Outlined.Info,
             ) {
-                Icon(
-                    imageVector = Icons.Outlined.Info,
-                    contentDescription = stringResource(id = com.d4rk.android.libs.apptoolkit.R.string.about)
-                )
-                MediumHorizontalSpacer()
                 Text(
-                    text = stringResource(id = R.string.app_details_about_title),
+                    text = appInfo.description,
                     style = MaterialTheme.typography.bodyLarge,
-                    fontWeight = FontWeight.SemiBold,
                 )
             }
-            ExtraSmallVerticalSpacer()
-            Text(
-                text = appInfo.description,
-                style = MaterialTheme.typography.bodyLarge,
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .padding(horizontal = SizeConstants.LargeSize)
-            )
         }
         if (appInfo.screenshots.isNotEmpty()) {
             LargeVerticalSpacer()
@@ -197,8 +147,7 @@ fun AppDetailsBottomSheet(
                     text = stringResource(id = R.string.app_details_screenshots_title),
                     style = MaterialTheme.typography.titleMedium,
                     fontWeight = FontWeight.SemiBold,
-                    modifier = Modifier
-                        .padding(horizontal = SizeConstants.LargeSize)
+                    modifier = Modifier.padding(horizontal = SizeConstants.LargeSize)
                 )
                 LargeVerticalSpacer()
                 LazyRow(
@@ -206,9 +155,7 @@ fun AppDetailsBottomSheet(
                     horizontalArrangement = Arrangement.spacedBy(SizeConstants.LargeSize)
                 ) {
                     items(appInfo.screenshots) { screenshotUrl ->
-                        Card(
-                            shape = RoundedCornerShape(SizeConstants.LargeSize),
-                        ) {
+                        Card(shape = RoundedCornerShape(SizeConstants.LargeSize)) {
                             AsyncImage(
                                 model = screenshotUrl,
                                 contentDescription = null,
@@ -223,26 +170,339 @@ fun AppDetailsBottomSheet(
                 }
             }
         }
+        AppLinksSection(appInfo = appInfo, actionLauncher = actionLauncher)
         LargeVerticalSpacer()
-        Row(
-            modifier = Modifier
-                .fillMaxWidth(),
-            horizontalArrangement = Arrangement.spacedBy(
-                SizeConstants.LargeSize,
-                Alignment.CenterHorizontally
-            ),
-            verticalAlignment = Alignment.CenterVertically
-        ) {
-            GeneralOutlinedButton(
-                onClick = onShareClick,
-                vectorIcon = Icons.Outlined.Share,
-                label = stringResource(id = R.string.app_details_share_content_description)
+        GeneralOutlinedButton(
+            onClick = onFavoriteClick,
+            vectorIcon = if (isFavorite) Icons.Outlined.Verified else Icons.Outlined.CheckBox,
+            label = stringResource(id = R.string.favorite_apps)
+        )
+        LargeVerticalSpacer()
+    }
+}
+
+@Composable
+private fun AppDetailsHeader(
+    appInfo: AppInfo,
+    isAppInstalled: Boolean?,
+    actionLauncher: AppActionLauncher,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = SizeConstants.LargeSize),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(SizeConstants.MediumSize)
+    ) {
+        Card(shape = RoundedCornerShape(SizeConstants.LargeSize)) {
+            AsyncImage(
+                model = appInfo.iconUrl,
+                contentDescription = appInfo.name,
+                modifier = Modifier.size(SizeConstants.ExtraExtraLargeSize * 2)
             )
+        }
+        Column(modifier = Modifier.weight(1f)) {
+            Text(
+                text = appInfo.name,
+                style = MaterialTheme.typography.headlineMedium,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                text = appInfo.packageName,
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
+        Column(
+            horizontalAlignment = Alignment.End,
+            verticalArrangement = Arrangement.spacedBy(SizeConstants.SmallSize)
+        ) {
+            when (isAppInstalled) {
+                true -> GeneralButton(
+                    onClick = { actionLauncher.openApp(appInfo.packageName) },
+                    vectorIcon = Icons.AutoMirrored.Outlined.OpenInNew,
+                    label = stringResource(id = R.string.app_details_open_app)
+                )
+
+                false -> Image(
+                    painter = painterResource(id = R.drawable.get_it_on_google_play),
+                    contentDescription = stringResource(R.string.app_details_view_on_play_store),
+                    contentScale = ContentScale.Fit,
+                    modifier = Modifier
+                        .bounceClick()
+                        .clickable(
+                            interactionSource = remember { MutableInteractionSource() },
+                            indication = null,
+                        ) { actionLauncher.openPlayStore(appInfo.packageName) }
+                )
+
+                null -> CircularWavyProgressIndicator()
+            }
             GeneralOutlinedButton(
-                onClick = onFavoriteClick,
-                vectorIcon = if (isFavorite) Icons.Filled.Star else Icons.Outlined.StarOutline,
-                label = stringResource(id = R.string.favorite_apps)
+                onClick = { actionLauncher.openAppInfo(appInfo.packageName) },
+                vectorIcon = Icons.Outlined.Info,
+                label = stringResource(id = R.string.app_details_app_info)
             )
         }
     }
 }
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun AppMetadataChips(
+    appInfo: AppInfo,
+    isAppInstalled: Boolean?,
+    installedVersionInfo: InstalledAppVersionInfo?,
+) {
+    FlowRow(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = SizeConstants.LargeSize),
+        horizontalArrangement = Arrangement.spacedBy(SizeConstants.MediumSize),
+        verticalArrangement = Arrangement.spacedBy(SizeConstants.SmallSize),
+    ) {
+        AppInfoChip(
+            icon = Icons.Outlined.CheckBox,
+            label = when (isAppInstalled) {
+                true -> stringResource(id = R.string.app_details_installed)
+                false -> stringResource(id = R.string.app_details_not_installed)
+                null -> stringResource(id = R.string.app_details_checking_install_state)
+            }
+        )
+        appInfo.category?.label?.takeIf { it.isNotBlank() }?.let { category ->
+            AppInfoChip(icon = Icons.Outlined.Category, label = category)
+        }
+        installedVersionInfo?.versionName?.takeIf { it.isNotBlank() }?.let { versionName ->
+            AppInfoChip(
+                icon = Icons.Outlined.Verified,
+                label = stringResource(id = R.string.app_details_version, versionName)
+            )
+        }
+    }
+}
+
+@Composable
+private fun AppInfoChip(
+    icon: ImageVector,
+    label: String,
+) {
+    ElevatedCard(
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+        ),
+        shape = RoundedCornerShape(SizeConstants.ExtraLargeSize),
+    ) {
+        Row(
+            modifier = Modifier.padding(
+                horizontal = SizeConstants.MediumSize,
+                vertical = SizeConstants.SmallSize,
+            ),
+            verticalAlignment = Alignment.CenterVertically,
+            horizontalArrangement = Arrangement.spacedBy(SizeConstants.SmallSize),
+        ) {
+            Icon(imageVector = icon, contentDescription = null)
+            Text(text = label, style = MaterialTheme.typography.bodyMedium)
+        }
+    }
+}
+
+@Composable
+private fun QuickActionsPanel(
+    appInfo: AppInfo,
+    actionLauncher: AppActionLauncher,
+) {
+    val quickActions = remember(appInfo, actionLauncher) {
+        listOf(
+            QuickActionUi(R.string.app_details_notifications, Icons.Outlined.Notifications) {
+                actionLauncher.openNotifications(appInfo.packageName)
+            },
+            QuickActionUi(R.string.app_details_permissions, Icons.Outlined.Security) {
+                actionLauncher.openPermissions(appInfo.packageName)
+            },
+            QuickActionUi(R.string.app_details_storage, Icons.Outlined.Storage) {
+                actionLauncher.openStorage(appInfo.packageName)
+            },
+            QuickActionUi(R.string.app_details_battery, Icons.Outlined.BatteryFull) {
+                actionLauncher.openBattery(appInfo.packageName)
+            },
+            QuickActionUi(R.string.app_details_app_info, Icons.Outlined.Info) {
+                actionLauncher.openAppInfo(appInfo.packageName)
+            },
+            QuickActionUi(R.string.app_details_share, Icons.Outlined.Share) {
+                actionLauncher.shareApp(appInfo.packageName, appInfo.name)
+            },
+            QuickActionUi(R.string.app_details_play_store, Icons.Outlined.PlayArrow) {
+                actionLauncher.openPlayStore(appInfo.packageName)
+            },
+            QuickActionUi(R.string.app_details_copy_package, Icons.Outlined.ContentCopy) {
+                actionLauncher.copyPackageName(appInfo.packageName)
+            },
+        )
+    }
+
+    Text(
+        text = stringResource(id = R.string.app_details_quick_actions_title),
+        style = MaterialTheme.typography.titleMedium,
+        fontWeight = FontWeight.SemiBold,
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = SizeConstants.LargeSize)
+    )
+    ExtraSmallVerticalSpacer()
+    ElevatedCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = SizeConstants.LargeSize),
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+        ),
+    ) {
+        FlowRow(
+            modifier = Modifier.padding(SizeConstants.MediumSize),
+            maxItemsInEachRow = 4,
+            horizontalArrangement = Arrangement.spacedBy(SizeConstants.SmallSize),
+            verticalArrangement = Arrangement.spacedBy(SizeConstants.SmallSize),
+        ) {
+            quickActions.forEach { quickAction ->
+                QuickActionTile(quickAction = quickAction)
+            }
+        }
+    }
+}
+
+@Composable
+private fun QuickActionTile(quickAction: QuickActionUi) {
+    ElevatedCard(
+        onClick = quickAction.onClick,
+        modifier = Modifier.widthIn(min = SizeConstants.ExtraExtraLargeSize * 2),
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainer,
+        ),
+    ) {
+        Box(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(SizeConstants.MediumSize),
+            contentAlignment = Alignment.Center,
+        ) {
+            Column(
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.spacedBy(SizeConstants.SmallSize),
+            ) {
+                Icon(imageVector = quickAction.icon, contentDescription = null)
+                Text(
+                    text = stringResource(id = quickAction.labelRes),
+                    style = MaterialTheme.typography.bodyMedium,
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun AppSectionCard(
+    title: String,
+    icon: ImageVector,
+    content: @Composable () -> Unit,
+) {
+    LargeVerticalSpacer()
+    ElevatedCard(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = SizeConstants.LargeSize),
+        colors = CardDefaults.elevatedCardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+        ),
+    ) {
+        Column(modifier = Modifier.padding(SizeConstants.LargeSize)) {
+            Row(verticalAlignment = Alignment.CenterVertically) {
+                Icon(imageVector = icon, contentDescription = null)
+                MediumHorizontalSpacer()
+                Text(
+                    text = title,
+                    style = MaterialTheme.typography.titleMedium,
+                    fontWeight = FontWeight.SemiBold,
+                )
+            }
+            ExtraSmallVerticalSpacer()
+            content()
+        }
+    }
+}
+
+@Composable
+private fun AppLinksSection(
+    appInfo: AppInfo,
+    actionLauncher: AppActionLauncher,
+) {
+    val links = listOfNotNull(
+        appInfo.githubUrl?.let {
+            AppLinkUi(
+                titleRes = R.string.app_details_github_repository,
+                summaryRes = R.string.app_details_github_repository_summary,
+                icon = Icons.Outlined.Source,
+                url = it,
+            )
+        },
+        appInfo.privacyPolicyUrl?.let {
+            AppLinkUi(
+                titleRes = R.string.app_details_privacy_policy,
+                summaryRes = R.string.app_details_privacy_policy_summary,
+                icon = Icons.Outlined.PrivacyTip,
+                url = it,
+            )
+        },
+    )
+    if (links.isEmpty()) return
+
+    AppSectionCard(
+        title = stringResource(id = R.string.app_details_links_title),
+        icon = Icons.AutoMirrored.Outlined.OpenInNew,
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(SizeConstants.SmallSize)) {
+            links.forEach { link ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .bounceClick()
+                        .clickable { actionLauncher.openUrl(link.url) }
+                        .padding(vertical = SizeConstants.SmallSize),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(imageVector = link.icon, contentDescription = null)
+                    MediumHorizontalSpacer()
+                    Column(modifier = Modifier.weight(1f)) {
+                        Text(
+                            text = stringResource(id = link.titleRes),
+                            style = MaterialTheme.typography.bodyLarge,
+                            fontWeight = FontWeight.SemiBold,
+                        )
+                        Text(
+                            text = stringResource(id = link.summaryRes),
+                            style = MaterialTheme.typography.bodyMedium,
+                        )
+                    }
+                    Icon(
+                        imageVector = Icons.AutoMirrored.Outlined.OpenInNew,
+                        contentDescription = null,
+                    )
+                }
+            }
+        }
+    }
+}
+
+@Immutable
+private data class QuickActionUi(
+    val labelRes: Int,
+    val icon: ImageVector,
+    val onClick: () -> Unit,
+)
+
+@Immutable
+private data class AppLinkUi(
+    val titleRes: Int,
+    val summaryRes: Int,
+    val icon: ImageVector,
+    val url: String,
+)

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/favorites/ui/FavoriteAppsScreen.kt
@@ -26,7 +26,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetValue
 import androidx.compose.material3.rememberBottomSheetState
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -40,6 +39,7 @@ import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.d4rk.android.apps.apptoolkit.R
 import com.d4rk.android.apps.apptoolkit.app.apps.common.domain.model.AppInfo
+import com.d4rk.android.apps.apptoolkit.app.apps.common.ui.views.AndroidAppActionLauncher
 import com.d4rk.android.apps.apptoolkit.app.apps.common.ui.views.AppDetailsBottomSheet
 import com.d4rk.android.apps.apptoolkit.app.apps.common.ui.views.analytics.AppInteractionType
 import com.d4rk.android.apps.apptoolkit.app.apps.common.ui.views.analytics.logAppInteraction
@@ -56,19 +56,20 @@ import com.d4rk.android.apps.apptoolkit.core.utils.constants.logging.FAVORITES_L
 import com.d4rk.android.libs.apptoolkit.core.coroutines.dispatchers.DispatcherProvider
 import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
 import com.d4rk.android.libs.apptoolkit.core.ui.model.ads.AdsConfig
+import com.d4rk.android.libs.apptoolkit.core.ui.model.AppVersionInfo as InstalledAppVersionInfo
 import com.d4rk.android.libs.apptoolkit.core.ui.state.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.views.ads.rememberAdsEnabled
 import com.d4rk.android.libs.apptoolkit.core.ui.views.layouts.NoDataScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.views.layouts.ScreenStateHandler
 import com.d4rk.android.libs.apptoolkit.core.ui.window.AppWindowWidthSizeClass
-import com.d4rk.android.libs.apptoolkit.core.utils.extensions.context.openPlayStoreForApp
+import com.d4rk.android.libs.apptoolkit.core.utils.extensions.packagemanager.getVersionInfo
 import com.d4rk.android.libs.apptoolkit.core.utils.extensions.packagemanager.isAppInstalled
 import kotlinx.collections.immutable.ImmutableSet
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ads.AdsQualifiers
 import kotlinx.collections.immutable.toImmutableSet
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import com.d4rk.android.libs.apptoolkit.core.utils.constants.ads.AdsQualifiers
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.qualifier.named
@@ -141,29 +142,25 @@ fun FavoriteAppsRoute(
         }
     }
 
-    val onOpenInPlayStore: (AppInfo) -> Unit = remember(context) {
-        { appInfo ->
-            if (appInfo.packageName.isNotEmpty()) {
-                val opened = context.openPlayStoreForApp(appInfo.packageName)
-                if (!opened) {
-                    Log.w(FAVORITES_LOG_TAG, "Unable to open Play Store for ${appInfo.packageName}")
-                }
-            }
-        }
-    }
-
     var selectedApp: AppInfo? by remember { mutableStateOf(null) }
     var isSelectedAppInstalled: Boolean? by remember { mutableStateOf(null) }
+    var selectedAppVersionInfo: InstalledAppVersionInfo? by remember { mutableStateOf(null) }
+    val appActionLauncher = remember(context) { AndroidAppActionLauncher(context) }
 
     val sheetState = rememberBottomSheetState(initialValue = SheetValue.Hidden)
     val coroutineScope = rememberCoroutineScope()
 
     LaunchedEffect(selectedApp?.packageName) {
-        isSelectedAppInstalled = selectedApp?.let { app ->
-            if (app.packageName.isNotEmpty()) {
-                withContext(dispatchers.io) {
-                    context.isAppInstalled(app.packageName)
+        val app = selectedApp
+        selectedAppVersionInfo = null
+        isSelectedAppInstalled = app?.let { selected ->
+            if (selected.packageName.isNotEmpty()) {
+                val installState = withContext(dispatchers.io) {
+                    context.packageManager.getVersionInfo(selected.packageName) to
+                        context.isAppInstalled(selected.packageName)
                 }
+                selectedAppVersionInfo = installState.first
+                installState.second
             } else {
                 false
             }
@@ -190,29 +187,8 @@ fun FavoriteAppsRoute(
                 appInfo = app,
                 isFavorite = favorites.contains(app.packageName),
                 isAppInstalled = isSelectedAppInstalled,
-                onShareClick = {
-                    firebaseController.logAppInteraction(
-                        source = "favorite_apps",
-                        appInfo = app,
-                        interaction = AppInteractionType.Share,
-                        interactionContext = "details_bottom_sheet"
-                    )
-                    buildShareClick(app)
-                },
-                onOpenAppClick = {
-                    firebaseController.logAppInteraction(source = "favorite_apps", appInfo = app, interaction = AppInteractionType.OpenInstalledApp)
-                    coroutineScope.launch {
-                        selectedApp = null
-                        openApp(app)
-                    }
-                },
-                onOpenInPlayStoreClick = {
-                    firebaseController.logAppInteraction(source = "favorite_apps", appInfo = app, interaction = AppInteractionType.OpenInPlayStore)
-                    coroutineScope.launch {
-                        selectedApp = null
-                        onOpenInPlayStore(app)
-                    }
-                },
+                installedVersionInfo = selectedAppVersionInfo,
+                actionLauncher = appActionLauncher,
                 onFavoriteClick = { onFavoriteToggle(app.packageName) },
                 adsConfig = appDetailsAdsConfig
             )
@@ -245,6 +221,7 @@ fun FavoriteAppsRoute(
                     if (sheetState.isVisible) sheetState.hide()
                     selectedApp = null
                     isSelectedAppInstalled = null
+                    selectedAppVersionInfo = null
                     openApp(action.app)
                 }
             }

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/apps/list/ui/AppsListScreen.kt
@@ -23,7 +23,6 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.SheetValue
 import androidx.compose.material3.rememberBottomSheetState
-import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
@@ -36,6 +35,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.d4rk.android.apps.apptoolkit.app.apps.common.domain.model.AppInfo
+import com.d4rk.android.apps.apptoolkit.app.apps.common.ui.views.AndroidAppActionLauncher
 import com.d4rk.android.apps.apptoolkit.app.apps.common.ui.views.AppDetailsBottomSheet
 import com.d4rk.android.apps.apptoolkit.app.apps.common.ui.views.analytics.AppInteractionType
 import com.d4rk.android.apps.apptoolkit.app.apps.common.ui.views.analytics.logAppInteraction
@@ -47,22 +47,22 @@ import com.d4rk.android.apps.apptoolkit.app.apps.list.ui.contract.HomeAction
 import com.d4rk.android.apps.apptoolkit.app.apps.list.ui.contract.HomeEvent
 import com.d4rk.android.apps.apptoolkit.app.apps.list.ui.state.AppListUiState
 import com.d4rk.android.apps.apptoolkit.app.main.ui.views.navigation.RandomAppHandler
-import com.d4rk.android.apps.apptoolkit.core.utils.constants.logging.APPS_LIST_LOG_TAG
 import com.d4rk.android.libs.apptoolkit.core.coroutines.dispatchers.DispatcherProvider
 import com.d4rk.android.libs.apptoolkit.core.domain.repository.FirebaseController
 import com.d4rk.android.libs.apptoolkit.core.ui.model.ads.AdsConfig
+import com.d4rk.android.libs.apptoolkit.core.ui.model.AppVersionInfo as InstalledAppVersionInfo
 import com.d4rk.android.libs.apptoolkit.core.ui.state.UiStateScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.views.ads.rememberAdsEnabled
 import com.d4rk.android.libs.apptoolkit.core.ui.views.layouts.NoDataScreen
 import com.d4rk.android.libs.apptoolkit.core.ui.views.layouts.ScreenStateHandler
 import com.d4rk.android.libs.apptoolkit.core.ui.window.AppWindowWidthSizeClass
-import com.d4rk.android.libs.apptoolkit.core.utils.extensions.context.openPlayStoreForApp
+import com.d4rk.android.libs.apptoolkit.core.utils.extensions.packagemanager.getVersionInfo
 import com.d4rk.android.libs.apptoolkit.core.utils.extensions.packagemanager.isAppInstalled
+import com.d4rk.android.libs.apptoolkit.core.utils.constants.ads.AdsQualifiers
 import kotlinx.collections.immutable.toImmutableSet
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import com.d4rk.android.libs.apptoolkit.core.utils.constants.ads.AdsQualifiers
 import org.koin.compose.koinInject
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.qualifier.named
@@ -140,32 +140,25 @@ fun AppsListRoute(
         }
     }
 
-    val onOpenInPlayStore: (AppInfo) -> Unit = remember(context) {
-        { appInfo ->
-            if (appInfo.packageName.isNotEmpty()) {
-                val opened = context.openPlayStoreForApp(appInfo.packageName)
-                if (!opened) {
-                    android.util.Log.w(
-                        APPS_LIST_LOG_TAG,
-                        "Unable to open Play Store for ${appInfo.packageName}"
-                    )
-                }
-            }
-        }
-    }
-
     var selectedApp: AppInfo? by remember { mutableStateOf(null) }
     var isSelectedAppInstalled: Boolean? by remember { mutableStateOf(null) }
+    var selectedAppVersionInfo: InstalledAppVersionInfo? by remember { mutableStateOf(null) }
+    val appActionLauncher = remember(context) { AndroidAppActionLauncher(context) }
 
     val sheetState = rememberBottomSheetState(initialValue = SheetValue.Hidden)
     val coroutineScope = rememberCoroutineScope()
 
     LaunchedEffect(selectedApp?.packageName) {
-        isSelectedAppInstalled = selectedApp?.let { app ->
-            if (app.packageName.isNotEmpty()) {
-                withContext(dispatchers.io) {
-                    context.isAppInstalled(app.packageName)
+        val app = selectedApp
+        selectedAppVersionInfo = null
+        isSelectedAppInstalled = app?.let { selected ->
+            if (selected.packageName.isNotEmpty()) {
+                val installState = withContext(dispatchers.io) {
+                    context.packageManager.getVersionInfo(selected.packageName) to
+                        context.isAppInstalled(selected.packageName)
                 }
+                selectedAppVersionInfo = installState.first
+                installState.second
             } else {
                 false
             }
@@ -192,29 +185,8 @@ fun AppsListRoute(
                 appInfo = app,
                 isFavorite = favorites.contains(app.packageName),
                 isAppInstalled = isSelectedAppInstalled,
-                onShareClick = {
-                    firebaseController.logAppInteraction(
-                        source = "apps_list",
-                        appInfo = app,
-                        interaction = AppInteractionType.Share,
-                        interactionContext = "details_bottom_sheet"
-                    )
-                    buildShareClick(app)
-                },
-                onOpenAppClick = {
-                    firebaseController.logAppInteraction(source = "apps_list", appInfo = app, interaction = AppInteractionType.OpenInstalledApp)
-                    coroutineScope.launch {
-                        selectedApp = null
-                        openApp(app)
-                    }
-                },
-                onOpenInPlayStoreClick = {
-                    firebaseController.logAppInteraction(source = "apps_list", appInfo = app, interaction = AppInteractionType.OpenInPlayStore)
-                    coroutineScope.launch {
-                        selectedApp = null
-                        onOpenInPlayStore(app)
-                    }
-                },
+                installedVersionInfo = selectedAppVersionInfo,
+                actionLauncher = appActionLauncher,
                 onFavoriteClick = { onFavoriteToggle(app.packageName) },
                 adsConfig = appDetailsAdsConfig
             )
@@ -237,6 +209,7 @@ fun AppsListRoute(
                     if (sheetState.isVisible) sheetState.hide()
                     selectedApp = null
                     isSelectedAppInstalled = null
+                    selectedAppVersionInfo = null
                     openApp(action.app)
                 }
             }

--- a/app/src/main/res/values-ar-rEG/strings.xml
+++ b/app/src/main/res/values-ar-rEG/strings.xml
@@ -41,6 +41,28 @@
     <string name="app_details_about_title">حول هذا التطبيق</string>
     <string name="app_details_screenshots_title">لقطات الشاشة</string>
     <string name="app_details_open_app">فتح التطبيق</string>
+    <string name="app_details_app_info">App info</string>
+    <string name="app_details_installed">Installed</string>
+    <string name="app_details_not_installed">Not installed</string>
+    <string name="app_details_checking_install_state">Checking install status</string>
+    <string name="app_details_version">Version %1$s</string>
+    <string name="app_details_quick_actions_title">Quick actions</string>
+    <string name="app_details_notifications">Notifications</string>
+    <string name="app_details_permissions">Permissions</string>
+    <string name="app_details_storage">Storage</string>
+    <string name="app_details_battery">Battery</string>
+    <string name="app_details_share">Share</string>
+    <string name="app_details_play_store">Play Store</string>
+    <string name="app_details_copy_package">Copy package</string>
+    <string name="app_details_share_title">Share app</string>
+    <string name="app_details_share_text">Check out %1$s:\n%2$s</string>
+    <string name="app_details_package_name_clip_label">Package name</string>
+    <string name="app_details_package_name_copied">Package name copied</string>
+    <string name="app_details_links_title">Links</string>
+    <string name="app_details_github_repository">GitHub Repository</string>
+    <string name="app_details_github_repository_summary">View source code and contribute</string>
+    <string name="app_details_privacy_policy">Privacy Policy</string>
+    <string name="app_details_privacy_policy_summary">Read our privacy policy</string>
 
     <!-- Help screen -->
     <string name="question_1">ما هو App Toolkit؟</string>

--- a/app/src/main/res/values-bg-rBG/strings.xml
+++ b/app/src/main/res/values-bg-rBG/strings.xml
@@ -41,6 +41,28 @@
     <string name="app_details_about_title">За това приложение</string>
     <string name="app_details_screenshots_title">Екранни снимки</string>
     <string name="app_details_open_app">Отвори приложението</string>
+    <string name="app_details_app_info">App info</string>
+    <string name="app_details_installed">Installed</string>
+    <string name="app_details_not_installed">Not installed</string>
+    <string name="app_details_checking_install_state">Checking install status</string>
+    <string name="app_details_version">Version %1$s</string>
+    <string name="app_details_quick_actions_title">Quick actions</string>
+    <string name="app_details_notifications">Notifications</string>
+    <string name="app_details_permissions">Permissions</string>
+    <string name="app_details_storage">Storage</string>
+    <string name="app_details_battery">Battery</string>
+    <string name="app_details_share">Share</string>
+    <string name="app_details_play_store">Play Store</string>
+    <string name="app_details_copy_package">Copy package</string>
+    <string name="app_details_share_title">Share app</string>
+    <string name="app_details_share_text">Check out %1$s:\n%2$s</string>
+    <string name="app_details_package_name_clip_label">Package name</string>
+    <string name="app_details_package_name_copied">Package name copied</string>
+    <string name="app_details_links_title">Links</string>
+    <string name="app_details_github_repository">GitHub Repository</string>
+    <string name="app_details_github_repository_summary">View source code and contribute</string>
+    <string name="app_details_privacy_policy">Privacy Policy</string>
+    <string name="app_details_privacy_policy_summary">Read our privacy policy</string>
 
     <!-- Help screen -->
     <string name="question_1">Какво е App Toolkit?</string>

--- a/app/src/main/res/values-bn-rBD/strings.xml
+++ b/app/src/main/res/values-bn-rBD/strings.xml
@@ -41,6 +41,28 @@
     <string name="app_details_about_title">এই অ্যাপ সম্পর্কে</string>
     <string name="app_details_screenshots_title">স্ক্রিনশট</string>
     <string name="app_details_open_app">অ্যাপ খুলুন</string>
+    <string name="app_details_app_info">App info</string>
+    <string name="app_details_installed">Installed</string>
+    <string name="app_details_not_installed">Not installed</string>
+    <string name="app_details_checking_install_state">Checking install status</string>
+    <string name="app_details_version">Version %1$s</string>
+    <string name="app_details_quick_actions_title">Quick actions</string>
+    <string name="app_details_notifications">Notifications</string>
+    <string name="app_details_permissions">Permissions</string>
+    <string name="app_details_storage">Storage</string>
+    <string name="app_details_battery">Battery</string>
+    <string name="app_details_share">Share</string>
+    <string name="app_details_play_store">Play Store</string>
+    <string name="app_details_copy_package">Copy package</string>
+    <string name="app_details_share_title">Share app</string>
+    <string name="app_details_share_text">Check out %1$s:\n%2$s</string>
+    <string name="app_details_package_name_clip_label">Package name</string>
+    <string name="app_details_package_name_copied">Package name copied</string>
+    <string name="app_details_links_title">Links</string>
+    <string name="app_details_github_repository">GitHub Repository</string>
+    <string name="app_details_github_repository_summary">View source code and contribute</string>
+    <string name="app_details_privacy_policy">Privacy Policy</string>
+    <string name="app_details_privacy_policy_summary">Read our privacy policy</string>
 
     <!-- Help screen -->
     <string name="question_1">App Toolkit কী?</string>

--- a/app/src/main/res/values-de-rDE/strings.xml
+++ b/app/src/main/res/values-de-rDE/strings.xml
@@ -41,6 +41,28 @@
     <string name="app_details_about_title">Über diese App</string>
     <string name="app_details_screenshots_title">Screenshots</string>
     <string name="app_details_open_app">App öffnen</string>
+    <string name="app_details_app_info">App info</string>
+    <string name="app_details_installed">Installed</string>
+    <string name="app_details_not_installed">Not installed</string>
+    <string name="app_details_checking_install_state">Checking install status</string>
+    <string name="app_details_version">Version %1$s</string>
+    <string name="app_details_quick_actions_title">Quick actions</string>
+    <string name="app_details_notifications">Notifications</string>
+    <string name="app_details_permissions">Permissions</string>
+    <string name="app_details_storage">Storage</string>
+    <string name="app_details_battery">Battery</string>
+    <string name="app_details_share">Share</string>
+    <string name="app_details_play_store">Play Store</string>
+    <string name="app_details_copy_package">Copy package</string>
+    <string name="app_details_share_title">Share app</string>
+    <string name="app_details_share_text">Check out %1$s:\n%2$s</string>
+    <string name="app_details_package_name_clip_label">Package name</string>
+    <string name="app_details_package_name_copied">Package name copied</string>
+    <string name="app_details_links_title">Links</string>
+    <string name="app_details_github_repository">GitHub Repository</string>
+    <string name="app_details_github_repository_summary">View source code and contribute</string>
+    <string name="app_details_privacy_policy">Privacy Policy</string>
+    <string name="app_details_privacy_policy_summary">Read our privacy policy</string>
 
     <!-- Help screen -->
     <string name="question_1">Was ist App Toolkit?</string>

--- a/app/src/main/res/values-es-rGQ/strings.xml
+++ b/app/src/main/res/values-es-rGQ/strings.xml
@@ -41,6 +41,28 @@
     <string name="app_details_about_title">Acerca de esta app</string>
     <string name="app_details_screenshots_title">Capturas de pantalla</string>
     <string name="app_details_open_app">Abrir app</string>
+    <string name="app_details_app_info">App info</string>
+    <string name="app_details_installed">Installed</string>
+    <string name="app_details_not_installed">Not installed</string>
+    <string name="app_details_checking_install_state">Checking install status</string>
+    <string name="app_details_version">Version %1$s</string>
+    <string name="app_details_quick_actions_title">Quick actions</string>
+    <string name="app_details_notifications">Notifications</string>
+    <string name="app_details_permissions">Permissions</string>
+    <string name="app_details_storage">Storage</string>
+    <string name="app_details_battery">Battery</string>
+    <string name="app_details_share">Share</string>
+    <string name="app_details_play_store">Play Store</string>
+    <string name="app_details_copy_package">Copy package</string>
+    <string name="app_details_share_title">Share app</string>
+    <string name="app_details_share_text">Check out %1$s:\n%2$s</string>
+    <string name="app_details_package_name_clip_label">Package name</string>
+    <string name="app_details_package_name_copied">Package name copied</string>
+    <string name="app_details_links_title">Links</string>
+    <string name="app_details_github_repository">GitHub Repository</string>
+    <string name="app_details_github_repository_summary">View source code and contribute</string>
+    <string name="app_details_privacy_policy">Privacy Policy</string>
+    <string name="app_details_privacy_policy_summary">Read our privacy policy</string>
 
     <!-- Help screen -->
     <string name="question_1">¿Qué es App Toolkit?</string>

--- a/app/src/main/res/values-es-rMX/strings.xml
+++ b/app/src/main/res/values-es-rMX/strings.xml
@@ -41,6 +41,28 @@
     <string name="app_details_about_title">Acerca de esta app</string>
     <string name="app_details_screenshots_title">Capturas de pantalla</string>
     <string name="app_details_open_app">Abrir app</string>
+    <string name="app_details_app_info">App info</string>
+    <string name="app_details_installed">Installed</string>
+    <string name="app_details_not_installed">Not installed</string>
+    <string name="app_details_checking_install_state">Checking install status</string>
+    <string name="app_details_version">Version %1$s</string>
+    <string name="app_details_quick_actions_title">Quick actions</string>
+    <string name="app_details_notifications">Notifications</string>
+    <string name="app_details_permissions">Permissions</string>
+    <string name="app_details_storage">Storage</string>
+    <string name="app_details_battery">Battery</string>
+    <string name="app_details_share">Share</string>
+    <string name="app_details_play_store">Play Store</string>
+    <string name="app_details_copy_package">Copy package</string>
+    <string name="app_details_share_title">Share app</string>
+    <string name="app_details_share_text">Check out %1$s:\n%2$s</string>
+    <string name="app_details_package_name_clip_label">Package name</string>
+    <string name="app_details_package_name_copied">Package name copied</string>
+    <string name="app_details_links_title">Links</string>
+    <string name="app_details_github_repository">GitHub Repository</string>
+    <string name="app_details_github_repository_summary">View source code and contribute</string>
+    <string name="app_details_privacy_policy">Privacy Policy</string>
+    <string name="app_details_privacy_policy_summary">Read our privacy policy</string>
 
     <!-- Help screen -->
     <string name="question_1">¿Qué es App Toolkit?</string>

--- a/app/src/main/res/values-fil-rPH/strings.xml
+++ b/app/src/main/res/values-fil-rPH/strings.xml
@@ -41,6 +41,28 @@
     <string name="app_details_about_title">Tungkol sa app na ito</string>
     <string name="app_details_screenshots_title">Mga screenshot</string>
     <string name="app_details_open_app">Buksan ang app</string>
+    <string name="app_details_app_info">App info</string>
+    <string name="app_details_installed">Installed</string>
+    <string name="app_details_not_installed">Not installed</string>
+    <string name="app_details_checking_install_state">Checking install status</string>
+    <string name="app_details_version">Version %1$s</string>
+    <string name="app_details_quick_actions_title">Quick actions</string>
+    <string name="app_details_notifications">Notifications</string>
+    <string name="app_details_permissions">Permissions</string>
+    <string name="app_details_storage">Storage</string>
+    <string name="app_details_battery">Battery</string>
+    <string name="app_details_share">Share</string>
+    <string name="app_details_play_store">Play Store</string>
+    <string name="app_details_copy_package">Copy package</string>
+    <string name="app_details_share_title">Share app</string>
+    <string name="app_details_share_text">Check out %1$s:\n%2$s</string>
+    <string name="app_details_package_name_clip_label">Package name</string>
+    <string name="app_details_package_name_copied">Package name copied</string>
+    <string name="app_details_links_title">Links</string>
+    <string name="app_details_github_repository">GitHub Repository</string>
+    <string name="app_details_github_repository_summary">View source code and contribute</string>
+    <string name="app_details_privacy_policy">Privacy Policy</string>
+    <string name="app_details_privacy_policy_summary">Read our privacy policy</string>
 
     <!-- Help screen -->
     <string name="question_1">Ano ang App Toolkit?</string>

--- a/app/src/main/res/values-fr-rFR/strings.xml
+++ b/app/src/main/res/values-fr-rFR/strings.xml
@@ -41,6 +41,28 @@
     <string name="app_details_about_title">À propos de cette application</string>
     <string name="app_details_screenshots_title">Captures d’écran</string>
     <string name="app_details_open_app">Ouvrir l’application</string>
+    <string name="app_details_app_info">App info</string>
+    <string name="app_details_installed">Installed</string>
+    <string name="app_details_not_installed">Not installed</string>
+    <string name="app_details_checking_install_state">Checking install status</string>
+    <string name="app_details_version">Version %1$s</string>
+    <string name="app_details_quick_actions_title">Quick actions</string>
+    <string name="app_details_notifications">Notifications</string>
+    <string name="app_details_permissions">Permissions</string>
+    <string name="app_details_storage">Storage</string>
+    <string name="app_details_battery">Battery</string>
+    <string name="app_details_share">Share</string>
+    <string name="app_details_play_store">Play Store</string>
+    <string name="app_details_copy_package">Copy package</string>
+    <string name="app_details_share_title">Share app</string>
+    <string name="app_details_share_text">Check out %1$s:\n%2$s</string>
+    <string name="app_details_package_name_clip_label">Package name</string>
+    <string name="app_details_package_name_copied">Package name copied</string>
+    <string name="app_details_links_title">Links</string>
+    <string name="app_details_github_repository">GitHub Repository</string>
+    <string name="app_details_github_repository_summary">View source code and contribute</string>
+    <string name="app_details_privacy_policy">Privacy Policy</string>
+    <string name="app_details_privacy_policy_summary">Read our privacy policy</string>
 
     <!-- Help screen -->
     <string name="question_1">Qu’est-ce qu’App Toolkit ?</string>

--- a/app/src/main/res/values-hi-rIN/strings.xml
+++ b/app/src/main/res/values-hi-rIN/strings.xml
@@ -41,6 +41,28 @@
     <string name="app_details_about_title">इस ऐप के बारे में</string>
     <string name="app_details_screenshots_title">स्क्रीनशॉट</string>
     <string name="app_details_open_app">ऐप खोलें</string>
+    <string name="app_details_app_info">App info</string>
+    <string name="app_details_installed">Installed</string>
+    <string name="app_details_not_installed">Not installed</string>
+    <string name="app_details_checking_install_state">Checking install status</string>
+    <string name="app_details_version">Version %1$s</string>
+    <string name="app_details_quick_actions_title">Quick actions</string>
+    <string name="app_details_notifications">Notifications</string>
+    <string name="app_details_permissions">Permissions</string>
+    <string name="app_details_storage">Storage</string>
+    <string name="app_details_battery">Battery</string>
+    <string name="app_details_share">Share</string>
+    <string name="app_details_play_store">Play Store</string>
+    <string name="app_details_copy_package">Copy package</string>
+    <string name="app_details_share_title">Share app</string>
+    <string name="app_details_share_text">Check out %1$s:\n%2$s</string>
+    <string name="app_details_package_name_clip_label">Package name</string>
+    <string name="app_details_package_name_copied">Package name copied</string>
+    <string name="app_details_links_title">Links</string>
+    <string name="app_details_github_repository">GitHub Repository</string>
+    <string name="app_details_github_repository_summary">View source code and contribute</string>
+    <string name="app_details_privacy_policy">Privacy Policy</string>
+    <string name="app_details_privacy_policy_summary">Read our privacy policy</string>
 
     <!-- Help screen -->
     <string name="question_1">App Toolkit क्या है?</string>

--- a/app/src/main/res/values-hu-rHU/strings.xml
+++ b/app/src/main/res/values-hu-rHU/strings.xml
@@ -41,6 +41,28 @@
     <string name="app_details_about_title">Az app névjegye</string>
     <string name="app_details_screenshots_title">Képernyőképek</string>
     <string name="app_details_open_app">App megnyitása</string>
+    <string name="app_details_app_info">App info</string>
+    <string name="app_details_installed">Installed</string>
+    <string name="app_details_not_installed">Not installed</string>
+    <string name="app_details_checking_install_state">Checking install status</string>
+    <string name="app_details_version">Version %1$s</string>
+    <string name="app_details_quick_actions_title">Quick actions</string>
+    <string name="app_details_notifications">Notifications</string>
+    <string name="app_details_permissions">Permissions</string>
+    <string name="app_details_storage">Storage</string>
+    <string name="app_details_battery">Battery</string>
+    <string name="app_details_share">Share</string>
+    <string name="app_details_play_store">Play Store</string>
+    <string name="app_details_copy_package">Copy package</string>
+    <string name="app_details_share_title">Share app</string>
+    <string name="app_details_share_text">Check out %1$s:\n%2$s</string>
+    <string name="app_details_package_name_clip_label">Package name</string>
+    <string name="app_details_package_name_copied">Package name copied</string>
+    <string name="app_details_links_title">Links</string>
+    <string name="app_details_github_repository">GitHub Repository</string>
+    <string name="app_details_github_repository_summary">View source code and contribute</string>
+    <string name="app_details_privacy_policy">Privacy Policy</string>
+    <string name="app_details_privacy_policy_summary">Read our privacy policy</string>
 
     <!-- Help screen -->
     <string name="question_1">Mi az App Toolkit?</string>

--- a/app/src/main/res/values-in-rID/strings.xml
+++ b/app/src/main/res/values-in-rID/strings.xml
@@ -41,6 +41,28 @@
     <string name="app_details_about_title">Tentang aplikasi ini</string>
     <string name="app_details_screenshots_title">Tangkapan layar</string>
     <string name="app_details_open_app">Buka aplikasi</string>
+    <string name="app_details_app_info">App info</string>
+    <string name="app_details_installed">Installed</string>
+    <string name="app_details_not_installed">Not installed</string>
+    <string name="app_details_checking_install_state">Checking install status</string>
+    <string name="app_details_version">Version %1$s</string>
+    <string name="app_details_quick_actions_title">Quick actions</string>
+    <string name="app_details_notifications">Notifications</string>
+    <string name="app_details_permissions">Permissions</string>
+    <string name="app_details_storage">Storage</string>
+    <string name="app_details_battery">Battery</string>
+    <string name="app_details_share">Share</string>
+    <string name="app_details_play_store">Play Store</string>
+    <string name="app_details_copy_package">Copy package</string>
+    <string name="app_details_share_title">Share app</string>
+    <string name="app_details_share_text">Check out %1$s:\n%2$s</string>
+    <string name="app_details_package_name_clip_label">Package name</string>
+    <string name="app_details_package_name_copied">Package name copied</string>
+    <string name="app_details_links_title">Links</string>
+    <string name="app_details_github_repository">GitHub Repository</string>
+    <string name="app_details_github_repository_summary">View source code and contribute</string>
+    <string name="app_details_privacy_policy">Privacy Policy</string>
+    <string name="app_details_privacy_policy_summary">Read our privacy policy</string>
 
     <!-- Help screen -->
     <string name="question_1">Apa itu App Toolkit?</string>

--- a/app/src/main/res/values-it-rIT/strings.xml
+++ b/app/src/main/res/values-it-rIT/strings.xml
@@ -41,6 +41,28 @@
     <string name="app_details_about_title">Informazioni su questa app</string>
     <string name="app_details_screenshots_title">Screenshot</string>
     <string name="app_details_open_app">Apri app</string>
+    <string name="app_details_app_info">App info</string>
+    <string name="app_details_installed">Installed</string>
+    <string name="app_details_not_installed">Not installed</string>
+    <string name="app_details_checking_install_state">Checking install status</string>
+    <string name="app_details_version">Version %1$s</string>
+    <string name="app_details_quick_actions_title">Quick actions</string>
+    <string name="app_details_notifications">Notifications</string>
+    <string name="app_details_permissions">Permissions</string>
+    <string name="app_details_storage">Storage</string>
+    <string name="app_details_battery">Battery</string>
+    <string name="app_details_share">Share</string>
+    <string name="app_details_play_store">Play Store</string>
+    <string name="app_details_copy_package">Copy package</string>
+    <string name="app_details_share_title">Share app</string>
+    <string name="app_details_share_text">Check out %1$s:\n%2$s</string>
+    <string name="app_details_package_name_clip_label">Package name</string>
+    <string name="app_details_package_name_copied">Package name copied</string>
+    <string name="app_details_links_title">Links</string>
+    <string name="app_details_github_repository">GitHub Repository</string>
+    <string name="app_details_github_repository_summary">View source code and contribute</string>
+    <string name="app_details_privacy_policy">Privacy Policy</string>
+    <string name="app_details_privacy_policy_summary">Read our privacy policy</string>
 
     <!-- Help screen -->
     <string name="question_1">Che cos’è App Toolkit?</string>

--- a/app/src/main/res/values-ja-rJP/strings.xml
+++ b/app/src/main/res/values-ja-rJP/strings.xml
@@ -41,6 +41,28 @@
     <string name="app_details_about_title">このアプリについて</string>
     <string name="app_details_screenshots_title">スクリーンショット</string>
     <string name="app_details_open_app">アプリを開く</string>
+    <string name="app_details_app_info">App info</string>
+    <string name="app_details_installed">Installed</string>
+    <string name="app_details_not_installed">Not installed</string>
+    <string name="app_details_checking_install_state">Checking install status</string>
+    <string name="app_details_version">Version %1$s</string>
+    <string name="app_details_quick_actions_title">Quick actions</string>
+    <string name="app_details_notifications">Notifications</string>
+    <string name="app_details_permissions">Permissions</string>
+    <string name="app_details_storage">Storage</string>
+    <string name="app_details_battery">Battery</string>
+    <string name="app_details_share">Share</string>
+    <string name="app_details_play_store">Play Store</string>
+    <string name="app_details_copy_package">Copy package</string>
+    <string name="app_details_share_title">Share app</string>
+    <string name="app_details_share_text">Check out %1$s:\n%2$s</string>
+    <string name="app_details_package_name_clip_label">Package name</string>
+    <string name="app_details_package_name_copied">Package name copied</string>
+    <string name="app_details_links_title">Links</string>
+    <string name="app_details_github_repository">GitHub Repository</string>
+    <string name="app_details_github_repository_summary">View source code and contribute</string>
+    <string name="app_details_privacy_policy">Privacy Policy</string>
+    <string name="app_details_privacy_policy_summary">Read our privacy policy</string>
 
     <!-- Help screen -->
     <string name="question_1">App Toolkit とは？</string>

--- a/app/src/main/res/values-ko-rKR/strings.xml
+++ b/app/src/main/res/values-ko-rKR/strings.xml
@@ -41,6 +41,28 @@
     <string name="app_details_about_title">이 앱 정보</string>
     <string name="app_details_screenshots_title">스크린샷</string>
     <string name="app_details_open_app">앱 열기</string>
+    <string name="app_details_app_info">App info</string>
+    <string name="app_details_installed">Installed</string>
+    <string name="app_details_not_installed">Not installed</string>
+    <string name="app_details_checking_install_state">Checking install status</string>
+    <string name="app_details_version">Version %1$s</string>
+    <string name="app_details_quick_actions_title">Quick actions</string>
+    <string name="app_details_notifications">Notifications</string>
+    <string name="app_details_permissions">Permissions</string>
+    <string name="app_details_storage">Storage</string>
+    <string name="app_details_battery">Battery</string>
+    <string name="app_details_share">Share</string>
+    <string name="app_details_play_store">Play Store</string>
+    <string name="app_details_copy_package">Copy package</string>
+    <string name="app_details_share_title">Share app</string>
+    <string name="app_details_share_text">Check out %1$s:\n%2$s</string>
+    <string name="app_details_package_name_clip_label">Package name</string>
+    <string name="app_details_package_name_copied">Package name copied</string>
+    <string name="app_details_links_title">Links</string>
+    <string name="app_details_github_repository">GitHub Repository</string>
+    <string name="app_details_github_repository_summary">View source code and contribute</string>
+    <string name="app_details_privacy_policy">Privacy Policy</string>
+    <string name="app_details_privacy_policy_summary">Read our privacy policy</string>
 
     <!-- Help screen -->
     <string name="question_1">App Toolkit이란 무엇인가요?</string>

--- a/app/src/main/res/values-pl-rPL/strings.xml
+++ b/app/src/main/res/values-pl-rPL/strings.xml
@@ -41,6 +41,28 @@
     <string name="app_details_about_title">O tej aplikacji</string>
     <string name="app_details_screenshots_title">Zrzuty ekranu</string>
     <string name="app_details_open_app">Otwórz aplikację</string>
+    <string name="app_details_app_info">App info</string>
+    <string name="app_details_installed">Installed</string>
+    <string name="app_details_not_installed">Not installed</string>
+    <string name="app_details_checking_install_state">Checking install status</string>
+    <string name="app_details_version">Version %1$s</string>
+    <string name="app_details_quick_actions_title">Quick actions</string>
+    <string name="app_details_notifications">Notifications</string>
+    <string name="app_details_permissions">Permissions</string>
+    <string name="app_details_storage">Storage</string>
+    <string name="app_details_battery">Battery</string>
+    <string name="app_details_share">Share</string>
+    <string name="app_details_play_store">Play Store</string>
+    <string name="app_details_copy_package">Copy package</string>
+    <string name="app_details_share_title">Share app</string>
+    <string name="app_details_share_text">Check out %1$s:\n%2$s</string>
+    <string name="app_details_package_name_clip_label">Package name</string>
+    <string name="app_details_package_name_copied">Package name copied</string>
+    <string name="app_details_links_title">Links</string>
+    <string name="app_details_github_repository">GitHub Repository</string>
+    <string name="app_details_github_repository_summary">View source code and contribute</string>
+    <string name="app_details_privacy_policy">Privacy Policy</string>
+    <string name="app_details_privacy_policy_summary">Read our privacy policy</string>
 
     <!-- Help screen -->
     <string name="question_1">Czym jest App Toolkit?</string>

--- a/app/src/main/res/values-pt-rBR/strings.xml
+++ b/app/src/main/res/values-pt-rBR/strings.xml
@@ -41,6 +41,28 @@
     <string name="app_details_about_title">Sobre este app</string>
     <string name="app_details_screenshots_title">Capturas de tela</string>
     <string name="app_details_open_app">Abrir app</string>
+    <string name="app_details_app_info">App info</string>
+    <string name="app_details_installed">Installed</string>
+    <string name="app_details_not_installed">Not installed</string>
+    <string name="app_details_checking_install_state">Checking install status</string>
+    <string name="app_details_version">Version %1$s</string>
+    <string name="app_details_quick_actions_title">Quick actions</string>
+    <string name="app_details_notifications">Notifications</string>
+    <string name="app_details_permissions">Permissions</string>
+    <string name="app_details_storage">Storage</string>
+    <string name="app_details_battery">Battery</string>
+    <string name="app_details_share">Share</string>
+    <string name="app_details_play_store">Play Store</string>
+    <string name="app_details_copy_package">Copy package</string>
+    <string name="app_details_share_title">Share app</string>
+    <string name="app_details_share_text">Check out %1$s:\n%2$s</string>
+    <string name="app_details_package_name_clip_label">Package name</string>
+    <string name="app_details_package_name_copied">Package name copied</string>
+    <string name="app_details_links_title">Links</string>
+    <string name="app_details_github_repository">GitHub Repository</string>
+    <string name="app_details_github_repository_summary">View source code and contribute</string>
+    <string name="app_details_privacy_policy">Privacy Policy</string>
+    <string name="app_details_privacy_policy_summary">Read our privacy policy</string>
 
     <!-- Help screen -->
     <string name="question_1">O que é o App Toolkit?</string>

--- a/app/src/main/res/values-ro-rRO/strings.xml
+++ b/app/src/main/res/values-ro-rRO/strings.xml
@@ -41,6 +41,28 @@
     <string name="app_details_about_title">Despre această aplicație</string>
     <string name="app_details_screenshots_title">Capturi de ecran</string>
     <string name="app_details_open_app">Deschide aplicația</string>
+    <string name="app_details_app_info">App info</string>
+    <string name="app_details_installed">Installed</string>
+    <string name="app_details_not_installed">Not installed</string>
+    <string name="app_details_checking_install_state">Checking install status</string>
+    <string name="app_details_version">Version %1$s</string>
+    <string name="app_details_quick_actions_title">Quick actions</string>
+    <string name="app_details_notifications">Notifications</string>
+    <string name="app_details_permissions">Permissions</string>
+    <string name="app_details_storage">Storage</string>
+    <string name="app_details_battery">Battery</string>
+    <string name="app_details_share">Share</string>
+    <string name="app_details_play_store">Play Store</string>
+    <string name="app_details_copy_package">Copy package</string>
+    <string name="app_details_share_title">Share app</string>
+    <string name="app_details_share_text">Check out %1$s:\n%2$s</string>
+    <string name="app_details_package_name_clip_label">Package name</string>
+    <string name="app_details_package_name_copied">Package name copied</string>
+    <string name="app_details_links_title">Links</string>
+    <string name="app_details_github_repository">GitHub Repository</string>
+    <string name="app_details_github_repository_summary">View source code and contribute</string>
+    <string name="app_details_privacy_policy">Privacy Policy</string>
+    <string name="app_details_privacy_policy_summary">Read our privacy policy</string>
 
     <!-- Help screen -->
     <string name="question_1">Ce este App Toolkit?</string>

--- a/app/src/main/res/values-ru-rRU/strings.xml
+++ b/app/src/main/res/values-ru-rRU/strings.xml
@@ -41,6 +41,28 @@
     <string name="app_details_about_title">Об этом приложении</string>
     <string name="app_details_screenshots_title">Скриншоты</string>
     <string name="app_details_open_app">Открыть приложение</string>
+    <string name="app_details_app_info">App info</string>
+    <string name="app_details_installed">Installed</string>
+    <string name="app_details_not_installed">Not installed</string>
+    <string name="app_details_checking_install_state">Checking install status</string>
+    <string name="app_details_version">Version %1$s</string>
+    <string name="app_details_quick_actions_title">Quick actions</string>
+    <string name="app_details_notifications">Notifications</string>
+    <string name="app_details_permissions">Permissions</string>
+    <string name="app_details_storage">Storage</string>
+    <string name="app_details_battery">Battery</string>
+    <string name="app_details_share">Share</string>
+    <string name="app_details_play_store">Play Store</string>
+    <string name="app_details_copy_package">Copy package</string>
+    <string name="app_details_share_title">Share app</string>
+    <string name="app_details_share_text">Check out %1$s:\n%2$s</string>
+    <string name="app_details_package_name_clip_label">Package name</string>
+    <string name="app_details_package_name_copied">Package name copied</string>
+    <string name="app_details_links_title">Links</string>
+    <string name="app_details_github_repository">GitHub Repository</string>
+    <string name="app_details_github_repository_summary">View source code and contribute</string>
+    <string name="app_details_privacy_policy">Privacy Policy</string>
+    <string name="app_details_privacy_policy_summary">Read our privacy policy</string>
 
     <!-- Help screen -->
     <string name="question_1">Что такое App Toolkit?</string>

--- a/app/src/main/res/values-sv-rSE/strings.xml
+++ b/app/src/main/res/values-sv-rSE/strings.xml
@@ -41,6 +41,28 @@
     <string name="app_details_about_title">Om den här appen</string>
     <string name="app_details_screenshots_title">Skärmbilder</string>
     <string name="app_details_open_app">Öppna app</string>
+    <string name="app_details_app_info">App info</string>
+    <string name="app_details_installed">Installed</string>
+    <string name="app_details_not_installed">Not installed</string>
+    <string name="app_details_checking_install_state">Checking install status</string>
+    <string name="app_details_version">Version %1$s</string>
+    <string name="app_details_quick_actions_title">Quick actions</string>
+    <string name="app_details_notifications">Notifications</string>
+    <string name="app_details_permissions">Permissions</string>
+    <string name="app_details_storage">Storage</string>
+    <string name="app_details_battery">Battery</string>
+    <string name="app_details_share">Share</string>
+    <string name="app_details_play_store">Play Store</string>
+    <string name="app_details_copy_package">Copy package</string>
+    <string name="app_details_share_title">Share app</string>
+    <string name="app_details_share_text">Check out %1$s:\n%2$s</string>
+    <string name="app_details_package_name_clip_label">Package name</string>
+    <string name="app_details_package_name_copied">Package name copied</string>
+    <string name="app_details_links_title">Links</string>
+    <string name="app_details_github_repository">GitHub Repository</string>
+    <string name="app_details_github_repository_summary">View source code and contribute</string>
+    <string name="app_details_privacy_policy">Privacy Policy</string>
+    <string name="app_details_privacy_policy_summary">Read our privacy policy</string>
 
     <!-- Help screen -->
     <string name="question_1">Vad är App Toolkit?</string>

--- a/app/src/main/res/values-th-rTH/strings.xml
+++ b/app/src/main/res/values-th-rTH/strings.xml
@@ -41,6 +41,28 @@
     <string name="app_details_about_title">เกี่ยวกับแอปนี้</string>
     <string name="app_details_screenshots_title">ภาพหน้าจอ</string>
     <string name="app_details_open_app">เปิดแอป</string>
+    <string name="app_details_app_info">App info</string>
+    <string name="app_details_installed">Installed</string>
+    <string name="app_details_not_installed">Not installed</string>
+    <string name="app_details_checking_install_state">Checking install status</string>
+    <string name="app_details_version">Version %1$s</string>
+    <string name="app_details_quick_actions_title">Quick actions</string>
+    <string name="app_details_notifications">Notifications</string>
+    <string name="app_details_permissions">Permissions</string>
+    <string name="app_details_storage">Storage</string>
+    <string name="app_details_battery">Battery</string>
+    <string name="app_details_share">Share</string>
+    <string name="app_details_play_store">Play Store</string>
+    <string name="app_details_copy_package">Copy package</string>
+    <string name="app_details_share_title">Share app</string>
+    <string name="app_details_share_text">Check out %1$s:\n%2$s</string>
+    <string name="app_details_package_name_clip_label">Package name</string>
+    <string name="app_details_package_name_copied">Package name copied</string>
+    <string name="app_details_links_title">Links</string>
+    <string name="app_details_github_repository">GitHub Repository</string>
+    <string name="app_details_github_repository_summary">View source code and contribute</string>
+    <string name="app_details_privacy_policy">Privacy Policy</string>
+    <string name="app_details_privacy_policy_summary">Read our privacy policy</string>
 
     <!-- Help screen -->
     <string name="question_1">App Toolkit คืออะไร?</string>

--- a/app/src/main/res/values-tr-rTR/strings.xml
+++ b/app/src/main/res/values-tr-rTR/strings.xml
@@ -41,6 +41,28 @@
     <string name="app_details_about_title">Bu uygulama hakkında</string>
     <string name="app_details_screenshots_title">Ekran görüntüleri</string>
     <string name="app_details_open_app">Uygulamayı aç</string>
+    <string name="app_details_app_info">App info</string>
+    <string name="app_details_installed">Installed</string>
+    <string name="app_details_not_installed">Not installed</string>
+    <string name="app_details_checking_install_state">Checking install status</string>
+    <string name="app_details_version">Version %1$s</string>
+    <string name="app_details_quick_actions_title">Quick actions</string>
+    <string name="app_details_notifications">Notifications</string>
+    <string name="app_details_permissions">Permissions</string>
+    <string name="app_details_storage">Storage</string>
+    <string name="app_details_battery">Battery</string>
+    <string name="app_details_share">Share</string>
+    <string name="app_details_play_store">Play Store</string>
+    <string name="app_details_copy_package">Copy package</string>
+    <string name="app_details_share_title">Share app</string>
+    <string name="app_details_share_text">Check out %1$s:\n%2$s</string>
+    <string name="app_details_package_name_clip_label">Package name</string>
+    <string name="app_details_package_name_copied">Package name copied</string>
+    <string name="app_details_links_title">Links</string>
+    <string name="app_details_github_repository">GitHub Repository</string>
+    <string name="app_details_github_repository_summary">View source code and contribute</string>
+    <string name="app_details_privacy_policy">Privacy Policy</string>
+    <string name="app_details_privacy_policy_summary">Read our privacy policy</string>
 
     <!-- Help screen -->
     <string name="question_1">App Toolkit nedir?</string>

--- a/app/src/main/res/values-uk-rUA/strings.xml
+++ b/app/src/main/res/values-uk-rUA/strings.xml
@@ -41,6 +41,28 @@
     <string name="app_details_about_title">Про цей застосунок</string>
     <string name="app_details_screenshots_title">Знімки екрана</string>
     <string name="app_details_open_app">Відкрити застосунок</string>
+    <string name="app_details_app_info">App info</string>
+    <string name="app_details_installed">Installed</string>
+    <string name="app_details_not_installed">Not installed</string>
+    <string name="app_details_checking_install_state">Checking install status</string>
+    <string name="app_details_version">Version %1$s</string>
+    <string name="app_details_quick_actions_title">Quick actions</string>
+    <string name="app_details_notifications">Notifications</string>
+    <string name="app_details_permissions">Permissions</string>
+    <string name="app_details_storage">Storage</string>
+    <string name="app_details_battery">Battery</string>
+    <string name="app_details_share">Share</string>
+    <string name="app_details_play_store">Play Store</string>
+    <string name="app_details_copy_package">Copy package</string>
+    <string name="app_details_share_title">Share app</string>
+    <string name="app_details_share_text">Check out %1$s:\n%2$s</string>
+    <string name="app_details_package_name_clip_label">Package name</string>
+    <string name="app_details_package_name_copied">Package name copied</string>
+    <string name="app_details_links_title">Links</string>
+    <string name="app_details_github_repository">GitHub Repository</string>
+    <string name="app_details_github_repository_summary">View source code and contribute</string>
+    <string name="app_details_privacy_policy">Privacy Policy</string>
+    <string name="app_details_privacy_policy_summary">Read our privacy policy</string>
 
     <!-- Help screen -->
     <string name="question_1">Що таке App Toolkit?</string>

--- a/app/src/main/res/values-ur-rPK/strings.xml
+++ b/app/src/main/res/values-ur-rPK/strings.xml
@@ -41,6 +41,28 @@
     <string name="app_details_about_title">اس ایپ کے بارے میں</string>
     <string name="app_details_screenshots_title">اسکرین شاٹس</string>
     <string name="app_details_open_app">ایپ کھولیں</string>
+    <string name="app_details_app_info">App info</string>
+    <string name="app_details_installed">Installed</string>
+    <string name="app_details_not_installed">Not installed</string>
+    <string name="app_details_checking_install_state">Checking install status</string>
+    <string name="app_details_version">Version %1$s</string>
+    <string name="app_details_quick_actions_title">Quick actions</string>
+    <string name="app_details_notifications">Notifications</string>
+    <string name="app_details_permissions">Permissions</string>
+    <string name="app_details_storage">Storage</string>
+    <string name="app_details_battery">Battery</string>
+    <string name="app_details_share">Share</string>
+    <string name="app_details_play_store">Play Store</string>
+    <string name="app_details_copy_package">Copy package</string>
+    <string name="app_details_share_title">Share app</string>
+    <string name="app_details_share_text">Check out %1$s:\n%2$s</string>
+    <string name="app_details_package_name_clip_label">Package name</string>
+    <string name="app_details_package_name_copied">Package name copied</string>
+    <string name="app_details_links_title">Links</string>
+    <string name="app_details_github_repository">GitHub Repository</string>
+    <string name="app_details_github_repository_summary">View source code and contribute</string>
+    <string name="app_details_privacy_policy">Privacy Policy</string>
+    <string name="app_details_privacy_policy_summary">Read our privacy policy</string>
 
     <!-- Help screen -->
     <string name="question_1">App Toolkit کیا ہے؟</string>

--- a/app/src/main/res/values-vi-rVN/strings.xml
+++ b/app/src/main/res/values-vi-rVN/strings.xml
@@ -41,6 +41,28 @@
     <string name="app_details_about_title">Giới thiệu về ứng dụng này</string>
     <string name="app_details_screenshots_title">Ảnh chụp màn hình</string>
     <string name="app_details_open_app">Mở ứng dụng</string>
+    <string name="app_details_app_info">App info</string>
+    <string name="app_details_installed">Installed</string>
+    <string name="app_details_not_installed">Not installed</string>
+    <string name="app_details_checking_install_state">Checking install status</string>
+    <string name="app_details_version">Version %1$s</string>
+    <string name="app_details_quick_actions_title">Quick actions</string>
+    <string name="app_details_notifications">Notifications</string>
+    <string name="app_details_permissions">Permissions</string>
+    <string name="app_details_storage">Storage</string>
+    <string name="app_details_battery">Battery</string>
+    <string name="app_details_share">Share</string>
+    <string name="app_details_play_store">Play Store</string>
+    <string name="app_details_copy_package">Copy package</string>
+    <string name="app_details_share_title">Share app</string>
+    <string name="app_details_share_text">Check out %1$s:\n%2$s</string>
+    <string name="app_details_package_name_clip_label">Package name</string>
+    <string name="app_details_package_name_copied">Package name copied</string>
+    <string name="app_details_links_title">Links</string>
+    <string name="app_details_github_repository">GitHub Repository</string>
+    <string name="app_details_github_repository_summary">View source code and contribute</string>
+    <string name="app_details_privacy_policy">Privacy Policy</string>
+    <string name="app_details_privacy_policy_summary">Read our privacy policy</string>
 
     <!-- Help screen -->
     <string name="question_1">App Toolkit là gì?</string>

--- a/app/src/main/res/values-zh-rTW/strings.xml
+++ b/app/src/main/res/values-zh-rTW/strings.xml
@@ -41,6 +41,28 @@
     <string name="app_details_about_title">關於此應用程式</string>
     <string name="app_details_screenshots_title">螢幕截圖</string>
     <string name="app_details_open_app">開啟應用程式</string>
+    <string name="app_details_app_info">App info</string>
+    <string name="app_details_installed">Installed</string>
+    <string name="app_details_not_installed">Not installed</string>
+    <string name="app_details_checking_install_state">Checking install status</string>
+    <string name="app_details_version">Version %1$s</string>
+    <string name="app_details_quick_actions_title">Quick actions</string>
+    <string name="app_details_notifications">Notifications</string>
+    <string name="app_details_permissions">Permissions</string>
+    <string name="app_details_storage">Storage</string>
+    <string name="app_details_battery">Battery</string>
+    <string name="app_details_share">Share</string>
+    <string name="app_details_play_store">Play Store</string>
+    <string name="app_details_copy_package">Copy package</string>
+    <string name="app_details_share_title">Share app</string>
+    <string name="app_details_share_text">Check out %1$s:\n%2$s</string>
+    <string name="app_details_package_name_clip_label">Package name</string>
+    <string name="app_details_package_name_copied">Package name copied</string>
+    <string name="app_details_links_title">Links</string>
+    <string name="app_details_github_repository">GitHub Repository</string>
+    <string name="app_details_github_repository_summary">View source code and contribute</string>
+    <string name="app_details_privacy_policy">Privacy Policy</string>
+    <string name="app_details_privacy_policy_summary">Read our privacy policy</string>
 
     <!-- Help screen -->
     <string name="question_1">什麼是 App Toolkit？</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,6 +74,28 @@
     <string name="app_details_about_title">About this app</string>
     <string name="app_details_screenshots_title">Screenshots</string>
     <string name="app_details_open_app">Open app</string>
+    <string name="app_details_app_info">App info</string>
+    <string name="app_details_installed">Installed</string>
+    <string name="app_details_not_installed">Not installed</string>
+    <string name="app_details_checking_install_state">Checking install status</string>
+    <string name="app_details_version">Version %1$s</string>
+    <string name="app_details_quick_actions_title">Quick actions</string>
+    <string name="app_details_notifications">Notifications</string>
+    <string name="app_details_permissions">Permissions</string>
+    <string name="app_details_storage">Storage</string>
+    <string name="app_details_battery">Battery</string>
+    <string name="app_details_share">Share</string>
+    <string name="app_details_play_store">Play Store</string>
+    <string name="app_details_copy_package">Copy package</string>
+    <string name="app_details_share_title">Share app</string>
+    <string name="app_details_share_text">Check out %1$s:\n%2$s</string>
+    <string name="app_details_package_name_clip_label">Package name</string>
+    <string name="app_details_package_name_copied">Package name copied</string>
+    <string name="app_details_links_title">Links</string>
+    <string name="app_details_github_repository">GitHub Repository</string>
+    <string name="app_details_github_repository_summary">View source code and contribute</string>
+    <string name="app_details_privacy_policy">Privacy Policy</string>
+    <string name="app_details_privacy_policy_summary">Read our privacy policy</string>
 
     <!-- Help screen -->
     <string name="question_1">What is App Toolkit?</string>


### PR DESCRIPTION
### Motivation
- Provide a reliable app-detail control panel that opens the appropriate Android system pages instead of attempting to change system settings directly. 
- Abstract Android `Intent`-based actions behind a platform-safe launcher to keep Compose code UI-only and avoid platform logic in composables. 
- Surface useful metadata (installed version, category) and developer links (GitHub / Privacy) in the detail sheet so users can quickly inspect or navigate to app surfaces.

### Description
- Added `AppActionLauncher` and `AndroidAppActionLauncher` that encapsulate app operations like `openApp`, `openAppInfo`, `openNotifications`, `openPlayStore`, `shareApp`, `copyPackageName`, and `openUrl` using best-effort public intents with safe fallbacks. 
- Reworked `AppDetailsBottomSheet` into a control-panel layout (header, install/category/version chips, quick-action grid, about/screenshots, links, favorite button) and wired it to accept an `AppActionLauncher` and optional installed `AppVersionInfo`. 
- Wired version lookup and the new `AndroidAppActionLauncher` into `AppsListRoute` and `FavoriteAppsRoute` so the detail sheet can show install state and invoke actions from the UI. 
- Extended the remote DTO, domain model, and mapper to include optional `githubUrl` and `privacyPolicyUrl` so the links section can render when present. 
- Added localized string resources for the app-detail control panel and share/links copy text across existing locale files. 
- Change Rationale: previous detail UI only exposed open/share/favorite and often attempted direct launches; the new approach uses stable public intents with fallbacks to `App info` so behavior remains consistent across Android/OEM variants and the UI does not promise control it cannot reliably perform.

### Testing
- Parsed all modified `strings.xml` files with a small script (`xml.etree.ElementTree.parse`) to verify well-formed resources, and the parse succeeded. 
- Ran `git diff --check` to validate whitespace/format issues and it passed. 
- Attempted to run `./gradlew :app:compileDebugKotlin` but it failed due to the environment lacking an Android SDK (`ANDROID_HOME` / `local.properties`), so full compilation/test could not be executed in this CI-less environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d7d1c0990832dbdd9b169e811c084)