### PR TITLE
Fix Kotlin DSL plugin resolution in build-logic/convention for CI

### DIFF
--- a/build-logic/convention/build.gradle.kts
+++ b/build-logic/convention/build.gradle.kts
@@ -16,7 +16,7 @@
  */
 
 plugins {
-    `kotlin-dsl`
+    id("org.gradle.kotlin.kotlin-dsl") version "6.7.6"
 }
 
 group = "com.d4rk.android.apptoolkit.buildlogic"


### PR DESCRIPTION
### Motivation
- CI failed during build-logic compilation because the `kotlin-dsl` plugin marker could not be resolved in the CI environment, blocking the build.

### Description
- Replaced the `kotlin-dsl` marker with an explicit plugin declaration `id("org.gradle.kotlin.kotlin-dsl") version "6.7.6"` in `build-logic/convention/build.gradle.kts`.
- Change Rationale: previously the build relied on the implicit `kotlin-dsl` marker (which referenced a Gradle-managed version that was not resolving in CI), so the plugin artifact could not be fetched; declaring the published plugin coordinates explicitly allows the plugin to be resolved reliably and lets the build logic compile.

### Testing
- Ran `./gradlew -p build-logic :convention:build` which completed successfully.
- Ran `./gradlew clean publishToMavenLocal -x test -x lint` which progressed past the original plugin-resolution failure but ultimately failed due to a missing Android SDK location in the environment (`ANDROID_HOME` / `local.properties`), confirming the plugin resolution issue is fixed while the remaining failure is an environment constraint.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a71ca15b2f4832da1822366f0a4049a)