### PR TITLE
Refine Apps tab and Quick Tools presentation

### DIFF
--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/tiles/domain/usecase/GetToolkitTilesUseCase.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/tiles/domain/usecase/GetToolkitTilesUseCase.kt
@@ -119,7 +119,7 @@ class GetToolkitTilesUseCase {
                         summaryResId = R.string.tool_material_colors_summary,
                         icon = ToolkitTileIcon.Palette,
                         status = ToolkitTileStatus.Available,
-                        kind = ToolkitToolKind.Quick,
+                        kind = ToolkitToolKind.Expanded,
                         quickTool = ToolkitQuickTool.MaterialColors,
                     ),
                     ToolkitTile(

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/tiles/ui/MaterialColorsToolDialog.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/tiles/ui/MaterialColorsToolDialog.kt
@@ -26,6 +26,7 @@ import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.ExperimentalLayoutApi
 import androidx.compose.foundation.layout.FlowRow
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
@@ -34,14 +35,15 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.Close
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.Immutable
 import androidx.compose.runtime.remember
@@ -57,7 +59,7 @@ import com.d4rk.android.apps.apptoolkit.R
 import com.d4rk.android.libs.apptoolkit.core.utils.constants.ui.SizeConstants
 import java.util.Locale
 
-/** Dialog-only quick tool that previews the current app and Android Material You palettes. */
+/** Full-height expanded tool that previews the current app and Android Material You palettes. */
 @Composable
 fun MaterialColorsToolDialog(
     onClose: () -> Unit,
@@ -73,9 +75,19 @@ fun MaterialColorsToolDialog(
         emptyList()
     }
 
-    AlertDialog(
-        onDismissRequest = {},
-        title = {
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+
+    ModalBottomSheet(
+        modifier = Modifier.fillMaxHeight(),
+        sheetState = sheetState,
+        onDismissRequest = onClose,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxHeight()
+                .padding(horizontal = SizeConstants.LargeSize),
+            verticalArrangement = Arrangement.spacedBy(SizeConstants.MediumSize),
+        ) {
             Row(
                 modifier = Modifier.fillMaxWidth(),
                 verticalAlignment = Alignment.CenterVertically,
@@ -92,9 +104,8 @@ fun MaterialColorsToolDialog(
                     )
                 }
             }
-        },
-        text = {
             LazyColumn(
+                modifier = Modifier.weight(1f),
                 verticalArrangement = Arrangement.spacedBy(SizeConstants.MediumSize),
             ) {
                 item {
@@ -124,9 +135,8 @@ fun MaterialColorsToolDialog(
                     }
                 }
             }
-        },
-        confirmButton = {},
-    )
+        }
+    }
 }
 
 @OptIn(ExperimentalLayoutApi::class)

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/tiles/ui/ToolkitTilesScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/tiles/ui/ToolkitTilesScreen.kt
@@ -72,8 +72,8 @@ import androidx.compose.material.icons.outlined.WarningAmber
 import androidx.compose.material.icons.outlined.WbSunny
 import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.AssistChip
-import androidx.compose.material3.Button
 import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.DropdownMenu
 import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ElevatedCard
@@ -362,8 +362,8 @@ private fun ToolkitTileCard(
             .fillMaxWidth()
             .groupedCorners(position),
         shape = RectangleShape,
-        colors = androidx.compose.material3.CardDefaults.cardColors(
-            containerColor = MaterialTheme.colorScheme.surfaceContainerLow,
+        colors = CardDefaults.cardColors(
+            containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
         ),
     ) {
         Column(
@@ -439,18 +439,6 @@ private fun ToolkitTileCard(
                     }
                 }
             }
-            if (tile.status != ToolkitTileStatus.Available && tile.status != ToolkitTileStatus.NeedsSetup) {
-                Row(
-                    modifier = Modifier.fillMaxWidth(),
-                    verticalAlignment = Alignment.CenterVertically,
-                    horizontalArrangement = Arrangement.spacedBy(
-                        SizeConstants.SmallSize,
-                        Alignment.End
-                    ),
-                ) {
-                    TileStatusChip(status = tile.status)
-                }
-            }
         }
     }
 }
