### PR TITLE
Fix published toolkit module coordinates

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -26,3 +26,11 @@ plugins {
     alias(notation = libs.plugins.about.libraries) apply true
     alias(notation = libs.plugins.mannodermaus.android.junit5) apply false
 }
+
+val publishingGroupId = providers.gradleProperty("JITPACK_GROUP_ID")
+val publishingVersion = providers.gradleProperty("PUBLISHING_VERSION")
+
+subprojects {
+    group = publishingGroupId.get()
+    version = publishingVersion.get()
+}

--- a/core/build.gradle.kts
+++ b/core/build.gradle.kts
@@ -21,6 +21,7 @@ import com.d4rk.android.apptoolkit.buildlogic.VersioningExtension
 plugins {
     alias(libs.plugins.android.library)
     id("com.d4rk.android.apptoolkit.versioning")
+    `maven-publish`
 }
 
 val versioning = extensions.getByType<VersioningExtension>()
@@ -41,6 +42,12 @@ android {
     kotlin {
         compilerOptions {
             jvmTarget.set(JvmTarget.JVM_21)
+        }
+    }
+
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
         }
     }
 }
@@ -71,4 +78,18 @@ dependencies {
     api(libs.ktor.client.content.negotiation)
     api(libs.ktor.client.logging)
     api(libs.ktor.serialization.kotlinx.json)
+}
+
+publishing {
+    publications {
+        register<MavenPublication>("release") {
+            groupId = project.group.toString()
+            artifactId = project.name
+            version = project.version.toString()
+
+            afterEvaluate {
+                from(components["release"])
+            }
+        }
+    }
 }

--- a/navigation/build.gradle.kts
+++ b/navigation/build.gradle.kts
@@ -23,6 +23,7 @@ plugins {
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.kotlin.parcelize)
     id("com.d4rk.android.apptoolkit.versioning")
+    `maven-publish`
 }
 
 val versioning = extensions.getByType<VersioningExtension>()
@@ -49,6 +50,12 @@ android {
     buildFeatures {
         compose = true
     }
+
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+        }
+    }
 }
 
 dependencies {
@@ -59,4 +66,18 @@ dependencies {
     api(platform(libs.androidx.compose.bom))
     api(libs.androidx.compose.material3)
     api(libs.androidx.compose.ui.tooling.preview)
+}
+
+publishing {
+    publications {
+        register<MavenPublication>("release") {
+            groupId = project.group.toString()
+            artifactId = project.name
+            version = project.version.toString()
+
+            afterEvaluate {
+                from(components["release"])
+            }
+        }
+    }
 }

--- a/playservices/build.gradle.kts
+++ b/playservices/build.gradle.kts
@@ -22,6 +22,7 @@ plugins {
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.parcelize)
     id("com.d4rk.android.apptoolkit.versioning")
+    `maven-publish`
 }
 
 val versioning = extensions.getByType<VersioningExtension>()
@@ -44,6 +45,12 @@ android {
             jvmTarget.set(JvmTarget.JVM_21)
         }
     }
+
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+        }
+    }
 }
 
 dependencies {
@@ -56,4 +63,18 @@ dependencies {
     // Coroutines
     implementation(libs.kotlinx.coroutines.android)
     implementation(libs.kotlinx.coroutines.play.services)
+}
+
+publishing {
+    publications {
+        register<MavenPublication>("release") {
+            groupId = project.group.toString()
+            artifactId = project.name
+            version = project.version.toString()
+
+            afterEvaluate {
+                from(components["release"])
+            }
+        }
+    }
 }


### PR DESCRIPTION
### Motivation
- Generated POM metadata contained invalid fallback coordinates (`unspecified` / `App Toolkit for Android`) because `apptoolkit` exposed internal modules via `api(project(...))` while those submodules had no Maven coordinates of their own.
- Make exposed modules publishable with consistent Maven coordinates so consumers (JitPack / Maven) can resolve the POM dependencies reliably.

### Description
- Set `group` and `version` for all subprojects from the existing `JITPACK_GROUP_ID` and `PUBLISHING_VERSION` Gradle properties in the root `build.gradle.kts` using `subprojects { group = ...; version = ... }`.
- Applied `maven-publish` and added `android.publishing.singleVariant("release") { withSourcesJar() }` to `:core`, `:navigation`, and `:playservices` so each module builds a release variant with sources.
- Registered a `release` `MavenPublication` in `:core`, `:navigation`, and `:playservices` that sets `groupId`, `artifactId`, and `version` from the project and publishes `from(components["release"])`.
- Kept all changes limited to Gradle build configuration; no runtime or API behavior was modified.

### Testing
- Ran `./gradlew projects --no-daemon` which completed successfully and listed the included projects.
- Ran `./gradlew :apptoolkit:generatePomFileForReleasePublication --no-daemon` which completed successfully and produced the publication POM.
- Ran `./gradlew :core:generatePomFileForReleasePublication :navigation:generatePomFileForReleasePublication :playservices:generatePomFileForReleasePublication --no-daemon` which completed successfully and produced POMs for each module.
- Inspected generated POMs (`apptoolkit/core/navigation/playservices/build/publications/release/pom-default.xml`) and verified submodule dependencies now contain proper `<groupId>`, `<artifactId>`, and `<version>` entries instead of `unspecified` or the root project name.
- Attempted `./gradlew publishToMavenLocal --no-daemon` but it could not complete in the container due to a missing Android SDK location (`ANDROID_HOME` / `local.properties`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4eac1f4820832d841af19da16cc997)