### PR TITLE
Preload native ads and stabilize ad visibility in Toolkit Tiles list

### DIFF
--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/tiles/ui/ToolkitTilesScreen.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/tiles/ui/ToolkitTilesScreen.kt
@@ -89,6 +89,7 @@ import androidx.compose.ui.graphics.vector.ImageVector
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.dp
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
@@ -210,12 +211,23 @@ fun ToolkitTilesScreen(
     }
 
     val visibleListItems = remember(listItems, state.loadedAdIds) {
-        listItems.filter { item ->
-            when (item) {
-                is ToolkitTilesListItem.Category -> true
-                is ToolkitTilesListItem.Ad -> item.id in state.loadedAdIds
+        listItems
+            .filter { item -> item.isVisible(loadedAdIds = state.loadedAdIds) }
+            .let { visibleItems ->
+                visibleItems.mapIndexed { index, item ->
+                    PositionedToolkitTilesListItem(
+                        item = item,
+                        position = groupedItemPosition(index, visibleItems.size),
+                    )
+                }
             }
-        }
+            .toImmutableList()
+    }
+    val preloadedAdItems = remember(listItems, state.loadedAdIds) {
+        listItems
+            .filterIsInstance<ToolkitTilesListItem.Ad>()
+            .filterNot { adItem -> adItem.id in state.loadedAdIds }
+            .toImmutableList()
     }
 
     LaunchedEffect(selectedTile) {
@@ -226,85 +238,81 @@ fun ToolkitTilesScreen(
         }
     }
 
-    LazyColumn(
-        modifier = Modifier.fillMaxSize(),
-        contentPadding = PaddingValues(
-            start = SizeConstants.LargeSize,
-            top = paddingValues.calculateTopPadding() + SizeConstants.LargeSize,
-            end = SizeConstants.LargeSize,
-            bottom = paddingValues.calculateBottomPadding() + SizeConstants.LargeSize,
-        ),
-        verticalArrangement = Arrangement.spacedBy(SizeConstants.ExtraTinySize),
-    ) {
-        item {
-            TilesFilters(
-                selectedFilter = state.selectedFilter,
-                onFilterSelected = { filter -> onEvent(ToolkitTilesEvent.FilterSelected(filter)) },
-            )
-        }
-        item { Spacer(modifier = Modifier.height(SizeConstants.SmallSize)) }
-        if (listItems.isEmpty()) {
+    Box(modifier = Modifier.fillMaxSize()) {
+        LazyColumn(
+            modifier = Modifier.fillMaxSize(),
+            contentPadding = PaddingValues(
+                start = SizeConstants.LargeSize,
+                top = paddingValues.calculateTopPadding() + SizeConstants.LargeSize,
+                end = SizeConstants.LargeSize,
+                bottom = paddingValues.calculateBottomPadding() + SizeConstants.LargeSize,
+            ),
+        ) {
             item {
-                EmptyFilterCard()
+                TilesFilters(
+                    selectedFilter = state.selectedFilter,
+                    onFilterSelected = { filter -> onEvent(ToolkitTilesEvent.FilterSelected(filter)) },
+                )
             }
-        } else {
-            itemsIndexed(
-                items = listItems,
-                key = { _, item ->
+            item { Spacer(modifier = Modifier.height(SizeConstants.SmallSize)) }
+            if (listItems.isEmpty()) {
+                item {
+                    EmptyFilterCard()
+                }
+            } else {
+                itemsIndexed(
+                    items = visibleListItems,
+                    key = { _, positionedItem -> positionedItem.item.stableKey },
+                ) { _, positionedItem ->
+                    val item = positionedItem.item
+                    val position = positionedItem.position
+
                     when (item) {
-                        is ToolkitTilesListItem.Category -> item.category.id
-                        is ToolkitTilesListItem.Ad -> item.id
-                    }
-                },
-            ) { _, item ->
-                // Recalculate position for every item based on the latest visible list
-                val visibleIndex = visibleListItems.indexOf(item)
-                val isVisible = visibleIndex != -1
-                val position = if (isVisible) {
-                    groupedItemPosition(visibleIndex, visibleListItems.size)
-                } else {
-                    GroupedItemPosition.MIDDLE // Default for items not yet in the visible list
-                }
+                        is ToolkitTilesListItem.Category -> {
+                            val category = item.category
+                            val expanded = category.id in state.expandedCategoryIds
+                            TileCategorySection(
+                                category = category,
+                                position = position,
+                                expanded = expanded,
+                                onToggle = { onEvent(ToolkitTilesEvent.CategoryToggled(category.id)) },
+                                onPreviewTile = { tile ->
+                                    if (tile.quickTool == ToolkitQuickTool.MaterialColors) {
+                                        quickToolDialog = ToolkitQuickTool.MaterialColors
+                                    } else {
+                                        selectedTile = tile
+                                    }
+                                },
+                            )
+                        }
 
-                when (item) {
-                    is ToolkitTilesListItem.Category -> {
-                        val category = item.category
-                        val expanded = category.id in state.expandedCategoryIds
-                        TileCategorySection(
-                            category = category,
-                            position = position,
-                            expanded = expanded,
-                            onToggle = { onEvent(ToolkitTilesEvent.CategoryToggled(category.id)) },
-                            onPreviewTile = { tile ->
-                                if (tile.quickTool == ToolkitQuickTool.MaterialColors) {
-                                    quickToolDialog = ToolkitQuickTool.MaterialColors
-                                } else {
-                                    selectedTile = tile
-                                }
-                            },
-                        )
-                    }
-
-                    is ToolkitTilesListItem.Ad -> {
-                        QuickToolsNativeAdCard(
-                            modifier = Modifier,
-                            adUnitId = item.adUnitId,
-                            position = position,
-                            onStatusChanged = { isLoaded ->
-                                onEvent(ToolkitTilesEvent.AdStatusChanged(item.id, isLoaded))
-                            }
-                        )
+                        is ToolkitTilesListItem.Ad -> {
+                            QuickToolsNativeAdCard(
+                                modifier = Modifier,
+                                adUnitId = item.adUnitId,
+                                position = position,
+                                initiallyLoaded = item.id in state.loadedAdIds,
+                                onStatusChanged = { isLoaded ->
+                                    onEvent(ToolkitTilesEvent.AdStatusChanged(item.id, isLoaded))
+                                },
+                            )
+                        }
                     }
                 }
             }
+            item { Spacer(modifier = Modifier.height(SizeConstants.SmallSize)) }
+            item {
+                HowToAddTilesCard()
+            }
+            item {
+                NavigationBarSpacer()
+            }
         }
-        item { Spacer(modifier = Modifier.height(SizeConstants.SmallSize)) }
-        item {
-            HowToAddTilesCard()
-        }
-        item {
-            NavigationBarSpacer()
-        }
+
+        HiddenAdPreloaders(
+            adItems = preloadedAdItems,
+            onEvent = onEvent,
+        )
     }
 
     selectedTile?.let { tile ->
@@ -327,6 +335,25 @@ fun ToolkitTilesScreen(
 
     if (quickToolDialog == ToolkitQuickTool.MaterialColors) {
         MaterialColorsToolDialog(onClose = { quickToolDialog = null })
+    }
+}
+
+
+@Composable
+private fun HiddenAdPreloaders(
+    adItems: ImmutableList<ToolkitTilesListItem.Ad>,
+    onEvent: (ToolkitTilesEvent) -> Unit,
+) {
+    Box(modifier = Modifier.size(0.dp)) {
+        adItems.forEach { item ->
+            QuickToolsNativeAdCard(
+                adUnitId = item.adUnitId,
+                position = GroupedItemPosition.MIDDLE,
+                onStatusChanged = { isLoaded ->
+                    onEvent(ToolkitTilesEvent.AdStatusChanged(item.id, isLoaded))
+                },
+            )
+        }
     }
 }
 
@@ -777,6 +804,22 @@ private data class StatusColors(
     val container: Color,
     val content: Color,
 )
+
+private data class PositionedToolkitTilesListItem(
+    val item: ToolkitTilesListItem,
+    val position: GroupedItemPosition,
+)
+
+private val ToolkitTilesListItem.stableKey: String
+    get() = when (this) {
+        is ToolkitTilesListItem.Category -> category.id
+        is ToolkitTilesListItem.Ad -> id
+    }
+
+private fun ToolkitTilesListItem.isVisible(loadedAdIds: Set<String>): Boolean = when (this) {
+    is ToolkitTilesListItem.Category -> true
+    is ToolkitTilesListItem.Ad -> id in loadedAdIds
+}
 
 private sealed class ToolkitTilesListItem {
     data class Category(val category: ToolkitTileCategory) : ToolkitTilesListItem()

--- a/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/tiles/ui/components/QuickToolsNativeAdCard.kt
+++ b/app/src/main/kotlin/com/d4rk/android/apps/apptoolkit/app/tiles/ui/components/QuickToolsNativeAdCard.kt
@@ -62,6 +62,12 @@ import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdLoaderCallba
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdRequest
 import com.google.android.libraries.ads.mobile.sdk.nativead.NativeAdView
 
+/**
+ * Loads and renders the native ad row used between Toolkit Tiles categories.
+ *
+ * [initiallyLoaded] keeps an already reported ad visible while this composable is moved from the
+ * hidden preloader slot into the visible list, avoiding a transient status reset and layout gap.
+ */
 @SuppressLint("InflateParams")
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -69,6 +75,7 @@ fun QuickToolsNativeAdCard(
     modifier: Modifier = Modifier,
     adUnitId: String,
     position: GroupedItemPosition,
+    initiallyLoaded: Boolean = false,
     onStatusChanged: (Boolean) -> Unit = {},
 ) {
     val inspectionMode = LocalInspectionMode.current
@@ -81,13 +88,9 @@ fun QuickToolsNativeAdCard(
 
     val mainHandler: Handler = remember { Handler(Looper.getMainLooper()) }
 
-    var isAdLoaded by remember(adUnitId) { mutableStateOf(false) }
+    var isAdLoaded by remember(adUnitId) { mutableStateOf(initiallyLoaded) }
     var nativeAdView by remember { mutableStateOf<NativeAdView?>(null) }
     var currentNativeAd by remember { mutableStateOf<NativeAd?>(null) }
-
-    LaunchedEffect(isAdLoaded) {
-        onStatusChanged(isAdLoaded)
-    }
 
     DisposableEffect(Unit) {
         onDispose {
@@ -102,10 +105,10 @@ fun QuickToolsNativeAdCard(
             currentNativeAd?.destroy()
             currentNativeAd = null
             isAdLoaded = false
+            onStatusChanged(false)
             return@LaunchedEffect
         }
 
-        isAdLoaded = false
         val adRequest: NativeAdRequest = NativeAdRequest.Builder(
             adUnitId,
             listOf(NativeAd.NativeAdType.NATIVE)
@@ -124,6 +127,7 @@ fun QuickToolsNativeAdCard(
                             view.isVisible = true
                         }
                         isAdLoaded = true
+                        onStatusChanged(true)
                     }
                 }
 
@@ -131,6 +135,7 @@ fun QuickToolsNativeAdCard(
                     mainHandler.post {
                         nativeAdView?.isVisible = false
                         isAdLoaded = false
+                        onStatusChanged(false)
                     }
                 }
             }


### PR DESCRIPTION
### Motivation
- Reduce layout jank and transient visibility changes when ad rows move from hidden preload slots into the visible tiles list by preserving already-reported ad state and preloading ads off-screen.

### Description
- Reworked tiles list to map visible items to `PositionedToolkitTilesListItem` using `groupedItemPosition` and introduced `stableKey` for stable item keys and `isVisible` helper for visibility logic.
- Added `HiddenAdPreloaders` composable that renders preloaded ad items inside a zero-size `Box` so ads can be loaded off-screen; the list now renders only visible items and uses preloaded items for loading work.
- Updated `QuickToolsNativeAdCard` to accept `initiallyLoaded: Boolean` and to call `onStatusChanged` when ad load state changes or when ads are disabled, preserving previously loaded state while moving an ad into the visible list.
- Minor layout changes: wrapped the `LazyColumn` in a `Box`, adjusted content ordering and padding, and added `dp` import usage.

### Testing
- Built the app with `./gradlew assembleDebug` and ran unit tests via `./gradlew test`, both completed successfully with no failures.
- Ran static checks/lint via `./gradlew lint` which succeeded with no new reported issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a48280f82f8832da9db13cb62029daf)