@@ -461,9 +449,26 @@ private fun ToolkitTilePreviewDialog(
     onClose: () -> Unit,
 ) {
     AlertDialog(
-        onDismissRequest = {},
+        onDismissRequest = onClose,
         icon = { TileIconBadge(icon = tile.icon, large = true) },
-        title = { Text(text = stringResource(id = tile.titleResId)) },
+        title = {
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                verticalAlignment = Alignment.CenterVertically,
+            ) {
+                Text(
+                    text = stringResource(id = tile.titleResId),
+                    style = MaterialTheme.typography.headlineSmall,
+                    modifier = Modifier.weight(1f),
+                )
+                IconButton(onClick = onClose) {
+                    Icon(
+                        imageVector = Icons.Outlined.Close,
+                        contentDescription = stringResource(id = R.string.tool_dialog_close_content_description),
+                    )
+                }
+            }
+        },
         text = {
             Column(verticalArrangement = Arrangement.spacedBy(SizeConstants.SmallSize)) {
                 Text(text = stringResource(id = tile.summaryResId))
@@ -474,11 +479,7 @@ private fun ToolkitTilePreviewDialog(
                 )
             }
         },
-        confirmButton = {
-            Button(onClick = onClose) {
-                Text(text = stringResource(id = R.string.tile_preview_close))
-            }
-        },
+        confirmButton = {},
     )
 }
 
@@ -510,12 +511,18 @@ private fun TileIconBadge(
 @Composable
 private fun ToolkitToolChips(tile: ToolkitTile) {
     Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .horizontalScroll(rememberScrollState()),
         horizontalArrangement = Arrangement.spacedBy(SizeConstants.SmallSize),
         verticalAlignment = Alignment.CenterVertically,
     ) {
         ToolTypeChip(kind = tile.kind)
         if (tile.requestKey != null) {
             TileAvailabilityChip()
+        }
+        if (tile.status != ToolkitTileStatus.Available) {
+            TileStatusChip(status = tile.status)
         }
     }
 }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -28,7 +28,7 @@
     <!-- Landing screen -->
 
     <!-- Home screen -->
-    <string name="apps_tools_title">Apps &amp; Tools</string>
+    <string name="apps_tools_title">Apps</string>
     <string name="all_apps">All apps</string>
     <string name="apps_filter_all">All</string>
     <string name="favorite_apps">Favorites</string>


### PR DESCRIPTION
### Motivation
- Improve clarity and UX of the Apps & Tools area by simplifying the tab label and making quick tools easier to consume.  
- Surface more-detailed tools (Material Colors) in a fuller UI so they can present richer content without feeling cramped.  
- Make cards and metadata chips more visible and consistent so tool rows read as distinct, tappable items.

### Description
- Renamed the home tab label from `Apps & Tools` to `Apps` by updating `app/src/main/res/values/strings.xml`.  
- Converted Material Colors from a compact `AlertDialog` into a full-height `ModalBottomSheet` (skips partially expanded state) and updated its header to use a top-right close `X` in `app/src/main/kotlin/.../MaterialColorsToolDialog.kt`.  
- Marked the Material Colors tile as an expanded tool in the catalog by changing its `kind` to `ToolkitToolKind.Expanded` in `GetToolkitTilesUseCase.kt`.  
- Improved card visibility by switching tool card container color to `surfaceContainerHigh`, moved non-available status chips into the same horizontally scrollable chips row, and changed preview dialogs to use a compact top-right close `X` while removing the bottom confirm button in `ToolkitTilesScreen.kt`.

### Testing
- Ran `git diff --check` and validated there are no whitespace/patch issues (passed).  
- Attempted `./gradlew :app:compileDebugKotlin` to validate Kotlin changes but the build could not run in this environment because the Android SDK location is not configured (`local.properties` / `ANDROID_HOME`); compilation was therefore not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1edaea9350832d8dd932ef1e886031)