### PR TITLE
Support Navigation 3 Scene states in bottom-tab transitions and simplify tab index logic

### DIFF
--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/main/ui/MainScreen.kt
@@ -585,16 +585,25 @@ private fun TopLevelContentNavDisplay(
 private fun BottomNavTransitions.betweenTabEntries(
     initialState: Any?,
     targetState: Any?,
-) = when {
-    tabIndex(initialState) >= 0 && tabIndex(targetState) >= 0 -> {
-        betweenTabs(forward = tabIndex(targetState) >= tabIndex(initialState))
-    }
+) = run {
+    val initialTabIndex = tabIndex(initialState)
+    val targetTabIndex = tabIndex(targetState)
 
-    else -> transition()
+    if (initialTabIndex >= 0 && targetTabIndex >= 0) {
+        betweenTabs(forward = targetTabIndex >= initialTabIndex)
+    } else {
+        transition()
+    }
 }
 
 private fun tabIndex(state: Any?): Int {
-    val entry = (state as? List<*>)?.lastOrNull() as? NavEntry<*>
+    val entry: NavEntry<*>? = when (state) {
+        // Navigation 3 transition scopes animate Scene objects; read their visible entry so
+        // predictive back between bottom tabs can use the same tab-direction motion as taps.
+        is Scene<*> -> state.entries.lastOrNull()
+        is List<*> -> state.lastOrNull() as? NavEntry<*>
+        else -> null
+    }
     val route = entry?.contentKey as? StableNavKey
     return MainNavigationDefaults.bottomBarItems.indexOfFirst { item -> item.route == route }
 }


### PR DESCRIPTION
### Motivation
- Fix bottom navigation transition direction when Navigation 3 uses `Scene` objects so predictive back gestures between bottom tabs use the correct tab-direction motion. 
- Reduce duplicated computation and make `tabIndex` resilient to different transition scope shapes to avoid incorrect index lookups.

### Description
- Replace the previous `betweenTabEntries` logic with a `run` block that caches `initialTabIndex` and `targetTabIndex` and chooses `betweenTabs` or `transition()` based on those values. 
- Extend `tabIndex` to handle `Scene<*>` transition scopes by reading `state.entries.lastOrNull()` in addition to the previous `List` handling, and add a comment explaining the Navigation 3 rationale. 
- Use explicit local typing for clarity and keep the original fallback behavior when neither state shape matches.

### Testing
- Built the app with `./gradlew assembleDebug` and the build completed successfully. 
- Ran static checks and unit tests with `./gradlew check` and the tasks passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21d35bb864832d8366ada806bed8ff)