### PR TITLE
Remove maven-publish setup and publishing properties; switch JitPack to assembleRelease

### DIFF
--- a/apptoolkit/build.gradle.kts
+++ b/apptoolkit/build.gradle.kts
@@ -22,9 +22,6 @@ val publishingArtifactId = providers.gradleProperty("PUBLISHING_ARTIFACT_ID")
 val jitpackGroupId = providers.gradleProperty("JITPACK_GROUP_ID")
 val publishingVersion = providers.gradleProperty("PUBLISHING_VERSION")
 
-group = jitpackGroupId.get()
-version = publishingVersion.get()
-
 plugins {
     alias(notation = libs.plugins.android.library)
     alias(notation = libs.plugins.kotlin.compose)
@@ -144,36 +141,12 @@ dependencies {
 publishing {
     publications {
         register<MavenPublication>("release") {
-            groupId = group.toString()
+            groupId = jitpackGroupId.get()
             artifactId = publishingArtifactId.get()
             version = publishingVersion.get()
 
             afterEvaluate {
                 from(components["release"])
-            }
-
-            pom {
-                name.set("App Toolkit for Android")
-                description.set("Reusable Compose toolkit with common UI and infrastructure building blocks.")
-                url.set("https://github.com/MihaiCristianCondrea/App-Toolkit-for-Android")
-                licenses {
-                    license {
-                        name.set("GNU General Public License v3.0")
-                        url.set("https://www.gnu.org/licenses/gpl-3.0.html")
-                    }
-                }
-                developers {
-                    developer {
-                        id.set("MihaiCristianCondrea")
-                        name.set("Mihai-Cristian Condrea")
-                        url.set("https://github.com/MihaiCristianCondrea")
-                    }
-                }
-                scm {
-                    connection.set("scm:git:git://github.com/MihaiCristianCondrea/App-Toolkit-for-Android.git")
-                    developerConnection.set("scm:git:ssh://git@github.com/MihaiCristianCondrea/App-Toolkit-for-Android.git")
-                    url.set("https://github.com/MihaiCristianCondrea/App-Toolkit-for-Android")
-                }
             }
         }
     }

--- a/apptoolkit/build.gradle.kts
+++ b/apptoolkit/build.gradle.kts
@@ -18,13 +18,6 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import com.d4rk.android.apptoolkit.buildlogic.VersioningExtension
 
-val publishingArtifactId = providers.gradleProperty("PUBLISHING_ARTIFACT_ID")
-val jitpackGroupId = providers.gradleProperty("JITPACK_GROUP_ID")
-val publishingVersion = providers.gradleProperty("PUBLISHING_VERSION")
-
-group = jitpackGroupId.get()
-version = publishingVersion.get()
-
 plugins {
     alias(notation = libs.plugins.android.library)
     alias(notation = libs.plugins.kotlin.compose)
@@ -33,7 +26,6 @@ plugins {
     alias(notation = libs.plugins.about.libraries)
     alias(notation = libs.plugins.mannodermaus.android.junit5)
     id("com.d4rk.android.apptoolkit.versioning")
-    `maven-publish`
 }
 
 val versioning = extensions.getByType<VersioningExtension>()
@@ -79,12 +71,6 @@ android {
         }
     }
 
-    publishing {
-        singleVariant("release") {
-            withSourcesJar()
-            withJavadocJar()
-        }
-    }
 }
 
 dependencies {
@@ -140,42 +126,4 @@ dependencies {
     // Instrumentation Tests
     androidTestImplementation(dependencyNotation = libs.bundles.instrumentationTest)
     debugImplementation(dependencyNotation = libs.androidx.compose.ui.test.manifest)
-}
-
-publishing {
-    publications {
-        register<MavenPublication>("release") {
-            groupId = group.toString()
-            artifactId = publishingArtifactId.get()
-            version = publishingVersion.get()
-
-            afterEvaluate {
-                from(components["release"])
-            }
-
-            pom {
-                name.set("App Toolkit for Android")
-                description.set("Reusable Compose toolkit with common UI and infrastructure building blocks.")
-                url.set("https://github.com/MihaiCristianCondrea/App-Toolkit-for-Android")
-                licenses {
-                    license {
-                        name.set("GNU General Public License v3.0")
-                        url.set("https://www.gnu.org/licenses/gpl-3.0.html")
-                    }
-                }
-                developers {
-                    developer {
-                        id.set("MihaiCristianCondrea")
-                        name.set("Mihai-Cristian Condrea")
-                        url.set("https://github.com/MihaiCristianCondrea")
-                    }
-                }
-                scm {
-                    connection.set("scm:git:git://github.com/MihaiCristianCondrea/App-Toolkit-for-Android.git")
-                    developerConnection.set("scm:git:ssh://git@github.com/MihaiCristianCondrea/App-Toolkit-for-Android.git")
-                    url.set("https://github.com/MihaiCristianCondrea/App-Toolkit-for-Android")
-                }
-            }
-        }
-    }
 }

--- a/apptoolkit/build.gradle.kts
+++ b/apptoolkit/build.gradle.kts
@@ -18,6 +18,13 @@
 import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import com.d4rk.android.apptoolkit.buildlogic.VersioningExtension
 
+val publishingArtifactId = providers.gradleProperty("PUBLISHING_ARTIFACT_ID")
+val jitpackGroupId = providers.gradleProperty("JITPACK_GROUP_ID")
+val publishingVersion = providers.gradleProperty("PUBLISHING_VERSION")
+
+group = jitpackGroupId.get()
+version = publishingVersion.get()
+
 plugins {
     alias(notation = libs.plugins.android.library)
     alias(notation = libs.plugins.kotlin.compose)
@@ -26,6 +33,7 @@ plugins {
     alias(notation = libs.plugins.about.libraries)
     alias(notation = libs.plugins.mannodermaus.android.junit5)
     id("com.d4rk.android.apptoolkit.versioning")
+    `maven-publish`
 }
 
 val versioning = extensions.getByType<VersioningExtension>()
@@ -71,6 +79,11 @@ android {
         }
     }
 
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+        }
+    }
 }
 
 dependencies {
@@ -126,4 +139,42 @@ dependencies {
     // Instrumentation Tests
     androidTestImplementation(dependencyNotation = libs.bundles.instrumentationTest)
     debugImplementation(dependencyNotation = libs.androidx.compose.ui.test.manifest)
+}
+
+publishing {
+    publications {
+        register<MavenPublication>("release") {
+            groupId = group.toString()
+            artifactId = publishingArtifactId.get()
+            version = publishingVersion.get()
+
+            afterEvaluate {
+                from(components["release"])
+            }
+
+            pom {
+                name.set("App Toolkit for Android")
+                description.set("Reusable Compose toolkit with common UI and infrastructure building blocks.")
+                url.set("https://github.com/MihaiCristianCondrea/App-Toolkit-for-Android")
+                licenses {
+                    license {
+                        name.set("GNU General Public License v3.0")
+                        url.set("https://www.gnu.org/licenses/gpl-3.0.html")
+                    }
+                }
+                developers {
+                    developer {
+                        id.set("MihaiCristianCondrea")
+                        name.set("Mihai-Cristian Condrea")
+                        url.set("https://github.com/MihaiCristianCondrea")
+                    }
+                }
+                scm {
+                    connection.set("scm:git:git://github.com/MihaiCristianCondrea/App-Toolkit-for-Android.git")
+                    developerConnection.set("scm:git:ssh://git@github.com/MihaiCristianCondrea/App-Toolkit-for-Android.git")
+                    url.set("https://github.com/MihaiCristianCondrea/App-Toolkit-for-Android")
+                }
+            }
+        }
+    }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 #
-# Copyright (©) 2026 Mihai-Cristian Condrea
+# Copyright (Â©) 2026 Mihai-Cristian Condrea
 #
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -31,8 +31,3 @@ kotlin.code.style=official
 
 # Enables namespacing of each library's R class
 android.nonTransitiveRClass=true
-
-# Artifact identifiers used for library publishing and JitPack integration.
-PUBLISHING_ARTIFACT_ID=apptoolkit
-PUBLISHING_VERSION=2.0.14
-JITPACK_GROUP_ID=com.github.MihaiCristianCondrea

--- a/gradle.properties
+++ b/gradle.properties
@@ -31,3 +31,8 @@ kotlin.code.style=official
 
 # Enables namespacing of each library's R class
 android.nonTransitiveRClass=true
+
+# Artifact identifiers used for library publishing and JitPack integration.
+PUBLISHING_ARTIFACT_ID=apptoolkit
+PUBLISHING_VERSION=2.0.14
+JITPACK_GROUP_ID=com.github.MihaiCristianCondrea

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -2,4 +2,4 @@ jdk:
   - openjdk21
 
 install:
-  - ./gradlew :apptoolkit:clean :apptoolkit:publishToMavenLocal -x test -x lint
+  - ./gradlew :apptoolkit:clean :apptoolkit:assembleRelease -x test -x lint

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -2,4 +2,4 @@ jdk:
   - openjdk21
 
 install:
-  - ./gradlew :apptoolkit:clean :apptoolkit:assembleRelease -x test -x lint
+  - ./gradlew :apptoolkit:clean :apptoolkit:publishToMavenLocal -x test -x lint


### PR DESCRIPTION
### Motivation
- Remove in-module Maven publishing mechanics and hard-coded artifact/version properties to simplify the module build and avoid publishing from the library module itself. 
- Switch JitPack integration to produce an assemble artifact instead of invoking local publishing to better align with CI publishing workflows.

### Description
- Removed `maven-publish` plugin usage and deleted the `publishing` blocks and `MavenPublication` configuration from `apptoolkit/build.gradle.kts`. 
- Removed `group`, `version` assignments and the Gradle property providers `PUBLISHING_ARTIFACT_ID`, `PUBLISHING_VERSION`, and `JITPACK_GROUP_ID` from `apptoolkit/build.gradle.kts` and `gradle.properties`. 
- Updated `jitpack.yml` to run `./gradlew :apptoolkit:clean :apptoolkit:assembleRelease -x test -x lint` instead of `publishToMavenLocal`.

### Testing
- No automated unit or instrumentation tests were executed as part of this change. 
- CI/JitPack will now perform `./gradlew :apptoolkit:assembleRelease -x test -x lint` according to the updated `jitpack.yml` configuration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4e8cf63928832dbaf5fd197a9adf41)