### PR TITLE
Specify Temurin Java 21 in jitpack.yml to fix JitPack JAVA_HOME error

### DIFF
--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,5 +1,6 @@
-jdk:
-  - openjdk21
+before_install:
+  - sdk install java 21.0.12+1.1-tem
+  - sdk use java 21.0.12+1.1-tem
 
 install:
   - ./gradlew clean publishToMavenLocal -x test -x lint


### PR DESCRIPTION
### Motivation
- Avoid JitPack build failures caused by SDKMAN resolving `openjdk21` to an unavailable `21.0.2-open`, which left `JAVA_HOME` invalid during publish.

### Description
- Replace `jdk: - openjdk21` in `jitpack.yml` with `before_install` steps that run `sdk install java 21.0.12+1.1-tem` and `sdk use java 21.0.12+1.1-tem`, and keep the existing `install` command `./gradlew clean publishToMavenLocal -x test -x lint`.

### Testing
- Validated `jitpack.yml` with a YAML check (succeeded), confirmed `21.0.12+1.1-tem` is available via the SDKMAN versions list (succeeded), ran `git diff --check` (clean), and attempted the local Gradle publish which failed due to a missing local Android SDK but is expected to succeed on JitPack where the Android SDK is provided.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a894cf21ebc832dbe15cee80713dde1)